### PR TITLE
chore(setup): bootstrap Secret Manager IAM in setup-gcloud.sh

### DIFF
--- a/scripts/setup-gcloud.sh
+++ b/scripts/setup-gcloud.sh
@@ -50,7 +50,8 @@ gcloud services enable \
   artifactregistry.googleapis.com \
   iam.googleapis.com \
   iamcredentials.googleapis.com \
-  cloudresourcemanager.googleapis.com
+  cloudresourcemanager.googleapis.com \
+  secretmanager.googleapis.com
 
 # ── Create Artifact Registry repository ─────────────────────
 
@@ -88,10 +89,17 @@ echo "==> Granting IAM roles..."
 # Note: roles/datastore.user is required by the Cloud Run runtime SA (not this
 # deploy SA) so the running service can read/write Firestore. Document this in
 # the README — it is granted to the runtime SA separately.
+#
+# roles/secretmanager.admin lets the deploy workflow bootstrap the
+# `meta-tokens-prod` Secret Manager entry on first run (and grant the runtime
+# SA `secretAccessor` on it). Without this role the deploy fails at the
+# `Sync META_TOKENS to Secret Manager` step with `secretmanager.secrets.create`
+# IAM_PERMISSION_DENIED.
 for role in \
   roles/artifactregistry.writer \
   roles/run.developer \
-  roles/iam.serviceAccountUser; do
+  roles/iam.serviceAccountUser \
+  roles/secretmanager.admin; do
   echo "    ${role}"
   gcloud projects add-iam-policy-binding "${GCP_PROJECT_ID}" \
     --member="serviceAccount:${SA_EMAIL}" \


### PR DESCRIPTION
## Summary

Patches a real production trap: \`scripts/setup-gcloud.sh\` did not grant the deploy SA the IAM it needs to bootstrap Secret Manager. The Cloud Run deploy after #31 merged hit \`secretmanager.secrets.create\` IAM_PERMISSION_DENIED on the new \`Sync META_TOKENS to Secret Manager\` step.

Existing prod was patched manually with one \`gcloud projects add-iam-policy-binding\` call. This PR makes future fork/setup runs idempotent so any contributor running the script gets a working deploy on the first try.

## What changed

- \`gcloud services enable\` now also enables \`secretmanager.googleapis.com\`. Without it, \`gcloud secrets describe\` returns NOT_FOUND for any secret name and the workflow's "if not exists" branch never triggers correctly.
- The IAM grant loop adds \`roles/secretmanager.admin\` for the deploy SA. Project-level rather than per-secret because the workflow self-bootstraps the secret on first run, so there is no secret to scope the binding to until after the first run.

## Why \`secretmanager.admin\`

The bootstrap path needs three permissions:
- \`secretmanager.secrets.create\` — to create \`meta-tokens-prod\` on first deploy.
- \`secretmanager.secrets.setIamPolicy\` — to grant the runtime SA \`secretAccessor\` on the new secret.
- \`secretmanager.versions.add\` — to publish new JSON values on subsequent deploys.

\`roles/secretmanager.admin\` covers all three. Granular roles (\`secretCreator\` + \`secretVersionAdder\` + per-secret IAM grant) would require pre-creating the secret out-of-band, which would re-introduce the manual setup step the workflow design avoided.

The deploy SA already holds \`run.admin\`, \`storage.admin\`, \`bigquery.dataEditor\`, etc.; \`secretmanager.admin\` is in the same tier of trust.

## How to verify

After this merges, anyone running:

\`\`\`bash
bash scripts/setup-gcloud.sh
\`\`\`

…on a fresh GCP project will end up with a deploy SA that can complete the first \`Deploy to Cloud Run\` workflow run end-to-end without manual IAM patching.

## Tests

- [x] \`bash -n scripts/setup-gcloud.sh\` (syntax)
- [x] gitleaks clean
- [ ] N/A — script-only, no code/runtime changes

## Auth / security surface

- [ ] Touches \`src/auth/\`, \`src/store/\`, or \`src/transport/security-config.ts\`
- [ ] Modifies the OAuth flow, session cookie shape, or Firestore document layout
- [ ] Adds, removes, or rotates an environment variable referenced as a secret
- [ ] Changes a GitHub Actions workflow under \`.github/workflows/\`
- [ ] Adds a new third-party dependency
- [ ] Loosens an existing access check or allowlist

> _Threat-model notes:_ Adds one project-level IAM role to the deploy bot. Same SA already holds \`run.admin\`, \`storage.admin\`, etc. Does not change any secret value, any code, any allowlist. The script change is bootstrap-only — it does not affect a running deployment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)