### PR TITLE
chore(release): v2.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@byadsco/meta-ads-mcp",
-  "version": "2.0.0",
+  "version": "2.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@byadsco/meta-ads-mcp",
-      "version": "2.0.0",
+      "version": "2.0.2",
       "license": "MIT",
       "dependencies": {
         "@google-cloud/firestore": "^8.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@byadsco/meta-ads-mcp",
-  "version": "2.0.0",
+  "version": "2.0.2",
   "description": "MCP server for Meta Ads (Facebook/Instagram) management - agency multi-account",
   "author": {
     "name": "Santiago Bastidas",


### PR DESCRIPTION
## Summary

Release bump for v2.0.2. Captures the post-v2.0.1 fixes that are already on main:

- 5266788 `ci(deploy): harden secret validation to catch placeholder values`
- #31 `fix(deploy): inject META_TOKENS from Secret Manager (closes JSON-comma leak)`
- #32 `chore(setup): grant deploy SA roles/secretmanager.admin and enable API`
- Codex review fixes on the publish workflow (preflight gate + prerelease tag handling)

## Why

v2.0.1 shipped with the buggy publish workflow that Codex flagged AND with the META_TOKENS env-var leak. Cutting v2.0.2 republishes the package + container with all the fixes — and ensures consumers pulling from \`@byadsco/meta-ads-mcp\` or \`ghcr.io/byadsco/meta-ads-mcp:latest\` get the corrected build.

## How to verify

After merge:

\`\`\`bash
git checkout main && git pull
git push origin v2.0.2          # tag was created locally by `npm version 2.0.2`
gh release create v2.0.2 --generate-notes --verify-tag
\`\`\`

Release event triggers \`publish.yml\`. Expect:

- \`npm view @byadsco/meta-ads-mcp@2.0.2 --registry=https://npm.pkg.github.com\` returns metadata
- \`docker pull ghcr.io/byadsco/meta-ads-mcp:2.0.2\` works
- \`:latest\` tag updates to point at 2.0.2 (because release is non-prerelease)

## Tests

- [x] Lint/typecheck/test/build all pass on the bump (CI)
- [x] No code changes — version bump only

## Auth / security surface

- [ ] Touches \`src/auth/\`, \`src/store/\`, or \`src/transport/security-config.ts\`
- [ ] Modifies the OAuth flow, session cookie shape, or Firestore document layout
- [ ] Adds, removes, or rotates an environment variable referenced as a secret
- [ ] Changes a GitHub Actions workflow under \`.github/workflows/\`
- [ ] Adds a new third-party dependency
- [ ] Loosens an existing access check or allowlist

> _None._ Version metadata only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)