### PR TITLE
fix(iam): pin Cloud Run to a dedicated least-privilege runtime SA

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -250,6 +250,7 @@ jobs:
           image: ${{ secrets.GCP_REGION }}-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/meta-ads-mcp/${{ env.IMAGE_NAME }}:${{ github.sha }}
           flags: >-
             --allow-unauthenticated
+            --service-account=meta-ads-mcp-runtime@${{ secrets.GCP_PROJECT_ID }}.iam.gserviceaccount.com
             --memory=512Mi
             --cpu=1
             --concurrency=80


### PR DESCRIPTION
## Summary

- Stop running the meta-ads-mcp container under the default Compute Engine SA (which carries `roles/editor` + `bigquery.admin` + `run.admin` + `iam.serviceAccountUser` + `serviceusage.serviceUsageAdmin`) and pin it to a new least-privilege SA: `meta-ads-mcp-runtime@byads-dsp.iam.gserviceaccount.com`.
- Add `--service-account=meta-ads-mcp-runtime@${{ secrets.GCP_PROJECT_ID }}.iam.gserviceaccount.com` to the `flags:` block of the deploy step so future deploys preserve the choice.

## Why

Audit finding **INFRA-C3**. With the default Compute SA, any RCE / SSRF inside the container could exfiltrate every Firestore document in the project, deploy malicious revisions, escalate via `iam.serviceAccountUser`, or modify enabled APIs. CLAUDE.md frames this as the highest-residual-risk after the secret leakage we already addressed in PR #38.

## What the new SA can do

```
roles/datastore.user                    # Firestore (users/, mcp_clients/, mcp_auth_codes/)
roles/logging.logWriter                 # stdout/stderr from Cloud Run
roles/secretmanager.secretAccessor      # scoped to each of the 6 secrets, NOT project-wide:
  - meta-tokens-prod
  - oauth-secret
  - token-encryption-key
  - session-cookie-secret
  - meta-app-secret
  - mcp-api-key
```

That's it. No `editor`, no `run.admin`, no `iam.serviceAccountUser`, no BigQuery, no broad Secret Manager access.

## State at PR creation time

Already done out-of-band:
1. SA `meta-ads-mcp-runtime@byads-dsp.iam.gserviceaccount.com` created with the 2 project roles + 6 per-secret bindings.
2. `gcloud run services update --service-account=meta-ads-mcp-runtime@…` migrated the live service to it.
3. Live revision `meta-ads-mcp-00083-pkj` runs under the new SA. `/health` 200, OAuth metadata 200.

This PR codifies the change in `deploy.yml`. Without it, the next deploy would revert to the Compute default SA.

## Test plan

- [x] `npm run lint`, `npm run typecheck`, `npm test` (246 tests), `npm run build` all green.
- [x] `gitleaks git --staged` clean.
- [x] Live service runs under the new SA — smoke test passed.
- [ ] After merge: deploy run produces a new revision; `gcloud run services describe meta-ads-mcp --region=us-east1 --format='value(spec.template.spec.serviceAccountName)'` returns `meta-ads-mcp-runtime@byads-dsp.iam.gserviceaccount.com`.
- [ ] Verify all flows still work: re-login at `/authorize`, `meta_ads_list_tokens`, a Meta Ads tool call.

## Out of scope (audit findings parked for later PRs)

- INFRA-A2 (recortar permisos del SA `github-actions-deploy@`): los 3 SAs `github-*` que existen en el proyecto ya tienen permisos razonables (sin `editor`, sin `secretmanager.admin`); el reporte original era impreciso. Tocarlos sin saber con certeza cuál es el activo en `${{ secrets.GCP_SERVICE_ACCOUNT }}` es riesgoso. Lo abordamos cuando sepamos cuál SA es.
- INFRA-A3 (GitHub native secret scanning): toggle UI manual.
- INFRA-A4 (`enforce_admins`, `required_signatures`): toggle UI manual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)