### PR TITLE
chore: OSS governance (CODEOWNERS, issue/PR templates, CoC, Dependabot)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,34 @@
+# CODEOWNERS for meta-ads-mcp
+#
+# When `require_code_owner_reviews` is enabled in branch protection on `main`,
+# any pull request that touches a path listed here requires an approving review
+# from at least one of the owners.
+#
+# Order matters: the LAST matching pattern wins.
+# See https://docs.github.com/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# Default owner — anything not matched by a more specific pattern.
+*                                   @MaxterPC
+
+# Authentication & encryption surface — highest blast radius.
+/src/auth/                          @MaxterPC
+/src/store/                         @MaxterPC
+/src/transport/auth-routes.ts       @MaxterPC
+/src/transport/security-config.ts   @MaxterPC
+
+# CI/CD, secret scanning, and deploy plumbing.
+/.github/                           @MaxterPC
+/.gitleaks.toml                     @MaxterPC
+/.gitignore                         @MaxterPC
+/Dockerfile                         @MaxterPC
+/docker-compose.yml                 @MaxterPC
+/scripts/                           @MaxterPC
+
+# Package manifest and lockfile — supply-chain surface.
+/package.json                       @MaxterPC
+/package-lock.json                  @MaxterPC
+
+# Project policy and security docs.
+/SECURITY.md                        @MaxterPC
+/CODE_OF_CONDUCT.md                 @MaxterPC
+/LICENSE                            @MaxterPC

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,95 @@
+name: Bug report
+description: Report a reproducible problem with meta-ads-mcp.
+title: "bug: <short description>"
+labels: ["bug", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a bug. Please fill in the sections below.
+        For **security vulnerabilities**, do not file a public issue —
+        follow [SECURITY.md](https://github.com/byadsco/meta-ads-mcp/blob/main/SECURITY.md) instead.
+
+  - type: input
+    id: version
+    attributes:
+      label: Version / commit
+      description: Output of `git rev-parse HEAD` or the package version you installed.
+      placeholder: "cbe5481 or @byadsco/meta-ads-mcp@2.0.1"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: transport
+    attributes:
+      label: Transport
+      description: Which transport are you running?
+      options:
+        - http
+        - stdio
+        - both
+        - other / unsure
+    validations:
+      required: true
+
+  - type: input
+    id: node-version
+    attributes:
+      label: Node.js version
+      placeholder: "20.18.0"
+    validations:
+      required: true
+
+  - type: input
+    id: os
+    attributes:
+      label: OS / runtime
+      description: e.g. macOS 14, Ubuntu 22.04, Cloud Run, Docker.
+      placeholder: "Cloud Run (managed)"
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: Minimal reproduction
+      description: Exact steps. Include the MCP tool call or HTTP request that triggers the bug.
+      placeholder: |
+        1. Set OAUTH_SECRET=...
+        2. Run `npm run dev`
+        3. Call tool `list_ad_accounts` with args `{...}`
+        4. Observe ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      description: Include the full error message and stack trace if any. Redact tokens with `EAA…` and `AIza…`.
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs
+      description: Pino structured log lines around the error. **Redact secrets before pasting.**
+      render: shell
+
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Confirm
+      options:
+        - label: I have searched existing issues and this is not a duplicate.
+          required: true
+        - label: I have removed any tokens, keys, or other secrets from the logs and repro.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/byadsco/meta-ads-mcp/security/advisories/new
+    about: Report a security vulnerability privately. Do not file a public issue. See SECURITY.md for the full disclosure policy.
+  - name: Question or discussion
+    url: https://github.com/byadsco/meta-ads-mcp/discussions
+    about: For open-ended questions, design discussions, or "how do I…" — please use Discussions instead of an issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,66 @@
+name: Feature request
+description: Propose a new tool, capability, or behavior change.
+title: "feat: <short description>"
+labels: ["enhancement", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the idea. Please answer the questions below so we can decide
+        whether and how to ship it. Concrete proposals beat vague wishlists.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What user-facing or operator-facing problem are you trying to solve?
+      placeholder: "When I do X, the server returns Y, which is unhelpful because Z."
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: What should change? Include the API shape, MCP tool signature, or env var name if relevant.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other options you thought about and why they are worse.
+
+  - type: dropdown
+    id: scope
+    attributes:
+      label: Surface area
+      description: Roughly which part of the codebase does this touch?
+      multiple: true
+      options:
+        - MCP tool (src/tools/)
+        - HTTP transport (src/transport/)
+        - Auth / OAuth (src/auth/)
+        - Token storage (src/store/)
+        - Build / CI / deploy (.github/)
+        - Documentation
+        - Unsure
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Context
+      description: Anything else — links to Meta API docs, related issues, screenshots.
+
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Confirm
+      options:
+        - label: I have searched existing issues and this is not a duplicate.
+          required: true
+        - label: I am open to discussing alternatives during review.
+          required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,57 @@
+<!--
+Thanks for contributing to meta-ads-mcp.
+
+Please complete the sections below. PRs that skip the security checklist or
+the verification steps are likely to be sent back. See CONTRIBUTING.md for the
+full contribution guide.
+-->
+
+## Summary
+
+<!-- One or two sentences: what changes and why. -->
+
+## Why
+
+<!-- The motivation. Link an issue if there is one (Fixes #123). -->
+
+## How to verify
+
+<!-- Reproducible steps. Commands, URLs, logs, screenshots — whatever makes
+the reviewer's life easier. -->
+
+```bash
+# example
+npm test
+```
+
+## Tests
+
+<!-- Which tests cover this change? If none, explain why. -->
+
+- [ ] New tests added under `tests/` mirroring the source path
+- [ ] Existing tests still pass (`npm test`)
+- [ ] Manual verification against a real dev environment (describe below)
+
+## Checklist
+
+- [ ] `npm run lint`, `npm run typecheck`, `npm test`, `npm run build` all pass locally
+- [ ] No secrets in the diff (env vars, tokens, keys). If unsure, run `gitleaks git --staged --config .gitleaks.toml`
+- [ ] Updated relevant docs (`README.md`, `SECURITY.md`, `CONTRIBUTING.md`) if behavior changed
+- [ ] Conventional commit prefix in title (`feat:`, `fix:`, `chore:`, `docs:`, `refactor:`, `test:`, `ci:`)
+
+## Auth / security surface
+
+Tick **all** that apply. If any box is ticked, expect extra review scrutiny and
+explain the threat-model impact in the description.
+
+- [ ] Touches `src/auth/`, `src/store/`, or `src/transport/security-config.ts`
+- [ ] Modifies the OAuth flow, session cookie shape, or Firestore document layout
+- [ ] Adds, removes, or rotates an environment variable referenced as a secret
+- [ ] Changes a GitHub Actions workflow under `.github/workflows/`
+- [ ] Adds a new third-party dependency (production or dev)
+- [ ] Loosens an existing access check or allowlist
+
+If none of the above apply, write *None* below and the bot will not block on
+the security reviewer.
+
+> _Threat-model notes:_

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,78 @@
+# Dependabot config for meta-ads-mcp.
+#
+# - npm: weekly grouped updates; ignore major bumps for the MCP SDK
+#   (those need manual review of the protocol change).
+# - github-actions: weekly, all in one PR so SHA-pinned actions can be
+#   upgraded in lockstep.
+# - docker: weekly for the base image referenced in the Dockerfile.
+#
+# Security updates run continuously regardless of this schedule (driven by
+# GitHub Advisory Database). Verified via `gh api repos/byadsco/meta-ads-mcp/automated-security-fixes`.
+
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: America/Bogota
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: chore
+      include: scope
+    labels:
+      - dependencies
+      - npm
+    groups:
+      dev-dependencies:
+        dependency-type: development
+      typescript:
+        patterns:
+          - "typescript"
+          - "tsx"
+          - "@types/*"
+          - "@typescript-eslint/*"
+          - "typescript-eslint"
+      eslint:
+        patterns:
+          - "eslint"
+          - "eslint-*"
+          - "@eslint/*"
+    ignore:
+      - dependency-name: "@modelcontextprotocol/sdk"
+        update-types: ["version-update:semver-major"]
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: America/Bogota
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: ci
+      include: scope
+    labels:
+      - dependencies
+      - github-actions
+    groups:
+      actions:
+        patterns: ["*"]
+
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: America/Bogota
+    open-pull-requests-limit: 3
+    commit-message:
+      prefix: chore
+      include: scope
+    labels:
+      - dependencies
+      - docker

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,85 @@
+
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at <security@byads.co>. All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at [https://www.contributor-covenant.org/faq][FAQ]. Translations are available at [https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations
+


### PR DESCRIPTION
## Summary

First of three OSS-readiness PRs (#2 of 3 — followups: workflow hardening + GitHub Packages).

Adds governance scaffolding the public repo was missing:

- **CODEOWNERS** scoped so auth (`src/auth/`, `src/store/`, `src/transport/auth-routes.ts`, `src/transport/security-config.ts`), CI (`.github/`, `.gitleaks.toml`, `Dockerfile`), and the package manifest always require a code-owner review once branch protection enables that requirement (PR 3).
- **Issue templates** (bug / feature) with required fields for repro, transport, version. Blank issues disabled. Security path explicitly routes to GitHub Private Vulnerability Reporting per [SECURITY.md](SECURITY.md).
- **PR template** enumerating the auth/security checklist — anything touching `src/auth/`, OAuth flow, env-var secrets, or workflows ticks the extra-scrutiny box.
- **Code of Conduct** — Contributor Covenant 2.1 verbatim, contact consolidated at `security@byads.co` (same inbox as security disclosures, intentional — single channel).
- **Dependabot** — weekly grouped updates (npm dev-deps / typescript / eslint groups, all github-actions in lockstep, docker base images). `@modelcontextprotocol/sdk` major bumps are ignored — protocol changes need manual review.

## Why

Public repo, no branch protection yet (PR 3 fixes that), and no formal contribution rails. This PR is the prerequisite for PR 3 (`require_code_owner_reviews: true` needs CODEOWNERS to mean anything).

## How to verify

```bash
npm run lint && npm run typecheck && npm test && npm run build  # all pass locally
gitleaks git --staged --redact --no-banner --config .gitleaks.toml  # no leaks
```

After merge, GitHub will surface:
- "Code of conduct" badge on the repo home
- "Code owners" tab under Insights → Community Standards
- Issue → "New" picker shows Bug / Feature / Security / Discussion options
- Dependabot opens its first batch on Monday 09:00 America/Bogota

## Tests

- [x] `npm run lint`, `npm run typecheck`, `npm test` (236 passed), `npm run build` all pass locally
- [x] No secrets in the diff (gitleaks clean)
- [ ] N/A — governance/docs only, no runtime behavior changed

## Auth / security surface

- [ ] Touches `src/auth/`, `src/store/`, or `src/transport/security-config.ts`
- [ ] Modifies the OAuth flow, session cookie shape, or Firestore document layout
- [ ] Adds, removes, or rotates an environment variable referenced as a secret
- [ ] Changes a GitHub Actions workflow under `.github/workflows/`
- [ ] Adds a new third-party dependency (production or dev)
- [ ] Loosens an existing access check or allowlist

*None of the above. Governance + templates only. Threat-model impact: zero.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)