### PR TITLE
fix(deploy): reconcile Secret Manager IAM on every run + tolerate read-perm gap

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -182,17 +182,33 @@ jobs:
           # doesn't exist (e.g. fork to a fresh project that hasn't been
           # bootstrapped yet). Without this, the deploy step fails with a
           # cryptic iam.serviceAccountUser error mid-rollout.
-          if ! gcloud iam service-accounts describe "${GCP_RUNTIME_SERVICE_ACCOUNT}" \
-              --project="${GCP_PROJECT_ID}" --quiet >/dev/null 2>&1; then
-            echo "Runtime service account ${GCP_RUNTIME_SERVICE_ACCOUNT} does not exist in project ${GCP_PROJECT_ID}."
-            echo "Create it with the minimum roles described in CONTRIBUTING.md, e.g.:"
-            echo "  gcloud iam service-accounts create meta-ads-mcp-runtime --project=${GCP_PROJECT_ID}"
-            echo "  gcloud projects add-iam-policy-binding ${GCP_PROJECT_ID} --member=serviceAccount:${GCP_RUNTIME_SERVICE_ACCOUNT} --role=roles/datastore.user"
-            echo "  gcloud projects add-iam-policy-binding ${GCP_PROJECT_ID} --member=serviceAccount:${GCP_RUNTIME_SERVICE_ACCOUNT} --role=roles/logging.logWriter"
-            echo "  # plus secretmanager.secretAccessor on each mounted secret"
-            exit 1
+          #
+          # Be tolerant of strict least-privilege deployers: roles/iam.serviceAccountUser
+          # grants iam.serviceAccounts.actAs but NOT iam.serviceAccounts.get,
+          # so `describe` may return PERMISSION_DENIED even when the SA exists
+          # and the deployer can legitimately attach it. Treat NOT_FOUND as
+          # blocking, but downgrade missing-read-permission to a warning.
+          if out=$(gcloud iam service-accounts describe "${GCP_RUNTIME_SERVICE_ACCOUNT}" \
+              --project="${GCP_PROJECT_ID}" --quiet 2>&1); then
+            echo "Runtime SA ${GCP_RUNTIME_SERVICE_ACCOUNT} exists."
+          else
+            if printf '%s' "$out" | grep -qiE "permission denied|insufficient permission|forbidden|does not have permission"; then
+              echo "::warning::Cannot read SA metadata for ${GCP_RUNTIME_SERVICE_ACCOUNT} (deployer lacks iam.serviceAccounts.get)."
+              echo "::warning::Skipping existence check; deploy will fail later with a clear iam.serviceAccountUser error if the SA does not exist."
+            elif printf '%s' "$out" | grep -qiE "not.*found|does not exist|NOT_FOUND"; then
+              echo "Runtime service account ${GCP_RUNTIME_SERVICE_ACCOUNT} does not exist in project ${GCP_PROJECT_ID}."
+              echo "Create it with the minimum roles described in CONTRIBUTING.md, e.g.:"
+              echo "  gcloud iam service-accounts create meta-ads-mcp-runtime --project=${GCP_PROJECT_ID}"
+              echo "  gcloud projects add-iam-policy-binding ${GCP_PROJECT_ID} --member=serviceAccount:${GCP_RUNTIME_SERVICE_ACCOUNT} --role=roles/datastore.user"
+              echo "  gcloud projects add-iam-policy-binding ${GCP_PROJECT_ID} --member=serviceAccount:${GCP_RUNTIME_SERVICE_ACCOUNT} --role=roles/logging.logWriter"
+              echo "  # plus secretmanager.secretAccessor on each mounted secret"
+              exit 1
+            else
+              echo "Unexpected error reading runtime SA metadata:"
+              printf '%s\n' "$out"
+              exit 1
+            fi
           fi
-          echo "Runtime SA ${GCP_RUNTIME_SERVICE_ACCOUNT} exists."
 
       - name: Sync META_TOKENS to Secret Manager
         env:
@@ -222,16 +238,29 @@ jobs:
           # the deploy step actually used.
           RUNTIME_SA="${GCP_RUNTIME_SERVICE_ACCOUNT}"
 
+          # Idempotent IAM reconcile: ensure the current runtime SA always
+          # has access to meta-tokens-prod, regardless of whether the secret
+          # is being created here or already existed. Without this, rotating
+          # GCP_RUNTIME_SERVICE_ACCOUNT to a new SA would mount the secret
+          # at deploy time but the new SA would lack secretmanager.secretAccessor,
+          # and the container would fail at startup.
+          ensure_iam_binding() {
+            local secret="$1"
+            gcloud secrets add-iam-policy-binding "$secret" \
+              --member="serviceAccount:${RUNTIME_SA}" \
+              --role=roles/secretmanager.secretAccessor \
+              --project="$GCP_PROJECT_ID" --condition=None --quiet >/dev/null
+          }
+
           if ! gcloud secrets describe "$SECRET_NAME" --project="$GCP_PROJECT_ID" --quiet >/dev/null 2>&1; then
             printf '%s' "${META_TOKENS}" | gcloud secrets create "$SECRET_NAME" \
               --data-file=- --replication-policy=automatic \
               --project="$GCP_PROJECT_ID" --quiet
-            gcloud secrets add-iam-policy-binding "$SECRET_NAME" \
-              --member="serviceAccount:${RUNTIME_SA}" \
-              --role=roles/secretmanager.secretAccessor \
-              --project="$GCP_PROJECT_ID" --quiet >/dev/null
+            ensure_iam_binding "$SECRET_NAME"
             echo "Created Secret Manager secret $SECRET_NAME and granted ${RUNTIME_SA} access."
           else
+            ensure_iam_binding "$SECRET_NAME"
+            echo "Reconciled ${RUNTIME_SA} access on existing $SECRET_NAME."
             # Only add a new version if the value actually changed — avoids
             # one new version per deploy (Secret Manager bills per-version).
             existing_hash=$(gcloud secrets versions access latest \


### PR DESCRIPTION
## Summary

Addresses [Codex feedback on PR #40](https://github.com/byadsco/meta-ads-mcp/pull/40#pullrequestreview-4176532929):

### P1 — Reconcile Secret Manager IAM on every run

The IAM binding for the runtime SA on `meta-tokens-prod` was previously only granted in the secret-**creation** branch. Now that `GCP_RUNTIME_SERVICE_ACCOUNT` is the single source of truth and can be rotated to a different SA in the future, the new SA would be mounted at deploy time but never receive `roles/secretmanager.secretAccessor` on the existing secret, causing the container to fail at startup.

Fix: extract the binding into an idempotent `ensure_iam_binding` helper and call it on both code paths (create + already-exists). `add-iam-policy-binding` is idempotent on a matching binding, so re-running it is a no-op when the binding is already in place.

### P2 — Tolerate strict-least-privilege deployers

The pre-deploy `Verify runtime SA exists` step hard-failed on any `gcloud iam service-accounts describe` error. But `roles/iam.serviceAccountUser` (the role a least-privilege deployer typically holds to attach a runtime SA) grants only `iam.serviceAccounts.actAs`, **not** `iam.serviceAccounts.get`. A deployer that could legitimately deploy was now blocked with a spurious `PERMISSION_DENIED`.

Fix: distinguish error classes with substring matching on `gcloud`'s error output:
- `NOT_FOUND` / "does not exist" → blocking, with the bootstrap commands.
- `PERMISSION_DENIED` / "insufficient permission" / "forbidden" → workflow warning, deploy proceeds. If the SA truly doesn't exist, the deploy step itself surfaces a clear `iam.serviceAccountUser` error.
- Anything else → blocking with the raw error printed.

## Test plan

- [x] `npm run lint`, `npm run typecheck`, `npm test` (246 tests), `npm run build` all green.
- [x] `gitleaks git --staged` clean.
- [ ] After merge: deploy run produces a new revision; `Verify runtime service account exists` step prints `Runtime SA … exists.` (our deployers happen to have read access via `run.admin`/`run.developer`); `Sync META_TOKENS to Secret Manager` step prints `Reconciled … access on existing meta-tokens-prod.`; smoke `/health` 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)