### PR TITLE
ci: harden workflows (SHA pin, concurrency, environment, npm audit, timeouts)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,18 +16,22 @@ jobs:
   quality:
     name: Lint, typecheck, test, build
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
         with:
           node-version: '20'
           cache: 'npm'
 
       - name: Install dependencies
         run: npm ci
+
+      - name: Audit production dependencies
+        run: npm audit --audit-level=high --omit=dev
 
       - name: Lint
         run: npm run lint
@@ -46,14 +50,15 @@ jobs:
   secret-scan:
     name: gitleaks (secret scan)
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
           fetch-depth: 0
 
       - name: Run gitleaks
-        uses: gitleaks/gitleaks-action@v2
+        uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7  # v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,24 +12,32 @@ permissions:
   contents: read
   id-token: write   # Required for WIF OIDC token
 
+concurrency:
+  group: deploy-${{ github.ref }}
+  cancel-in-progress: false   # never cancel an in-flight deploy
+
 jobs:
   preflight:
     name: Preflight (lint, typecheck, test, build, secret scan)
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
         with:
           node-version: '20'
           cache: 'npm'
 
       - name: Install dependencies
         run: npm ci
+
+      - name: Audit production dependencies
+        run: npm audit --audit-level=high --omit=dev
 
       - name: Lint
         run: npm run lint
@@ -46,7 +54,7 @@ jobs:
         run: npm run build
 
       - name: Run gitleaks
-        uses: gitleaks/gitleaks-action@v2
+        uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7  # v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}
@@ -55,10 +63,14 @@ jobs:
   deploy:
     needs: preflight
     runs-on: ubuntu-latest
+    timeout-minutes: 30
+    environment:
+      name: production
+      url: ${{ steps.deploy.outputs.url }}
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
       - name: Validate required production secrets
         env:
@@ -90,24 +102,24 @@ jobs:
 
       - name: Authenticate to Google Cloud
         id: auth
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed  # v2
         with:
           workload_identity_provider: ${{ secrets.GCP_WIF_PROVIDER }}
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
 
       - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
+        uses: google-github-actions/setup-gcloud@e427ad8a34f8676edf47cf7d7925499adf3eb74f  # v2
 
       - name: Configure Docker for Artifact Registry
-        run: gcloud auth configure-docker "$GCP_REGION-docker.pkg.dev" --quiet
         env:
           GCP_REGION: ${{ secrets.GCP_REGION }}
+        run: gcloud auth configure-docker "$GCP_REGION-docker.pkg.dev" --quiet
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f  # v3
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8  # v6
         with:
           context: .
           push: true
@@ -119,7 +131,7 @@ jobs:
 
       - name: Deploy to Cloud Run
         id: deploy
-        uses: google-github-actions/deploy-cloudrun@v2
+        uses: google-github-actions/deploy-cloudrun@251330ba9a8a34bfbc1622895f42e1d53fd14522  # v2
         with:
           service: ${{ env.SERVICE_NAME }}
           region: ${{ secrets.GCP_REGION }}


### PR DESCRIPTION
## Summary

Second of three OSS-readiness PRs (#21 = governance, this = hardening, next = GitHub Packages).

Hardens both workflows and is the prerequisite for enabling branch protection on `main`.

## What changed

- **SHA-pin every external action.** `@v4` / `@v3` / `@v6` / `@v2` tag pins replaced with full commit SHAs and the major retained as a trailing comment for reviewability. Affects: `actions/checkout`, `actions/setup-node`, `gitleaks/gitleaks-action`, `google-github-actions/{auth,setup-gcloud,deploy-cloudrun}`, `docker/{setup-buildx-action,build-push-action}`. Dependabot's `github-actions` ecosystem will still bump these in lockstep weekly.
- **`concurrency:` added to `deploy.yml`** with `cancel-in-progress: false`. An in-flight deploy is never cancelled by a new push to `main` — the second deploy queues. This avoids half-applied Cloud Run revisions.
- **`environment: production`** on the deploy job. Surfaces the deployed URL in the GitHub Environments timeline and unlocks per-environment secret scoping (next step: graduate `OAUTH_SECRET`, `TOKEN_ENCRYPTION_KEY`, `META_APP_SECRET`, etc. from repo-level to environment-level secrets).
- **`npm audit --audit-level=high --omit=dev`** added to `quality` (CI) and `preflight` (deploy). Dev tooling excluded (eslint/tsx/vitest) — those CVEs don't reach prod. Production-dep CVEs of high or critical severity now block merge and deploy.
- **`timeout-minutes`** on every job: 15 (quality/preflight), 10 (secret-scan), 30 (deploy). Prevents stuck runs from clogging the runner queue.
- **Small cleanup**: moved `GCP_REGION` for the Artifact Registry configure step into the step's `env:` block to match the pattern already used by the validate-secrets and update-env-vars steps.

## Why

The repo is public. Tag pins (`@v4`) are mutable — an upstream compromise could land malicious code in our pipeline that has access to GCP secrets. SHA pinning closes that vector. Concurrency in deploy prevents revision races. The `environment` block lets us tighten secret scope. `npm audit` catches known-vulnerable transitive deps before they ship.

After this merges, branch protection on `main` is applied via `gh api` (see `~/.claude/plans/pr-2-gobernanza-oss-greedy-kitten.md`):

\`\`\`bash
gh api -X PUT repos/byadsco/meta-ads-mcp/branches/main/protection --input - <<'JSON'
{
  "required_status_checks": {"strict": true, "contexts": ["Lint, typecheck, test, build", "gitleaks (secret scan)"]},
  "enforce_admins": false,
  "required_pull_request_reviews": {"dismiss_stale_reviews": true, "require_code_owner_reviews": true, "required_approving_review_count": 1, "require_last_push_approval": false},
  "restrictions": null,
  "required_linear_history": true,
  "allow_force_pushes": false,
  "allow_deletions": false,
  "required_conversation_resolution": true,
  "lock_branch": false,
  "allow_fork_syncing": true
}
JSON
\`\`\`

(Status check contexts intentionally match the existing job names — no rename in this PR.)

## How to verify

Locally:

\`\`\`bash
npm audit --audit-level=high --omit=dev   # 0 vulnerabilities
npm run lint && npm run typecheck && npm test && npm run build  # all pass
\`\`\`

In the PR itself: every changed step (SHA pin, npm audit, concurrency, environment, timeouts) runs in this PR's own workflow. If any of them are misconfigured, the PR turns red.

After merge + branch protection apply:
- \`gh api repos/byadsco/meta-ads-mcp/branches/main/protection\` returns 200 with the configured contexts and review rules.
- \`git push --force origin main\` from any branch is rejected.
- A PR with failing checks shows the merge button disabled.

## Tests

- [x] \`npm audit --audit-level=high --omit=dev\` passes (0 vulnerabilities)
- [x] \`npm run lint\`, \`npm run typecheck\`, \`npm test\` (236 passed), \`npm run build\` all pass locally
- [x] gitleaks clean on the staged diff
- [ ] N/A — workflow-only change, no runtime behavior

## Auth / security surface

- [ ] Touches \`src/auth/\`, \`src/store/\`, or \`src/transport/security-config.ts\`
- [ ] Modifies the OAuth flow, session cookie shape, or Firestore document layout
- [ ] Adds, removes, or rotates an environment variable referenced as a secret
- [x] Changes a GitHub Actions workflow under \`.github/workflows/\`
- [ ] Adds a new third-party dependency (production or dev)
- [ ] Loosens an existing access check or allowlist

> _Threat-model notes:_ Tightens, doesn't loosen. SHA pin closes a supply-chain hole; \`environment: production\` is foundational for per-env secret scoping; \`npm audit\` raises the bar for a known-vuln dep landing in prod. No secret value, no logic, no allowlist changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)