### PR TITLE
Add multi-token registry and token management tools

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -70,6 +70,7 @@ jobs:
             LOG_LEVEL=info
             NODE_ENV=production
             META_ACCESS_TOKEN=${{ secrets.META_ACCESS_TOKEN }}
+            META_TOKENS=${{ secrets.META_TOKENS }}
             OAUTH_SECRET=${{ secrets.OAUTH_SECRET }}
             OAUTH_APPROVAL_PIN=${{ secrets.OAUTH_APPROVAL_PIN }}
 

--- a/src/auth/token-manager.ts
+++ b/src/auth/token-manager.ts
@@ -1,0 +1,92 @@
+import { logger } from "../utils/logger.js";
+
+export class TokenManager {
+  private tokens = new Map<string, string>();
+  private activeTokenName: string | null = null;
+
+  constructor() {
+    this.loadFromEnv();
+  }
+
+  private loadFromEnv(): void {
+    const metaTokensJson = process.env.META_TOKENS;
+    if (metaTokensJson) {
+      try {
+        const parsed: unknown = JSON.parse(metaTokensJson);
+        if (
+          typeof parsed === "object" &&
+          parsed !== null &&
+          !Array.isArray(parsed)
+        ) {
+          for (const [name, token] of Object.entries(parsed)) {
+            if (typeof token === "string" && token.length > 0) {
+              this.tokens.set(name, token);
+            }
+          }
+          const firstKey = Object.keys(parsed)[0];
+          if (firstKey && this.tokens.has(firstKey)) {
+            this.activeTokenName = firstKey;
+          }
+          logger.info(
+            { count: this.tokens.size },
+            "Loaded tokens from META_TOKENS",
+          );
+        }
+      } catch (err) {
+        logger.error({ error: err }, "Failed to parse META_TOKENS JSON");
+      }
+    }
+
+    // Fallback: register META_ACCESS_TOKEN as "default" if not already present
+    const singleToken = process.env.META_ACCESS_TOKEN;
+    if (singleToken && !this.tokens.has("default")) {
+      this.tokens.set("default", singleToken);
+      if (!this.activeTokenName) {
+        this.activeTokenName = "default";
+      }
+    }
+  }
+
+  getActiveToken(): string | null {
+    if (!this.activeTokenName) return null;
+    return this.tokens.get(this.activeTokenName) ?? null;
+  }
+
+  getActiveTokenName(): string | null {
+    return this.activeTokenName;
+  }
+
+  setActiveToken(name: string): boolean {
+    if (!this.tokens.has(name)) return false;
+    this.activeTokenName = name;
+    logger.info({ tokenName: name }, "Active token changed");
+    return true;
+  }
+
+  listTokens(): { active: string | null; available: string[] } {
+    return {
+      active: this.activeTokenName,
+      available: Array.from(this.tokens.keys()),
+    };
+  }
+
+  registerToken(name: string, token: string): void {
+    this.tokens.set(name, token);
+    if (!this.activeTokenName) {
+      this.activeTokenName = name;
+    }
+    logger.info({ tokenName: name }, "Token registered");
+  }
+
+  hasTokens(): boolean {
+    return this.tokens.size > 0;
+  }
+}
+
+/** Mask a token for safe display: first 10 chars + "..." */
+export function maskToken(token: string): string {
+  if (token.length <= 10) return token.slice(0, 3) + "***";
+  return token.slice(0, 10) + "...";
+}
+
+export const tokenManager = new TokenManager();

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -16,6 +16,7 @@ import { registerRuleTools } from "./rules.js";
 import { registerABTestingTools } from "./abtesting.js";
 import { registerReportTools } from "./reports.js";
 import { registerBillingTools } from "./billing.js";
+import { registerTokenTools } from "./tokens.js";
 
 /**
  * Register all Meta Ads tools on the MCP server.
@@ -42,5 +43,8 @@ export function registerAllTools(server: McpServer): void {
   registerReportTools(server);       // 3 tools — Async scheduled reports
   registerBillingTools(server);      // 3 tools — Billing & spend limits
 
-  // Total: 68 tools
+  // ─── Token Management ────────────────────────────────────
+  registerTokenTools(server);        // 3 tools — Multi-token registry
+
+  // Total: 71 tools
 }

--- a/src/tools/tokens.ts
+++ b/src/tools/tokens.ts
@@ -1,0 +1,173 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { tokenManager, maskToken } from "../auth/token-manager.js";
+import { logger } from "../utils/logger.js";
+
+const META_API_VERSION = process.env.META_API_VERSION ?? "v22.0";
+const META_BASE_URL = "https://graph.facebook.com";
+
+/**
+ * Validate a token by calling GET /me against the Meta Graph API.
+ * Uses raw fetch (not MetaApiClient) because we need to test the
+ * candidate token, not the currently active one.
+ */
+async function validateTokenWithMeta(
+  token: string,
+): Promise<{ valid: boolean; name?: string; error?: string }> {
+  try {
+    const url = `${META_BASE_URL}/${META_API_VERSION}/me?fields=id,name&access_token=${encodeURIComponent(token)}`;
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), 15_000);
+
+    const response = await fetch(url, { signal: controller.signal });
+    clearTimeout(timeoutId);
+
+    const body = (await response.json()) as Record<string, unknown>;
+
+    if (body.error) {
+      const err = body.error as { message?: string };
+      return { valid: false, error: err.message ?? "Unknown Meta API error" };
+    }
+
+    if (!response.ok) {
+      return { valid: false, error: `HTTP ${response.status}` };
+    }
+
+    return { valid: true, name: String(body.name ?? "") };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return { valid: false, error: `Validation request failed: ${message}` };
+  }
+}
+
+export function registerTokenTools(server: McpServer): void {
+  // ─── List Tokens ──────────────────────────────────────────
+  server.tool(
+    "meta_ads_list_tokens",
+    "List all registered Business Managers / token names with their active status. Never exposes actual token values.",
+    {},
+    async () => {
+      const { active, available } = tokenManager.listTokens();
+
+      if (available.length === 0) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: "No tokens registered. Set META_TOKENS or META_ACCESS_TOKEN environment variable, or use meta_ads_register_token to add one.",
+            },
+          ],
+        };
+      }
+
+      const lines = available.map(
+        (name) => `• ${name}${name === active ? " [ACTIVE]" : ""}`,
+      );
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Registered tokens (${available.length}):\n\n${lines.join("\n")}`,
+          },
+          {
+            type: "text",
+            text: JSON.stringify({ active, available }, null, 2),
+          },
+        ],
+      };
+    },
+  );
+
+  // ─── Set Active Token ─────────────────────────────────────
+  server.tool(
+    "meta_ads_set_active_token",
+    "Switch the active Meta API token by Business Manager name. All subsequent API calls will use this token.",
+    {
+      bm_name: z
+        .string()
+        .min(1)
+        .describe("Name of the registered token / Business Manager to activate"),
+    },
+    async ({ bm_name }) => {
+      const success = tokenManager.setActiveToken(bm_name);
+
+      if (!success) {
+        const { available } = tokenManager.listTokens();
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Token "${bm_name}" not found. Available tokens: ${available.join(", ") || "none"}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Active token switched to "${bm_name}". All subsequent API calls will use this token.`,
+          },
+        ],
+      };
+    },
+  );
+
+  // ─── Register Token ───────────────────────────────────────
+  server.tool(
+    "meta_ads_register_token",
+    "Register a new Meta API access token with a friendly name. Validates the token against the Meta Graph API (GET /me) before registering. The token is stored in memory only (not persisted across restarts).",
+    {
+      bm_name: z
+        .string()
+        .min(1)
+        .max(64)
+        .describe("Friendly name for this token (e.g. 'byads', 'client_acme')"),
+      access_token: z
+        .string()
+        .min(10)
+        .describe("Meta API access token to register"),
+    },
+    async ({ bm_name, access_token }) => {
+      // Validate the token via GET /me
+      logger.info(
+        { tokenName: bm_name, maskedToken: maskToken(access_token) },
+        "Validating token before registration",
+      );
+      const validation = await validateTokenWithMeta(access_token);
+
+      if (!validation.valid) {
+        logger.warn(
+          { tokenName: bm_name, error: validation.error },
+          "Token validation failed",
+        );
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Token validation failed: ${validation.error}\n\nThe token was NOT registered. Please provide a valid Meta API access token.`,
+            },
+          ],
+          isError: true,
+        };
+      }
+
+      tokenManager.registerToken(bm_name, access_token);
+
+      return {
+        content: [
+          {
+            type: "text",
+            text:
+              `Token "${bm_name}" registered successfully.\n` +
+              `Validated as: ${validation.name}\n` +
+              `Token: ${maskToken(access_token)}`,
+          },
+        ],
+      };
+    },
+  );
+}

--- a/tests/tools/registration.test.ts
+++ b/tests/tools/registration.test.ts
@@ -3,10 +3,10 @@ import { registerAllTools } from "../../src/tools/index.js";
 import { createMockMcpServer } from "../setup.js";
 
 describe("registerAllTools", () => {
-  it("registers exactly 68 tools total", () => {
+  it("registers exactly 71 tools total", () => {
     const server = createMockMcpServer();
     registerAllTools(server as never);
-    expect(server.tool).toHaveBeenCalledTimes(68);
+    expect(server.tool).toHaveBeenCalledTimes(71);
   });
 
   it("registers all tools with unique names", () => {
@@ -56,6 +56,11 @@ describe("registerAllTools", () => {
     expect(names).toContain("meta_ads_get_campaigns");
     expect(names).toContain("meta_ads_create_campaign");
     expect(names).toContain("meta_ads_get_insights");
+
+    // Token management tools
+    expect(names).toContain("meta_ads_list_tokens");
+    expect(names).toContain("meta_ads_set_active_token");
+    expect(names).toContain("meta_ads_register_token");
 
     // Extended feature tools
     expect(names).toContain("meta_ads_get_lead_forms");


### PR DESCRIPTION
## Summary
This PR introduces a multi-token registry system that allows managing multiple Meta API access tokens simultaneously, with the ability to switch between them. Three new MCP tools are added to register, list, and activate tokens, while the existing token resolution logic is updated to support the new registry.

## Key Changes

- **New TokenManager class** (`src/auth/token-manager.ts`):
  - Manages multiple named tokens in memory
  - Loads tokens from `META_TOKENS` (JSON object) and `META_ACCESS_TOKEN` (legacy fallback) environment variables
  - Tracks an active token that is used for API calls
  - Provides methods to register, list, and switch active tokens

- **New token management tools** (`src/tools/tokens.ts`):
  - `meta_ads_list_tokens`: Lists all registered tokens with their active status (never exposes actual token values)
  - `meta_ads_set_active_token`: Switches the active token by Business Manager name
  - `meta_ads_register_token`: Registers a new token with validation against Meta Graph API (GET /me) before storing

- **Updated token resolution priority** (`src/auth/token-store.ts`):
  - Now follows: AsyncLocalStorage context → TokenManager active token → META_ACCESS_TOKEN env var
  - Allows per-request overrides via X-Meta-Token header while supporting multi-token registry

- **Updated HTTP middleware** (`src/transport/http.ts`):
  - Modified `metaTokenMiddleware` to check TokenManager for available tokens
  - Proceeds without setting request context if only TokenManager has tokens (context will be resolved at call time)
  - Updated error messages to reference new token configuration options

- **Token masking utility**: Added `maskToken()` function to safely display tokens (first 10 chars + "...") in logs and responses

- **Test updates**: Updated tool registration test to expect 71 tools (was 68) to account for the 3 new token management tools

## Implementation Details

- Tokens are stored in memory only and not persisted across server restarts
- Token validation uses raw fetch (not MetaApiClient) to test candidate tokens independently
- The system maintains backward compatibility with existing `META_ACCESS_TOKEN` environment variable
- New `META_TOKENS` environment variable accepts a JSON object: `{"bm_name": "token_value", ...}`

https://claude.ai/code/session_01B6nTni843w7NxXNLKstrhq