### PR TITLE
fix: META_TOKENS JSON commas corrupted by gcloud delimiter + middlewa…

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -70,18 +70,22 @@ jobs:
             LOG_LEVEL=info
             NODE_ENV=production
             META_ACCESS_TOKEN=${{ secrets.META_ACCESS_TOKEN }}
-            META_TOKENS=${{ secrets.META_TOKENS }}
             OAUTH_SECRET=${{ secrets.OAUTH_SECRET }}
             OAUTH_APPROVAL_PIN=${{ secrets.OAUTH_APPROVAL_PIN }}
 
-      - name: Set SERVER_URL
+      - name: Set SERVER_URL and META_TOKENS
         env:
           GCP_REGION: ${{ secrets.GCP_REGION }}
           SERVICE_URL: ${{ steps.deploy.outputs.url }}
+          META_TOKENS: ${{ secrets.META_TOKENS }}
         run: |
+          UPDATE_VARS="SERVER_URL=$SERVICE_URL"
+          if [ -n "$META_TOKENS" ]; then
+            UPDATE_VARS="$UPDATE_VARS||META_TOKENS=$META_TOKENS"
+          fi
           gcloud run services update "$SERVICE_NAME" \
             --region="$GCP_REGION" \
-            --update-env-vars="SERVER_URL=$SERVICE_URL"
+            --update-env-vars="^||^$UPDATE_VARS"
 
       - name: Smoke test
         env:


### PR DESCRIPTION
…re priority

Bug 1: gcloud --set-env-vars uses commas as separator between key=value pairs. META_TOKENS is a JSON string containing commas, which gcloud misinterprets as separators — corrupting the value silently. Fix: move META_TOKENS out of env_vars block and set it via a separate gcloud step using ^||^ custom delimiter.

Bug 2: metaTokenMiddleware checked META_ACCESS_TOKEN env var BEFORE tokenManager.getActiveToken(), making meta_ads_set_active_token() ineffective when both env vars were set. Fix: reorder priority to header → TokenManager → env var fallback.

https://claude.ai/code/session_01B6nTni843w7NxXNLKstrhq