### PR TITLE
fix(deploy): inject META_TOKENS via Secret Manager (closes JSON-comma leak)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -168,6 +168,60 @@ jobs:
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@e427ad8a34f8676edf47cf7d7925499adf3eb74f  # v2
 
+      - name: Sync META_TOKENS to Secret Manager
+        env:
+          GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
+          GCP_REGION: ${{ secrets.GCP_REGION }}
+          META_TOKENS: ${{ secrets.META_TOKENS }}
+        run: |
+          set -u
+          if [ -z "${META_TOKENS}" ]; then
+            echo "META_TOKENS not set; skipping Secret Manager sync"
+            exit 0
+          fi
+
+          # Sanity-check: it must be valid JSON (catches the buggy
+          # comma-split fragments that broke production).
+          if ! printf '%s' "${META_TOKENS}" | python3 -c 'import json,sys; json.loads(sys.stdin.read())' 2>/dev/null; then
+            echo "META_TOKENS is not valid JSON; refusing to sync"
+            exit 1
+          fi
+
+          SECRET_NAME=meta-tokens-prod
+          RUNTIME_SA=$(gcloud run services describe "$SERVICE_NAME" \
+            --region="$GCP_REGION" --project="$GCP_PROJECT_ID" \
+            --format='value(spec.template.spec.serviceAccountName)' 2>/dev/null || true)
+          if [ -z "$RUNTIME_SA" ]; then
+            # Fallback: default Compute SA if the service hasn't been created yet
+            PROJECT_NUMBER=$(gcloud projects describe "$GCP_PROJECT_ID" --format='value(projectNumber)')
+            RUNTIME_SA="${PROJECT_NUMBER}-compute@developer.gserviceaccount.com"
+          fi
+
+          if ! gcloud secrets describe "$SECRET_NAME" --project="$GCP_PROJECT_ID" --quiet >/dev/null 2>&1; then
+            printf '%s' "${META_TOKENS}" | gcloud secrets create "$SECRET_NAME" \
+              --data-file=- --replication-policy=automatic \
+              --project="$GCP_PROJECT_ID" --quiet
+            gcloud secrets add-iam-policy-binding "$SECRET_NAME" \
+              --member="serviceAccount:${RUNTIME_SA}" \
+              --role=roles/secretmanager.secretAccessor \
+              --project="$GCP_PROJECT_ID" --quiet >/dev/null
+            echo "Created Secret Manager secret $SECRET_NAME and granted ${RUNTIME_SA} access."
+          else
+            # Only add a new version if the value actually changed — avoids
+            # one new version per deploy (Secret Manager bills per-version).
+            existing_hash=$(gcloud secrets versions access latest \
+              --secret="$SECRET_NAME" --project="$GCP_PROJECT_ID" 2>/dev/null \
+              | shasum -a 256 | cut -d' ' -f1 || true)
+            desired_hash=$(printf '%s' "${META_TOKENS}" | shasum -a 256 | cut -d' ' -f1)
+            if [ "${existing_hash}" != "${desired_hash}" ]; then
+              printf '%s' "${META_TOKENS}" | gcloud secrets versions add "$SECRET_NAME" \
+                --data-file=- --project="$GCP_PROJECT_ID" --quiet
+              echo "Added new version of $SECRET_NAME (value changed)."
+            else
+              echo "$SECRET_NAME is already up to date."
+            fi
+          fi
+
       - name: Configure Docker for Artifact Registry
         env:
           GCP_REGION: ${{ secrets.GCP_REGION }}
@@ -218,6 +272,8 @@ jobs:
             FIRESTORE_PROJECT_ID=${{ secrets.FIRESTORE_PROJECT_ID }}
             META_ACCESS_TOKEN=${{ secrets.META_ACCESS_TOKEN }}
             MCP_API_KEY=${{ secrets.MCP_API_KEY }}
+          secrets: |
+            META_TOKENS=meta-tokens-prod:latest
 
       - name: Mask service URL in logs
         env:
@@ -230,21 +286,22 @@ jobs:
           HOST="${HOST#http://}"
           echo "::add-mask::${HOST}"
 
-      - name: Set SERVER_URL and META_TOKENS
+      - name: Set SERVER_URL on the new revision
         env:
           GCP_REGION: ${{ secrets.GCP_REGION }}
           SERVICE_URL: ${{ steps.deploy.outputs.url }}
-          META_TOKENS: ${{ secrets.META_TOKENS }}
         run: |
-          UPDATE_VARS="SERVER_URL=$SERVICE_URL"
-          if [ -n "$META_TOKENS" ]; then
-            UPDATE_VARS="$UPDATE_VARS||META_TOKENS=$META_TOKENS"
-          fi
+          # SERVER_URL isn't known until the deploy completes (Cloud Run
+          # assigns the hostname). META_TOKENS is no longer set here —
+          # it's injected from Secret Manager via the deploy step's
+          # `secrets:` parameter, which avoids the gcloud comma-delimiter
+          # issue that previously broke the JSON value into pieces and
+          # leaked a Meta token as an env var name.
           gcloud run services update "$SERVICE_NAME" \
             --region="$GCP_REGION" \
-            --update-env-vars="^||^$UPDATE_VARS" \
+            --update-env-vars="SERVER_URL=$SERVICE_URL" \
             --quiet > /dev/null 2>&1 || {
-              echo "Failed to update SERVER_URL / META_TOKENS env vars"
+              echo "Failed to update SERVER_URL env var"
               exit 1
             }
 


### PR DESCRIPTION
## Summary

Closes a real production secret leak in the Cloud Run deploy and restores the multi-system-user-token use case (which has been silently broken since #20).

## Root cause

The post-deploy step in [.github/workflows/deploy.yml](.github/workflows/deploy.yml) packed \`META_TOKENS\` into a \`--update-env-vars\` flag using a custom \`^||^\` delimiter:

\`\`\`
--update-env-vars="^||^SERVER_URL=...||META_TOKENS={\"name1\":\"EAA…\",\"name2\":\"EAA…\"}"
\`\`\`

When \`META_TOKENS\` holds **more than one entry** — the common case for this MCP, which is designed to support several system-user tokens per user — the JSON contains \`,\` between entries. gcloud's parser splits on the comma, and the trailing fragment

\`\`\`
"ByAds_Respaldo_1_GlobalCom":"EAA…"}
\`\`\`

ends up registered on the Cloud Run revision as an env var **name**. The real Meta access token is then visible to anyone with \`roles/run.viewer\` on the project.

Side effect of the same bug: the entries before that fragment lose their \`KEY=VALUE\` shape and Cloud Run drops them, which is why the container wouldn't have started even with all secrets correctly set.

The leaked token has been **rotated out of band**. This PR closes the ingress path so it cannot recur.

## What changed

1. **New step \`Sync META_TOKENS to Secret Manager\`** runs before the deploy.
   - Validates META_TOKENS is parseable JSON (catches a bad value before production).
   - Resolves the Cloud Run runtime SA dynamically via \`gcloud run services describe\`. Falls back to the default Compute SA on first deploy when the service does not exist yet.
   - Creates \`meta-tokens-prod\` in Secret Manager on first run and grants the runtime SA \`roles/secretmanager.secretAccessor\`.
   - On subsequent deploys, only writes a new version if the value actually changed (sha256 compare). Avoids one new version per deploy — Secret Manager bills per version-month.
2. **\`Deploy to Cloud Run\` step** gains a \`secrets:\` block:
   \`\`\`yaml
   secrets: |
     META_TOKENS=meta-tokens-prod:latest
   \`\`\`
   Cloud Run injects the value as a real env var inside the container, never via the gcloud command line. Comma-in-value problem is impossible by construction.
3. **Post-deploy step renamed** to \`Set SERVER_URL on the new revision\` and now only updates \`SERVER_URL\` — single var, no custom delimiter, no parsing surprises.

GitHub Secret \`META_TOKENS\` remains the source of truth — the workflow propagates it to Secret Manager. No new GitHub Secret needed; runtime SA discovery is automatic.

## Required cleanup (out-of-band, after this merges)

The leaked token is gone from upstream. But existing Cloud Run revisions 00054-00057 still carry the parsed-fragment env var name in their spec. To remove them:

\`\`\`bash
for rev in meta-ads-mcp-00057-pvx meta-ads-mcp-00056-2vc meta-ads-mcp-00055-7mn meta-ads-mcp-00054-4tx; do
  gcloud run revisions delete "\$rev" --region=us-east1 --project=byads-dsp --quiet
done
\`\`\`

(Skip 00057 if it's the latest serving — but it shouldn't be since 00058 from #5266788 is now serving.)

## How to verify

After merge, the next push to \`main\`:
1. \`Sync META_TOKENS to Secret Manager\` step creates \`meta-tokens-prod\` (first run) and grants IAM.
2. The new Cloud Run revision gets \`META_TOKENS\` from Secret Manager — visible via \`gcloud run revisions describe <rev> --format=json\` as \`valueFrom.secretKeyRef.name=meta-tokens-prod\`, NOT as an inline value.
3. Container logs show \`Loaded tokens from META_TOKENS (count: 2)\` exactly as before.
4. \`gcloud secrets describe meta-tokens-prod --project=byads-dsp\` returns the secret; \`gcloud secrets versions list meta-tokens-prod\` shows version 1.
5. No env var on the new revision contains \`EAA…\` as part of its name.

## Tests

- [x] Bash syntax check on the new step
- [x] No secret values logged (gcloud commands run with \`>/dev/null\` where needed; no \`echo\` of \$META_TOKENS)
- [x] gitleaks clean
- [ ] Workflow itself only verifiable post-merge (the deploy job is gated on push to main)

## Auth / security surface

- [ ] Touches \`src/auth/\`, \`src/store/\`, or \`src/transport/security-config.ts\`
- [ ] Modifies the OAuth flow, session cookie shape, or Firestore document layout
- [x] Adds, removes, or rotates an environment variable referenced as a secret  *(METADATA only — same secret value, different injection mechanism)*
- [x] Changes a GitHub Actions workflow under \`.github/workflows/\`
- [ ] Adds a new third-party dependency
- [ ] Loosens an existing access check or allowlist

> _Threat-model notes:_ Tightens. Closes a path where Meta access tokens become readable to any \`roles/run.viewer\` principal on the project. Adds Secret Manager (with audit logs and version history) as the runtime delivery channel. Runtime SA gains exactly one new role on exactly one secret. No code path changes — \`process.env.META_TOKENS\` reads the same JSON shape, just delivered cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)