### PR TITLE
feat(oauth): drop meta_token_name from JWT so the agent can pivot tokens

### DIFF
--- a/src/auth/oauth-provider.ts
+++ b/src/auth/oauth-provider.ts
@@ -43,7 +43,6 @@ function getJwtSecret(): Uint8Array {
 
 export interface PendingAuthSession {
   fbUserId: string;
-  metaTokenName: string;
 }
 
 export class MetaAdsOAuthProvider implements OAuthServerProvider {
@@ -79,7 +78,6 @@ export class MetaAdsOAuthProvider implements OAuthServerProvider {
       redirectUri: params.redirectUri,
       resource: params.resource?.href,
       fbUserId: pending?.fbUserId,
-      metaTokenName: pending?.metaTokenName,
       expiresAt: Math.floor(Date.now() / 1000) + 600,
     });
 
@@ -140,7 +138,6 @@ export class MetaAdsOAuthProvider implements OAuthServerProvider {
       resource:
         resource ?? (entry.resource ? new URL(entry.resource) : undefined),
       fbUserId: entry.fbUserId,
-      metaTokenName: entry.metaTokenName,
     });
   }
 
@@ -168,10 +165,6 @@ export class MetaAdsOAuthProvider implements OAuthServerProvider {
       resource,
       fbUserId:
         typeof payload.fb_user_id === "string" ? payload.fb_user_id : undefined,
-      metaTokenName:
-        typeof payload.meta_token_name === "string"
-          ? payload.meta_token_name
-          : undefined,
     });
   }
 
@@ -189,9 +182,6 @@ export class MetaAdsOAuthProvider implements OAuthServerProvider {
     const extra: Record<string, unknown> = {};
     if (typeof payload.fb_user_id === "string") {
       extra.fbUserId = payload.fb_user_id;
-    }
-    if (typeof payload.meta_token_name === "string") {
-      extra.metaTokenName = payload.meta_token_name;
     }
 
     const authInfo: AuthInfo = {
@@ -218,7 +208,6 @@ export class MetaAdsOAuthProvider implements OAuthServerProvider {
     clientId: string;
     resource?: URL;
     fbUserId?: string;
-    metaTokenName?: string;
   }): Promise<OAuthTokens> {
     const secret = getJwtSecret();
     const now = Math.floor(Date.now() / 1000);
@@ -229,7 +218,6 @@ export class MetaAdsOAuthProvider implements OAuthServerProvider {
     };
     if (input.resource) claims.resource = input.resource.href;
     if (input.fbUserId) claims.fb_user_id = input.fbUserId;
-    if (input.metaTokenName) claims.meta_token_name = input.metaTokenName;
 
     const accessToken = await new SignJWT(claims)
       .setProtectedHeader({ alg: "HS256" })
@@ -242,7 +230,6 @@ export class MetaAdsOAuthProvider implements OAuthServerProvider {
       type: "refresh",
     };
     if (input.fbUserId) refreshClaims.fb_user_id = input.fbUserId;
-    if (input.metaTokenName) refreshClaims.meta_token_name = input.metaTokenName;
 
     const refreshToken = await new SignJWT(refreshClaims)
       .setProtectedHeader({ alg: "HS256" })

--- a/src/auth/token-store.ts
+++ b/src/auth/token-store.ts
@@ -5,7 +5,6 @@ import { tokenManager } from "./token-manager.js";
 export interface RequestContext {
   accessToken: string;
   fbUserId?: string;
-  metaTokenName?: string;
 }
 
 /**
@@ -49,10 +48,6 @@ export function getAccessToken(): string {
 
 export function getCurrentFbUserId(): string | undefined {
   return requestContext.getStore()?.fbUserId;
-}
-
-export function getCurrentTokenName(): string | undefined {
-  return requestContext.getStore()?.metaTokenName;
 }
 
 /**

--- a/src/store/persistent-auth-codes.ts
+++ b/src/store/persistent-auth-codes.ts
@@ -8,7 +8,6 @@ export interface AuthCodeEntry {
   redirectUri: string;
   resource?: string;
   fbUserId?: string;
-  metaTokenName?: string;
   expiresAt: number;
 }
 

--- a/src/transport/http.ts
+++ b/src/transport/http.ts
@@ -35,7 +35,6 @@ import { logger } from "../utils/logger.js";
 
 interface PendingAuth {
   fbUserId: string;
-  metaTokenName: string;
 }
 
 const pendingAuthStorage = new AsyncLocalStorage<PendingAuth>();
@@ -309,20 +308,16 @@ function buildMetaTokenMiddleware(
     }).auth;
     const fbUserId =
       typeof auth?.extra?.fbUserId === "string" ? auth.extra.fbUserId : undefined;
-    const metaTokenName =
-      typeof auth?.extra?.metaTokenName === "string"
-        ? auth.extra.metaTokenName
-        : undefined;
 
     if (multiTenantEnabled && fbUserId) {
       try {
         const accessToken = await getDecryptedToken(
           fbUserId,
-          metaTokenName,
+          undefined,
           serverUrl,
         );
         requestContext.run(
-          { accessToken, fbUserId, metaTokenName },
+          { accessToken, fbUserId },
           () => next(),
         );
         return;
@@ -330,7 +325,6 @@ function buildMetaTokenMiddleware(
         logger.warn(
           {
             fbUserId,
-            metaTokenName,
             error: err instanceof Error ? err.message : String(err),
           },
           "Failed to resolve user Meta token",
@@ -508,10 +502,7 @@ export async function startHttpTransport(
           return;
         }
 
-        pendingAuthStorage.run(
-          { fbUserId: session.fbUserId, metaTokenName: activeName },
-          () => next(),
-        );
+        pendingAuthStorage.run({ fbUserId: session.fbUserId }, () => next());
       },
     );
   }

--- a/tests/auth/oauth-provider.test.ts
+++ b/tests/auth/oauth-provider.test.ts
@@ -37,12 +37,9 @@ describe("MetaAdsOAuthProvider", () => {
     resetOAuthProviderForTests();
   });
 
-  it("issues a code that can be exchanged for tokens including fb_user_id", async () => {
+  it("issues a code that can be exchanged for tokens including fb_user_id (and never the token name)", async () => {
     oauthProvider.configure({
-      resolvePendingAuth: () => ({
-        fbUserId: "fb-1234",
-        metaTokenName: "personal",
-      }),
+      resolvePendingAuth: () => ({ fbUserId: "fb-1234" }),
     });
 
     const res = fakeRes();
@@ -78,8 +75,8 @@ describe("MetaAdsOAuthProvider", () => {
       "fb-1234",
     );
     expect(
-      (authInfo.extra as { metaTokenName?: string } | undefined)?.metaTokenName,
-    ).toBe("personal");
+      (authInfo.extra as Record<string, unknown> | undefined)?.metaTokenName,
+    ).toBeUndefined();
   });
 
   it("rejects auth code that was issued to a different client", async () => {
@@ -108,12 +105,9 @@ describe("MetaAdsOAuthProvider", () => {
     ).rejects.toThrow(/different client/);
   });
 
-  it("preserves fb_user_id across refresh-token exchange", async () => {
+  it("preserves fb_user_id across refresh-token exchange (token name is never in the JWT)", async () => {
     oauthProvider.configure({
-      resolvePendingAuth: () => ({
-        fbUserId: "fb-9999",
-        metaTokenName: "byads",
-      }),
+      resolvePendingAuth: () => ({ fbUserId: "fb-9999" }),
     });
     const res = fakeRes();
     await oauthProvider.authorize(
@@ -143,7 +137,7 @@ describe("MetaAdsOAuthProvider", () => {
       "fb-9999",
     );
     expect(
-      (authInfo.extra as { metaTokenName?: string } | undefined)?.metaTokenName,
-    ).toBe("byads");
+      (authInfo.extra as Record<string, unknown> | undefined)?.metaTokenName,
+    ).toBeUndefined();
   });
 });

--- a/tests/store/meta-token-repo.test.ts
+++ b/tests/store/meta-token-repo.test.ts
@@ -203,4 +203,32 @@ describe("InMemoryMetaTokenRepo", () => {
     expect(tokens[0].businessId).toBeNull();
     expect(tokens[0].businessName).toBeNull();
   });
+
+  it("getDecryptedToken without a name resolves the current default after setDefaultToken (enables agent token pivoting)", async () => {
+    await repo.saveToken(
+      makeInput({
+        name: "byads",
+        kind: "system_user",
+        expiresAt: null,
+        accessToken: "byads-token",
+        setAsDefault: true,
+      }),
+    );
+    await repo.saveToken(
+      makeInput({
+        name: "personal",
+        kind: "system_user",
+        expiresAt: null,
+        accessToken: "personal-token",
+      }),
+    );
+
+    expect(await repo.getDecryptedToken("fb-1")).toBe("byads-token");
+
+    expect(await repo.setDefaultToken("fb-1", "personal")).toBe(true);
+    expect(await repo.getDecryptedToken("fb-1")).toBe("personal-token");
+
+    expect(await repo.setDefaultToken("fb-1", "byads")).toBe(true);
+    expect(await repo.getDecryptedToken("fb-1")).toBe("byads-token");
+  });
 });


### PR DESCRIPTION
## Summary

- Remove `meta_token_name` from the OAuth access/refresh JWTs ([oauth-provider.ts](src/auth/oauth-provider.ts)) and from the persisted auth-code entry ([persistent-auth-codes.ts](src/store/persistent-auth-codes.ts)).
- Make the HTTP middleware call `getDecryptedToken(fbUserId, undefined, ...)` so Firestore's `isDefault` flag is the single source of truth for the active token ([http.ts](src/transport/http.ts)).
- Drop the now-dead `metaTokenName` field from `RequestContext` and remove `getCurrentTokenName()` (unused) ([token-store.ts](src/auth/token-store.ts)).
- Tests updated to reflect that the JWT no longer carries the token name; new repo test that documents the pivoting behaviour: `setDefaultToken("personal")` then `getDecryptedToken()` returns the personal plaintext on the next call.

## Why

The user has 3 tokens registered and needs the agent to pivot between them inside one conversation. The tool [`meta_ads_set_active_token`](src/tools/tokens.ts#L88-L146) already exists and updates `isDefault` in Firestore correctly, but the middleware ignored that change because it kept reading `meta_token_name` from the JWT issued at `/authorize` time. The token effectively got pinned for the JWT's lifetime (1h access + 30d refresh).

This is a regression from earlier behaviour the user remembers: prior to the JWT-pinning the active token was global and `set_active_token` actually pivoted future requests.

## Trade-off (called out)

The active token is now global per Meta user. Two simultaneous sessions of the same `fb_user_id` (two Claude.ai tabs, scripted clients sharing creds, etc.) share the same active token; last writer wins. This matches the behaviour the user reports they had before, and is consistent with the name *active* token. If we ever need per-session isolation, we'd add a session ID and store the override in `requestContext` — out of scope here.

## Test plan

- [x] `npm run lint`, `npm run typecheck`, `npm test` (246 tests, +1 pivoting test), `npm run build` all green.
- [x] `gitleaks git --staged` clean. `pre-deploy-guard` full mode 7 PASS / 0 FAIL.
- [x] Updated `tests/auth/oauth-provider.test.ts` asserts the JWT no longer carries `metaTokenName` and `verifyAccessToken` no longer surfaces it on `authInfo.extra`.
- [x] New `tests/store/meta-token-repo.test.ts` case round-trips a switch: register two tokens, default to `byads`, `getDecryptedToken` returns the byads plaintext; `setDefaultToken("personal")`, next `getDecryptedToken` returns the personal plaintext; switch back, returns byads again.
- [x] Post-deploy: re-approve `/authorize`, then through Claude.ai run `meta_ads_list_tokens`, `meta_ads_set_active_token({bm_name: "personal"})`, then a Meta-Ads tool — confirm it used the `personal` token (e.g. by listing accounts visible only to that BM).

🤖 Generated with [Claude Code](https://claude.com/claude-code)