### PR TITLE
fix(security): validate redirect_uri in GET /authorize and tighten CORS

### DIFF
--- a/src/transport/authorize-validation.ts
+++ b/src/transport/authorize-validation.ts
@@ -1,0 +1,75 @@
+import type { OAuthClientInformationFull } from "@modelcontextprotocol/sdk/shared/auth.js";
+
+export type AuthorizeValidationResult =
+  | { ok: true; redirectUri: string; redirectOrigin: string }
+  | { ok: false; status: number; message: string };
+
+export interface AuthorizeQuery {
+  client_id?: string | string[];
+  redirect_uri?: string | string[];
+  [key: string]: unknown;
+}
+
+function single(value: string | string[] | undefined): string {
+  if (typeof value === "string") return value;
+  if (Array.isArray(value) && value.length > 0 && typeof value[0] === "string")
+    return value[0];
+  return "";
+}
+
+/**
+ * Validate the OAuth authorization request before rendering the consent
+ * page or kicking off the upstream login flow.
+ *
+ * This protects against an open redirect / phishing vector where the
+ * "Deny" form on the consent page submits to query.redirect_uri: without
+ * this check, an attacker could craft a /authorize URL with
+ * redirect_uri=https://evil.example/ pointing at any registered client
+ * and ride the user's session into an arbitrary host. mcp-sdk validates
+ * these in POST /authorize but the GET handler used to reflect the
+ * value verbatim.
+ */
+export async function validateAuthorizeQuery(
+  query: AuthorizeQuery,
+  getClient: (
+    clientId: string,
+  ) => Promise<OAuthClientInformationFull | undefined>,
+): Promise<AuthorizeValidationResult> {
+  const clientId = single(query.client_id);
+  const redirectUri = single(query.redirect_uri);
+
+  if (!clientId || !redirectUri) {
+    return {
+      ok: false,
+      status: 400,
+      message: "client_id and redirect_uri are required.",
+    };
+  }
+
+  const client = await getClient(clientId);
+  if (!client) {
+    return { ok: false, status: 400, message: "Unknown client." };
+  }
+
+  const registered = client.redirect_uris ?? [];
+  if (!registered.includes(redirectUri)) {
+    return {
+      ok: false,
+      status: 400,
+      message: "redirect_uri is not registered for this client.",
+    };
+  }
+
+  let redirectOrigin: string;
+  try {
+    redirectOrigin = new URL(redirectUri).origin;
+  } catch {
+    return {
+      ok: false,
+      status: 400,
+      message: "redirect_uri is malformed.",
+    };
+  }
+
+  return { ok: true, redirectUri, redirectOrigin };
+}

--- a/src/transport/http.ts
+++ b/src/transport/http.ts
@@ -13,6 +13,7 @@ import { tokenManager } from "../auth/token-manager.js";
 import { getSession } from "../auth/session.js";
 import { resolveSecurityConfig } from "./security-config.js";
 import { mountAuthRoutes } from "./auth-routes.js";
+import { validateAuthorizeQuery } from "./authorize-validation.js";
 import {
   FirestoreClientsStore,
   InMemoryClientsStore,
@@ -376,7 +377,31 @@ export async function startHttpTransport(
   const config = resolveSecurityConfig();
 
   app.set("trust proxy", 1);
-  app.use(cors());
+  // CORS: explicit allowlist instead of wildcard. The previous app.use(cors())
+  // set Access-Control-Allow-Origin: * on every response, which let any origin
+  // invoke /mcp with a stolen Bearer token. We only need cross-origin reads
+  // for Claude.ai (and any operator-configured peers); /authorize and /auth/*
+  // are top-level navigations that don't depend on CORS.
+  const corsAllowedOrigins = (process.env.CORS_ALLOWED_ORIGINS?.trim() || "https://claude.ai")
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+  app.use(
+    cors({
+      origin: corsAllowedOrigins,
+      credentials: false,
+      methods: ["GET", "POST", "OPTIONS"],
+      allowedHeaders: [
+        "Content-Type",
+        "Authorization",
+        "X-API-Key",
+        "X-Meta-Token",
+        "Mcp-Session-Id",
+      ],
+      maxAge: 600,
+    }),
+  );
+  logger.info({ corsAllowedOrigins }, "CORS allowlist configured");
   app.use(cookieParser());
   app.use(express.json({ limit: "10mb" }));
 
@@ -436,6 +461,27 @@ export async function startHttpTransport(
     mountAuthRoutes(app, { serverUrl });
 
     app.get("/authorize", async (req, res) => {
+      const query = req.query as Record<string, string>;
+
+      // Validate client_id and redirect_uri BEFORE rendering the consent
+      // page or kicking off the Meta login dance. mcp-sdk validates these
+      // in POST /authorize but the GET handler used to reflect the value
+      // verbatim into the "Deny" form action.
+      const validation = await validateAuthorizeQuery(query, async (id) =>
+        oauthProvider.clientsStore.getClient(id),
+      );
+      if (!validation.ok) {
+        logger.warn(
+          { clientId: query.client_id, redirectUri: query.redirect_uri, reason: validation.message },
+          "Rejected /authorize",
+        );
+        res.status(validation.status).type("html").send(
+          `<h1>Invalid request</h1><p>${validation.message}</p>`,
+        );
+        return;
+      }
+      const { redirectOrigin } = validation;
+
       const session = await getSession(req);
       if (!session) {
         const returnTo = req.originalUrl;
@@ -446,15 +492,9 @@ export async function startHttpTransport(
       const tokens = await listTokens(session.fbUserId);
       const activeName = await getDefaultTokenName(session.fbUserId);
 
-      const query = req.query as Record<string, string>;
-      const redirectOrigin = query.redirect_uri
-        ? new URL(query.redirect_uri, serverUrl).origin
-        : null;
       res.setHeader(
         "Content-Security-Policy",
-        `default-src 'none'; style-src 'unsafe-inline'; form-action 'self'${
-          redirectOrigin ? ` ${redirectOrigin}` : ""
-        }`,
+        `default-src 'none'; style-src 'unsafe-inline'; form-action 'self' ${redirectOrigin}`,
       );
 
       res.type("html").send(

--- a/tests/transport/authorize-validation.test.ts
+++ b/tests/transport/authorize-validation.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from "vitest";
+import { validateAuthorizeQuery } from "../../src/transport/authorize-validation.js";
+import type { OAuthClientInformationFull } from "@modelcontextprotocol/sdk/shared/auth.js";
+
+const claudeClient: OAuthClientInformationFull = {
+  client_id: "claude-client",
+  client_name: "Claude.ai",
+  redirect_uris: ["https://claude.ai/api/mcp/auth_callback"],
+  grant_types: ["authorization_code", "refresh_token"],
+  response_types: ["code"],
+  token_endpoint_auth_method: "client_secret_post",
+  client_id_issued_at: 0,
+};
+
+function makeGetClient(map: Record<string, OAuthClientInformationFull>) {
+  return async (id: string) => map[id];
+}
+
+describe("validateAuthorizeQuery", () => {
+  it("accepts a request with a registered client and matching redirect_uri", async () => {
+    const r = await validateAuthorizeQuery(
+      {
+        client_id: "claude-client",
+        redirect_uri: "https://claude.ai/api/mcp/auth_callback",
+      },
+      makeGetClient({ "claude-client": claudeClient }),
+    );
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.redirectUri).toBe("https://claude.ai/api/mcp/auth_callback");
+      expect(r.redirectOrigin).toBe("https://claude.ai");
+    }
+  });
+
+  it("rejects when client_id is missing", async () => {
+    const r = await validateAuthorizeQuery(
+      { redirect_uri: "https://claude.ai/api/mcp/auth_callback" },
+      makeGetClient({}),
+    );
+    expect(r).toEqual({
+      ok: false,
+      status: 400,
+      message: expect.stringContaining("required"),
+    });
+  });
+
+  it("rejects when redirect_uri is missing", async () => {
+    const r = await validateAuthorizeQuery(
+      { client_id: "claude-client" },
+      makeGetClient({ "claude-client": claudeClient }),
+    );
+    expect(r.ok).toBe(false);
+  });
+
+  it("rejects when the client is unknown", async () => {
+    const r = await validateAuthorizeQuery(
+      {
+        client_id: "ghost-client",
+        redirect_uri: "https://claude.ai/api/mcp/auth_callback",
+      },
+      makeGetClient({}),
+    );
+    expect(r).toEqual({
+      ok: false,
+      status: 400,
+      message: "Unknown client.",
+    });
+  });
+
+  it("rejects redirect_uri not registered for the client (open-redirect defense)", async () => {
+    const r = await validateAuthorizeQuery(
+      {
+        client_id: "claude-client",
+        redirect_uri: "https://evil.example/steal",
+      },
+      makeGetClient({ "claude-client": claudeClient }),
+    );
+    expect(r).toEqual({
+      ok: false,
+      status: 400,
+      message: "redirect_uri is not registered for this client.",
+    });
+  });
+
+  it("rejects when redirect_uri is malformed even if it appears in the registered list", async () => {
+    const weirdClient: OAuthClientInformationFull = {
+      ...claudeClient,
+      redirect_uris: ["not a url"],
+    };
+    const r = await validateAuthorizeQuery(
+      { client_id: "claude-client", redirect_uri: "not a url" },
+      makeGetClient({ "claude-client": weirdClient }),
+    );
+    expect(r).toEqual({
+      ok: false,
+      status: 400,
+      message: "redirect_uri is malformed.",
+    });
+  });
+
+  it("uses exact match (no path-prefix tricks)", async () => {
+    const r = await validateAuthorizeQuery(
+      {
+        client_id: "claude-client",
+        redirect_uri: "https://claude.ai/api/mcp/auth_callback/extra",
+      },
+      makeGetClient({ "claude-client": claudeClient }),
+    );
+    expect(r.ok).toBe(false);
+  });
+
+  it("uses exact match (no fragment tricks)", async () => {
+    const r = await validateAuthorizeQuery(
+      {
+        client_id: "claude-client",
+        redirect_uri: "https://claude.ai/api/mcp/auth_callback#extra",
+      },
+      makeGetClient({ "claude-client": claudeClient }),
+    );
+    expect(r.ok).toBe(false);
+  });
+
+  it("rejects array values for client_id (Express duplicates) by collapsing to first then validating", async () => {
+    const r = await validateAuthorizeQuery(
+      {
+        client_id: ["claude-client", "evil-client"],
+        redirect_uri: "https://claude.ai/api/mcp/auth_callback",
+      },
+      makeGetClient({ "claude-client": claudeClient }),
+    );
+    // first value used, valid client, valid redirect → accepted.
+    expect(r.ok).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Two related audit findings.

### CODE-C2 — open-redirect / phishing on GET /authorize

The handler at [http.ts:438](src/transport/http.ts#L438) reflected `query.redirect_uri` verbatim into:
1. The CSP `form-action` source (line 456).
2. The "Deny" form's `action` attribute on the consent page ([http.ts:206](src/transport/http.ts#L206)).

`mcp-sdk` validates `redirect_uri` in `POST /authorize` but the **GET** handler used to take it on faith. So a crafted URL like
```
GET /authorize?client_id=<some_real_id>&redirect_uri=https://evil.example/&state=...
```
would render the consent page; clicking "Deny" submits to `evil.example` with the user's session in flight. Combined with a registered `client_id` (DCR is open), this is a working open-redirect / phishing primitive.

**Fix**: load the client via `oauthProvider.clientsStore.getClient(client_id)` and require an exact match between `query.redirect_uri` and one of `client.redirect_uris`. No path-prefix or fragment tricks. Refuse with 400 before any render or upstream login redirect. Logic lives in [src/transport/authorize-validation.ts](src/transport/authorize-validation.ts) so it's unit-testable.

### CODE-C1 — wildcard CORS

`app.use(cors())` emitted `Access-Control-Allow-Origin: *` on every response, including `/mcp` and `/auth/*`. Any origin in any browser tab could `fetch('/mcp', { headers: { Authorization: \`Bearer \${stolenToken}\` } })` and read the JSON-RPC response.

**Fix**: explicit allowlist via `cors({ origin: corsAllowedOrigins, credentials: false, ... })`. Default `https://claude.ai`; configurable via env `CORS_ALLOWED_ORIGINS` (comma-separated). `credentials: false` because the MCP transport authenticates with Bearer tokens, not cookies. `/authorize` and `/auth/*` are top-level navigations and don't rely on CORS, so the tightening doesn't affect them.

## Test plan

- [x] `npm run lint`, `npm run typecheck`, `npm test` (270 tests, +9), `npm run build` all green.
- [x] `gitleaks git --staged` clean.
- [x] New unit tests cover: happy path, missing fields, unknown client, unregistered `redirect_uri`, malformed URL, exact-match enforcement (path-prefix + fragment variants both rejected), Express duplicate-query-key collapse.
- [ ] Post-deploy: `/health` 200; OAuth flow from Claude.ai still works (registered client + registered redirect → consent page renders); a `curl -H "Origin: https://evil.example"` to `/mcp` no longer gets `Access-Control-Allow-Origin`.

## Notes

- The `/health` smoke test in `deploy.yml` is unaffected (no `Origin` header).
- If at some point we need to support additional MCP clients (Claude Desktop, custom in-house clients), set `CORS_ALLOWED_ORIGINS=https://claude.ai,https://other.example` in the deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)