### PR TITLE
fix(secrets): migrate 5 critical secrets to Secret Manager

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -261,19 +261,18 @@ jobs:
             META_API_VERSION=v22.0
             LOG_LEVEL=info
             NODE_ENV=production
-            OAUTH_SECRET=${{ secrets.OAUTH_SECRET }}
-            TOKEN_ENCRYPTION_KEY=${{ secrets.TOKEN_ENCRYPTION_KEY }}
-            SESSION_COOKIE_SECRET=${{ secrets.SESSION_COOKIE_SECRET }}
             META_APP_ID=${{ secrets.META_APP_ID }}
-            META_APP_SECRET=${{ secrets.META_APP_SECRET }}
             AUTH_ALLOWED_EMAILS=${{ secrets.AUTH_ALLOWED_EMAILS }}
             AUTH_ALLOWED_DOMAINS=${{ secrets.AUTH_ALLOWED_DOMAINS }}
             AUTH_ALLOWED_FB_USER_IDS=${{ secrets.AUTH_ALLOWED_FB_USER_IDS }}
             FIRESTORE_PROJECT_ID=${{ secrets.FIRESTORE_PROJECT_ID }}
-            META_ACCESS_TOKEN=${{ secrets.META_ACCESS_TOKEN }}
-            MCP_API_KEY=${{ secrets.MCP_API_KEY }}
           secrets: |
             META_TOKENS=meta-tokens-prod:latest
+            OAUTH_SECRET=oauth-secret:latest
+            TOKEN_ENCRYPTION_KEY=token-encryption-key:latest
+            SESSION_COOKIE_SECRET=session-cookie-secret:latest
+            META_APP_SECRET=meta-app-secret:latest
+            MCP_API_KEY=mcp-api-key:latest
 
       - name: Mask service URL in logs
         env:

--- a/scripts/rotate-token-encryption-key.mjs
+++ b/scripts/rotate-token-encryption-key.mjs
@@ -1,0 +1,148 @@
+#!/usr/bin/env node
+// Re-encrypts every Meta token in Firestore from OLD TOKEN_ENCRYPTION_KEY to NEW.
+//
+// Usage:
+//   OLD_KEY=<64-hex> NEW_KEY=<64-hex> [DRY_RUN=1] [PROJECT_ID=byads-dsp] \
+//     node scripts/rotate-token-encryption-key.mjs
+//
+// Behaviour:
+//   1. Smoke test: write+roundtrip 2 docs in `_rotation_test`, then clean up.
+//   2. Iterate `users/*/meta_tokens/*`, decrypt with OLD, encrypt with NEW, write.
+//   3. Verify: re-read each doc, decrypt with NEW, sanity-check plaintext.
+//
+// Prints only counts and per-doc {name, fbUserId, ok}; never prints plaintext.
+
+import { Firestore } from "@google-cloud/firestore";
+import crypto from "node:crypto";
+
+const ALG = "aes-256-gcm";
+const IV_LEN = 12;
+const KEY_LEN = 32;
+
+function parseKey(raw, label) {
+  if (!raw || !/^[0-9a-fA-F]{64}$/.test(raw)) {
+    throw new Error(`${label} must be 64 hex chars`);
+  }
+  return Buffer.from(raw, "hex");
+}
+
+function encrypt(plaintext, key) {
+  const iv = crypto.randomBytes(IV_LEN);
+  const cipher = crypto.createCipheriv(ALG, key, iv);
+  const ct = Buffer.concat([cipher.update(plaintext, "utf8"), cipher.final()]);
+  const tag = cipher.getAuthTag();
+  return {
+    ciphertext: ct.toString("base64"),
+    iv: iv.toString("base64"),
+    tag: tag.toString("base64"),
+  };
+}
+
+function decrypt(payload, key) {
+  const iv = Buffer.from(payload.iv, "base64");
+  const tag = Buffer.from(payload.tag, "base64");
+  const ct = Buffer.from(payload.ciphertext, "base64");
+  const dec = crypto.createDecipheriv(ALG, key, iv);
+  dec.setAuthTag(tag);
+  const pt = Buffer.concat([dec.update(ct), dec.final()]);
+  return pt.toString("utf8");
+}
+
+async function smokeTest(db, oldKey, newKey, dryRun) {
+  const colRef = db.collection("_rotation_test");
+  const docA = colRef.doc("probe-a");
+  const docB = colRef.doc("probe-b");
+  const sampleA = "EAA-sample-token-A-" + Date.now();
+  const sampleB = "system-user-token-B-" + Date.now();
+
+  await docA.set({ encryptedToken: encrypt(sampleA, oldKey) });
+  await docB.set({ encryptedToken: encrypt(sampleB, oldKey) });
+
+  for (const ref of [docA, docB]) {
+    const snap = await ref.get();
+    const oldPayload = snap.data().encryptedToken;
+    const pt = decrypt(oldPayload, oldKey);
+    const newPayload = encrypt(pt, newKey);
+    await ref.update({ encryptedToken: newPayload });
+    const verify = await ref.get();
+    const back = decrypt(verify.data().encryptedToken, newKey);
+    if (back !== pt) throw new Error(`Smoke test failed for ${ref.id}`);
+  }
+
+  // Cleanup
+  if (!dryRun) {
+    await docA.delete();
+    await docB.delete();
+  }
+  console.log("Smoke test: OK (probe-a, probe-b round-tripped)");
+}
+
+async function main() {
+  const oldKey = parseKey(process.env.OLD_KEY, "OLD_KEY");
+  const newKey = parseKey(process.env.NEW_KEY, "NEW_KEY");
+  const dryRun = process.env.DRY_RUN === "1";
+  const projectId = process.env.PROJECT_ID ?? "byads-dsp";
+
+  if (oldKey.equals(newKey)) {
+    throw new Error("OLD_KEY and NEW_KEY are identical — nothing to rotate");
+  }
+
+  const db = new Firestore({ projectId, ignoreUndefinedProperties: true });
+
+  console.log(`Project: ${projectId}, dryRun=${dryRun}`);
+  await smokeTest(db, oldKey, newKey, dryRun);
+
+  console.log("Scanning users/*/meta_tokens/*...");
+  const usersSnap = await db.collection("users").get();
+  console.log(`users: ${usersSnap.size}`);
+
+  let total = 0;
+  let rotated = 0;
+  let failed = 0;
+  const failures = [];
+
+  for (const userDoc of usersSnap.docs) {
+    const tokensSnap = await db
+      .collection("users")
+      .doc(userDoc.id)
+      .collection("meta_tokens")
+      .get();
+    for (const td of tokensSnap.docs) {
+      total++;
+      const data = td.data();
+      try {
+        const pt = decrypt(data.encryptedToken, oldKey);
+        const newPayload = encrypt(pt, newKey);
+        if (!dryRun) {
+          await td.ref.update({
+            encryptedToken: newPayload,
+            updatedAt: Math.floor(Date.now() / 1000),
+          });
+          // Verify
+          const after = await td.ref.get();
+          const verify = decrypt(after.data().encryptedToken, newKey);
+          if (verify !== pt) throw new Error("post-write verify mismatch");
+        }
+        rotated++;
+        console.log(` ✓ ${userDoc.id}/${td.id}`);
+      } catch (err) {
+        failed++;
+        failures.push({ user: userDoc.id, name: td.id, error: err.message });
+        console.log(` ✗ ${userDoc.id}/${td.id}: ${err.message}`);
+      }
+    }
+  }
+
+  console.log(`\nSummary: total=${total} rotated=${rotated} failed=${failed} dryRun=${dryRun}`);
+  if (failures.length) {
+    console.log("Failures:", JSON.stringify(failures));
+    process.exit(2);
+  }
+
+  await db.terminate();
+}
+
+main().catch((err) => {
+  console.error("FATAL:", err.message);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

- Move `OAUTH_SECRET`, `TOKEN_ENCRYPTION_KEY`, `SESSION_COOKIE_SECRET`, `META_APP_SECRET`, `MCP_API_KEY` from `env_vars:` to `secrets:` block in [deploy.yml](.github/workflows/deploy.yml), mounted from Secret Manager `:latest` (same pattern `META_TOKENS` already uses).
- Drop dead env vars `META_ACCESS_TOKEN` and `OAUTH_APPROVAL_PIN` that referenced non-existent GitHub secrets.
- Add [scripts/rotate-token-encryption-key.mjs](scripts/rotate-token-encryption-key.mjs): one-shot Node script that re-encrypts every `users/*/meta_tokens/*` doc with a new key. Includes a smoke test against `_rotation_test`.

## Why

Audit finding INFRA-C1: those 5 values were visible in Cloud Run revision specs as `value:` literal — readable by anyone with `run.viewer`, persisted in audit logs and historical revisions. `TOKEN_ENCRYPTION_KEY` is the AES-256-GCM key for tokens-at-rest, flagged as "catastrophic if leaked" in [CLAUDE.md](CLAUDE.md).

Also closes INFRA-M2 (existing `oauth-secret`, `mcp-api-key` in Secret Manager but not connected), INFRA-M3 (`META_ACCESS_TOKEN`, `OAUTH_APPROVAL_PIN` referenced but missing), INFRA-B3 (duplication GH↔SM).

## State at PR creation time (already done out-of-band)

Secrets were rotated and migrated **before** this PR opens, in this order:
1. New values generated locally (4 with `crypto.randomBytes(32).toString("hex")`, `META_APP_SECRET` rotated by maintainer in Meta Developer Console).
2. `_rotation_test` smoke + re-encryption of the 3 live tokens in `users/26562288036735699/meta_tokens/*` from old → new `TOKEN_ENCRYPTION_KEY` (script verified post-write decrypt).
3. Created/updated 5 versions in GCP Secret Manager (`token-encryption-key`, `session-cookie-secret`, `meta-app-secret`, `oauth-secret`, `mcp-api-key`); granted `secretmanager.secretAccessor` to the runtime SA on each.
4. `gcloud run services update --remove-env-vars=... --update-secrets=...` → revision `meta-ads-mcp-00079-hvr` now serves with all 5 mounted from Secret Manager. `/health` 200.
5. GitHub Actions secrets updated to the new values so the `Validate required production secrets` job continues to pass on the next deploy.

This PR codifies steps 1-5 in the workflow so future deploys preserve the new state.

## Test plan

- [x] `npm run lint`, `npm run typecheck`, `npm test` (246 tests), `npm run build` all green.
- [x] `gitleaks git --staged` clean. Pre-deploy-guard quick mode 3 PASS / 0 FAIL.
- [x] Live revision `meta-ads-mcp-00079-hvr` serving — smoke test passed.
- [ ] After merge: deploy run produces a new revision; `/health` 200; re-login at `/authorize` works (will require fresh login since `OAUTH_SECRET` and `SESSION_COOKIE_SECRET` rotated); `meta_ads_list_tokens` shows the 3 tokens (preserved by re-encryption).
- [ ] Cleanup: delete old revisions that still hold plain-text secrets in their spec (≤ 00078).

## Security note

`META_APP_SECRET` rotation invalidates the old Meta App Secret. Long-lived Meta tokens already issued remain valid (Meta does not bind them to the app secret post-issuance). New OAuth flows use the new secret.

`OAUTH_SECRET` and `SESSION_COOKIE_SECRET` rotation invalidates all current MCP JWTs and session cookies — Claude.ai will require a fresh `/authorize` flow on next call. The 3 Meta tokens themselves are intact (re-encrypted, not re-issued).

🤖 Generated with [Claude Code](https://claude.com/claude-code)