### PR TITLE
fix(security): block SSRF on user-supplied URLs in upload + creative tools

### DIFF
--- a/src/tools/creatives.ts
+++ b/src/tools/creatives.ts
@@ -184,17 +184,6 @@ export function registerCreativeTools(server: McpServer): void {
     }) => {
       const id = normalizeAccountId(account_id);
 
-      if (image_url) {
-        try {
-          await assertSafePublicUrl(image_url);
-        } catch (err) {
-          if (err instanceof UnsafeUrlError) {
-            throw new Error(`Refusing to forward image_url to Meta: ${err.message}`);
-          }
-          throw err;
-        }
-      }
-
       const body: Record<string, string | number | boolean> = { name };
 
       if (source_instagram_media_id) {
@@ -220,6 +209,20 @@ export function registerCreativeTools(server: McpServer): void {
         }
         if (video_id && !image_hash && !image_url) {
           throw new Error("video creatives built from scratch require image_hash or image_url as a thumbnail.");
+        }
+        // SSRF guard: only validate image_url when it will actually be
+        // forwarded to Meta — i.e. Mode 1 with no image_hash override. Other
+        // modes ignore image_url entirely, so a stale value shouldn't fail
+        // the call.
+        if (image_url && !image_hash) {
+          try {
+            await assertSafePublicUrl(image_url);
+          } catch (err) {
+            if (err instanceof UnsafeUrlError) {
+              throw new Error(`Refusing to forward image_url to Meta: ${err.message}`);
+            }
+            throw err;
+          }
         }
         const objectStorySpec: Record<string, unknown> = { page_id };
 

--- a/src/tools/creatives.ts
+++ b/src/tools/creatives.ts
@@ -8,6 +8,7 @@ import { IMAGE_DEFAULT_FIELDS } from "../meta/types/image.js";
 import { VIDEO_DEFAULT_FIELDS, VIDEO_DETAIL_FIELDS } from "../meta/types/video.js";
 import type { AdCreative, AdImage, AdVideo, MetaApiResponse } from "../meta/types/index.js";
 import { logger } from "../utils/logger.js";
+import { assertSafePublicUrl, UnsafeUrlError } from "../utils/url-guard.js";
 
 const ctaEnum = z.enum([
   // Core actions
@@ -183,6 +184,17 @@ export function registerCreativeTools(server: McpServer): void {
     }) => {
       const id = normalizeAccountId(account_id);
 
+      if (image_url) {
+        try {
+          await assertSafePublicUrl(image_url);
+        } catch (err) {
+          if (err instanceof UnsafeUrlError) {
+            throw new Error(`Refusing to forward image_url to Meta: ${err.message}`);
+          }
+          throw err;
+        }
+      }
+
       const body: Record<string, string | number | boolean> = { name };
 
       if (source_instagram_media_id) {
@@ -314,9 +326,20 @@ export function registerCreativeTools(server: McpServer): void {
     async ({ account_id, image_url, name }) => {
       const id = normalizeAccountId(account_id);
 
+      // SSRF guard: validate URL scheme + reject private/loopback/metadata IPs.
+      let safeUrl: URL;
+      try {
+        safeUrl = await assertSafePublicUrl(image_url);
+      } catch (err) {
+        if (err instanceof UnsafeUrlError) {
+          throw new Error(`Refusing to download image_url: ${err.message}`);
+        }
+        throw err;
+      }
+
       // Download the image
       logger.info({ image_url }, "Downloading image for upload");
-      const imageResponse = await fetch(image_url);
+      const imageResponse = await fetch(safeUrl.toString());
       if (!imageResponse.ok) {
         throw new Error(`Failed to download image: HTTP ${imageResponse.status}`);
       }
@@ -504,6 +527,18 @@ export function registerCreativeTools(server: McpServer): void {
       if (source_instagram_media_id) {
         body.source_instagram_media_id = source_instagram_media_id;
       } else if (file_url) {
+        // SSRF guard: Meta will fetch this URL on its end, but we still want to
+        // refuse forwarding URLs that look like internal addresses — both as a
+        // belt-and-braces measure and so the rejection happens with a clear
+        // error here instead of a generic Meta-side failure later.
+        try {
+          await assertSafePublicUrl(file_url);
+        } catch (err) {
+          if (err instanceof UnsafeUrlError) {
+            throw new Error(`Refusing to forward file_url to Meta: ${err.message}`);
+          }
+          throw err;
+        }
         body.file_url = file_url;
       } else {
         throw new Error("Either file_url or source_instagram_media_id is required.");

--- a/src/utils/url-guard.ts
+++ b/src/utils/url-guard.ts
@@ -1,0 +1,174 @@
+import { promises as dns } from "node:dns";
+import { isIP } from "node:net";
+
+const ALLOWED_PROTOCOLS = new Set(["https:"]);
+
+const PRIVATE_V4_RANGES: Array<[bigint, bigint, string]> = [
+  [bn("10.0.0.0"), bn("10.255.255.255"), "RFC1918 10.0.0.0/8"],
+  [bn("172.16.0.0"), bn("172.31.255.255"), "RFC1918 172.16.0.0/12"],
+  [bn("192.168.0.0"), bn("192.168.255.255"), "RFC1918 192.168.0.0/16"],
+  [bn("127.0.0.0"), bn("127.255.255.255"), "loopback 127.0.0.0/8"],
+  [bn("169.254.0.0"), bn("169.254.255.255"), "link-local / GCP metadata 169.254.0.0/16"],
+  [bn("0.0.0.0"), bn("0.255.255.255"), "current-network 0.0.0.0/8"],
+  [bn("100.64.0.0"), bn("100.127.255.255"), "CGNAT 100.64.0.0/10"],
+  [bn("224.0.0.0"), bn("239.255.255.255"), "multicast 224.0.0.0/4"],
+  [bn("240.0.0.0"), bn("255.255.255.255"), "reserved 240.0.0.0/4"],
+];
+
+function bn(ipv4: string): bigint {
+  return ipv4
+    .split(".")
+    .reduce<bigint>((acc, oct) => (acc << 8n) | BigInt(parseInt(oct, 10)), 0n);
+}
+
+function ipv4ToBigInt(ip: string): bigint | null {
+  if (isIP(ip) !== 4) return null;
+  return bn(ip);
+}
+
+function isPrivateV4(ip: string): { reason: string } | null {
+  const value = ipv4ToBigInt(ip);
+  if (value === null) return null;
+  for (const [lo, hi, label] of PRIVATE_V4_RANGES) {
+    if (value >= lo && value <= hi) return { reason: label };
+  }
+  return null;
+}
+
+function isPrivateV6(ip: string): { reason: string } | null {
+  if (isIP(ip) !== 6) return null;
+  const lower = ip.toLowerCase();
+  if (lower === "::1" || lower === "::") return { reason: "IPv6 loopback/unspecified" };
+  if (lower.startsWith("fe80:") || lower.startsWith("fe8") || lower.startsWith("fe9") || lower.startsWith("fea") || lower.startsWith("feb")) {
+    // fe80::/10 covers fe80–febf
+    return { reason: "IPv6 link-local fe80::/10" };
+  }
+  if (/^f[cd]/.test(lower)) return { reason: "IPv6 unique-local fc00::/7" };
+  // IPv4-mapped IPv6 (::ffff:a.b.c.d). Node may render it as
+  // "::ffff:7f00:1" instead of "::ffff:127.0.0.1", so parse both forms.
+  if (lower.startsWith("::ffff:")) {
+    const tail = lower.slice("::ffff:".length);
+    let v4: string | null = null;
+    if (/^[0-9.]+$/.test(tail)) {
+      v4 = tail;
+    } else {
+      // hex form like "7f00:1" or "7f00:0001"
+      const segs = tail.split(":");
+      if (segs.length === 2) {
+        const hi = parseInt(segs[0], 16);
+        const lo = parseInt(segs[1], 16);
+        if (Number.isFinite(hi) && Number.isFinite(lo)) {
+          v4 = [
+            (hi >> 8) & 0xff,
+            hi & 0xff,
+            (lo >> 8) & 0xff,
+            lo & 0xff,
+          ].join(".");
+        }
+      }
+    }
+    if (v4) {
+      const block = isPrivateV4(v4);
+      if (block) return { reason: `IPv4-mapped → ${block.reason}` };
+    }
+  }
+  return null;
+}
+
+export class UnsafeUrlError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "UnsafeUrlError";
+  }
+}
+
+export interface AssertSafeUrlOptions {
+  /**
+   * Inject a DNS resolver. Defaults to node:dns/promises lookup.
+   * Tests can stub this to avoid real network calls.
+   */
+  resolve?: (hostname: string) => Promise<Array<{ address: string }>>;
+}
+
+/**
+ * Throws UnsafeUrlError if the URL is not a safe public destination for an
+ * outbound fetch. Used by tools that accept user-supplied URLs (image/video
+ * upload) to prevent SSRF against the GCP metadata service, container
+ * loopback, RFC1918, link-local and other internal addresses.
+ *
+ * Validation:
+ *   1. Parses as a URL.
+ *   2. Protocol must be https:
+ *   3. If the host is a literal IP, it must not be in any private range.
+ *   4. Otherwise, resolves the hostname (A + AAAA) and rejects if any
+ *      resolved address falls in a private range. (Catches DNS rebinding
+ *      and host names that point at internal addresses.)
+ */
+export async function assertSafePublicUrl(
+  raw: string,
+  options: AssertSafeUrlOptions = {},
+): Promise<URL> {
+  let url: URL;
+  try {
+    url = new URL(raw);
+  } catch {
+    throw new UnsafeUrlError(`URL is malformed: ${raw}`);
+  }
+  if (!ALLOWED_PROTOCOLS.has(url.protocol)) {
+    throw new UnsafeUrlError(
+      `URL protocol "${url.protocol}" is not allowed; only https:`,
+    );
+  }
+  if (!url.hostname) {
+    throw new UnsafeUrlError("URL is missing a hostname");
+  }
+
+  // url.hostname wraps IPv6 literals in [...]; strip them for isIP.
+  const bareHost = url.hostname.startsWith("[") && url.hostname.endsWith("]")
+    ? url.hostname.slice(1, -1)
+    : url.hostname;
+  const literalIpVersion = isIP(bareHost);
+  if (literalIpVersion === 4) {
+    const block = isPrivateV4(bareHost);
+    if (block) throw new UnsafeUrlError(`URL points at private IP (${block.reason})`);
+    return url;
+  }
+  if (literalIpVersion === 6) {
+    const block = isPrivateV6(bareHost);
+    if (block) throw new UnsafeUrlError(`URL points at private IP (${block.reason})`);
+    return url;
+  }
+
+  // Hostname → resolve and reject if any address is private.
+  const resolver =
+    options.resolve ??
+    (async (hostname: string) => {
+      const records = await dns.lookup(hostname, { all: true, verbatim: true });
+      return records;
+    });
+  let addresses: Array<{ address: string }>;
+  try {
+    addresses = await resolver(url.hostname);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    throw new UnsafeUrlError(`Cannot resolve hostname ${url.hostname}: ${msg}`);
+  }
+  if (addresses.length === 0) {
+    throw new UnsafeUrlError(`Hostname ${url.hostname} did not resolve to any address`);
+  }
+  for (const { address } of addresses) {
+    const v4 = isPrivateV4(address);
+    if (v4) {
+      throw new UnsafeUrlError(
+        `Hostname ${url.hostname} resolves to private IP ${address} (${v4.reason})`,
+      );
+    }
+    const v6 = isPrivateV6(address);
+    if (v6) {
+      throw new UnsafeUrlError(
+        `Hostname ${url.hostname} resolves to private IP ${address} (${v6.reason})`,
+      );
+    }
+  }
+  return url;
+}

--- a/tests/utils/url-guard.test.ts
+++ b/tests/utils/url-guard.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from "vitest";
+import {
+  assertSafePublicUrl,
+  UnsafeUrlError,
+} from "../../src/utils/url-guard.js";
+
+function fakeResolve(addresses: string[]) {
+  return async (_hostname: string) => addresses.map((address) => ({ address }));
+}
+
+describe("assertSafePublicUrl", () => {
+  it("accepts a public https URL whose host resolves to a public IP", async () => {
+    const url = await assertSafePublicUrl("https://example.com/path", {
+      resolve: fakeResolve(["93.184.216.34"]),
+    });
+    expect(url.toString()).toBe("https://example.com/path");
+  });
+
+  it("rejects http://", async () => {
+    await expect(
+      assertSafePublicUrl("http://example.com/x", { resolve: fakeResolve(["8.8.8.8"]) }),
+    ).rejects.toThrow(UnsafeUrlError);
+  });
+
+  it("rejects file://", async () => {
+    await expect(
+      assertSafePublicUrl("file:///etc/passwd", { resolve: fakeResolve([]) }),
+    ).rejects.toThrow(UnsafeUrlError);
+  });
+
+  it("rejects malformed URLs", async () => {
+    await expect(
+      assertSafePublicUrl("not-a-url", { resolve: fakeResolve([]) }),
+    ).rejects.toThrow(/malformed/i);
+  });
+
+  it("rejects literal RFC1918 IPs", async () => {
+    await expect(
+      assertSafePublicUrl("https://10.0.0.1/", { resolve: fakeResolve([]) }),
+    ).rejects.toThrow(/RFC1918 10\.0\.0\.0\/8/);
+    await expect(
+      assertSafePublicUrl("https://192.168.1.1/", { resolve: fakeResolve([]) }),
+    ).rejects.toThrow(/RFC1918 192\.168/);
+    await expect(
+      assertSafePublicUrl("https://172.20.0.1/", { resolve: fakeResolve([]) }),
+    ).rejects.toThrow(/RFC1918 172\.16/);
+  });
+
+  it("rejects literal loopback IPs", async () => {
+    await expect(
+      assertSafePublicUrl("https://127.0.0.1/", { resolve: fakeResolve([]) }),
+    ).rejects.toThrow(/loopback/i);
+  });
+
+  it("rejects the GCP metadata service IP", async () => {
+    await expect(
+      assertSafePublicUrl("https://169.254.169.254/computeMetadata/v1/", {
+        resolve: fakeResolve([]),
+      }),
+    ).rejects.toThrow(/link-local|GCP metadata/i);
+  });
+
+  it("rejects hostnames that resolve to a private IP (DNS rebinding defense)", async () => {
+    await expect(
+      assertSafePublicUrl("https://attacker-controlled.com/x", {
+        resolve: fakeResolve(["10.1.2.3"]),
+      }),
+    ).rejects.toThrow(/resolves to private IP 10\.1\.2\.3/);
+  });
+
+  it("rejects when one of multiple resolved IPs is private (mixed A records)", async () => {
+    await expect(
+      assertSafePublicUrl("https://example.com/x", {
+        resolve: fakeResolve(["8.8.8.8", "127.0.0.1"]),
+      }),
+    ).rejects.toThrow(/127\.0\.0\.1/);
+  });
+
+  it("rejects IPv6 loopback", async () => {
+    await expect(
+      assertSafePublicUrl("https://[::1]/", { resolve: fakeResolve([]) }),
+    ).rejects.toThrow(/IPv6 loopback/i);
+  });
+
+  it("rejects IPv6 link-local", async () => {
+    await expect(
+      assertSafePublicUrl("https://[fe80::1]/", { resolve: fakeResolve([]) }),
+    ).rejects.toThrow(/link-local/i);
+  });
+
+  it("rejects IPv6 unique-local", async () => {
+    await expect(
+      assertSafePublicUrl("https://[fd00::1]/", { resolve: fakeResolve([]) }),
+    ).rejects.toThrow(/unique-local/i);
+  });
+
+  it("rejects IPv4-mapped IPv6 to a private v4", async () => {
+    await expect(
+      assertSafePublicUrl("https://[::ffff:127.0.0.1]/", {
+        resolve: fakeResolve([]),
+      }),
+    ).rejects.toThrow(/IPv4-mapped/);
+  });
+
+  it("rejects when DNS resolution fails", async () => {
+    await expect(
+      assertSafePublicUrl("https://nope.invalid/", {
+        resolve: async () => {
+          throw new Error("ENOTFOUND");
+        },
+      }),
+    ).rejects.toThrow(/Cannot resolve/);
+  });
+
+  it("rejects when DNS returns no addresses", async () => {
+    await expect(
+      assertSafePublicUrl("https://nope.invalid/", { resolve: fakeResolve([]) }),
+    ).rejects.toThrow(/did not resolve/);
+  });
+});


### PR DESCRIPTION
## Summary

Audit finding **CODE-A3**. Three MCP tools accept URLs from callers and either fetch them server-side or forward them to Meta:

| Tool | Path | What happens with the URL |
|---|---|---|
| `meta_ads_upload_ad_image` | [creatives.ts:319](src/tools/creatives.ts#L319) | server `fetch(image_url)` |
| `meta_ads_upload_ad_video` | [creatives.ts:507](src/tools/creatives.ts#L507) | forwarded to Meta as `file_url` |
| `meta_ads_create_ad_creative` | [creatives.ts:170](src/tools/creatives.ts#L170) | forwarded to Meta as `picture` |

The Zod schema validated only as `z.string()`, so callers could pass `http://169.254.169.254/computeMetadata/v1/` (GCP metadata), `http://127.0.0.1/`, RFC1918 ranges, etc. With the now-tightened runtime SA from PR #41, the blast radius is limited to whatever that SA can read — but the guard belongs at the application boundary regardless.

## What this PR adds

New helper `src/utils/url-guard.ts` exports `assertSafePublicUrl(raw, opts) -> URL` that:

1. Parses the URL.
2. Requires protocol `https:`.
3. **Literal IP** in the host: rejects RFC1918 (10/8, 172.16/12, 192.168/16), loopback (127/8), link-local (169.254/16), 0/8, CGNAT (100.64/10), multicast (224/4), reserved (240/4).
4. **Hostname**: resolves both A and AAAA records; rejects if **any** address is private. Defends against DNS rebinding and deliberately public hostnames pointing at internal IPs.
5. **IPv6**: rejects loopback (`::1`), unspecified (`::`), link-local (`fe80::/10`), unique-local (`fc00::/7`), and IPv4-mapped (`::ffff:a.b.c.d`, including Node's compact form `::ffff:7f00:1`).

Wired into all three tool handlers; an `UnsafeUrlError` is rewrapped into a clear `Refusing to download image_url: …` / `Refusing to forward file_url to Meta: …` message so the agent gets actionable feedback.

## Test plan

- [x] `npm run lint`, `npm run typecheck`, `npm test` (261 tests, +15), `npm run build` all green.
- [x] `gitleaks git --staged` clean.
- New unit tests cover:
  - Happy path with public IP A record.
  - Reject `http://`, `file://`, malformed URLs.
  - Reject literal IPs in every covered range (RFC1918, loopback, GCP metadata, IPv6 loopback / link-local / unique-local, IPv4-mapped).
  - DNS rebinding defense (hostname resolves to private IP).
  - Mixed A records (one public + one private → rejected).
  - DNS resolution failure / empty answer.

## Out of scope

- Tools that hit Meta's own endpoints (already trusted) — not validated.
- HTTP redirects following the safe URL: Node's `fetch` follows redirects by default, so a malicious server could return a 302 to `127.0.0.1`. Hardening that needs `redirect: "manual"` + a re-validation loop. Filed mentally for a follow-up; flagged here so reviewers can comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)