### PR TITLE
fix(security): harden OAuth flow — atomic code consume, PKCE recheck, jti revocation

### DIFF
--- a/src/auth/oauth-provider.ts
+++ b/src/auth/oauth-provider.ts
@@ -191,13 +191,15 @@ export class MetaAdsOAuthProvider implements OAuthServerProvider {
     if (!jti) {
       throw new Error("Refresh token missing jti");
     }
-    if (!(await this.refreshJtiStoreImpl.has(jti))) {
+    // Atomic consume: under concurrent refresh requests with the same
+    // token, only one wins. Without this, has()+delete() were two
+    // separate calls, leaving a replay window across instances backed by
+    // Firestore (and breaking the rotation guarantee in-memory under
+    // sufficient async interleaving). Even if generateTokens fails after
+    // this, the worst case is the user has to re-authorize.
+    if (!(await this.refreshJtiStoreImpl.consume(jti))) {
       throw new Error("Refresh token has been revoked or already used");
     }
-    // Rotation: invalidate the old jti before minting a new pair. Even if
-    // generateTokens fails after this, the worst case is the user has to
-    // re-authorize — not a stuck-but-valid token sitting around.
-    await this.refreshJtiStoreImpl.delete(jti);
 
     return this.generateTokens({
       clientId: client.client_id,

--- a/src/auth/oauth-provider.ts
+++ b/src/auth/oauth-provider.ts
@@ -18,6 +18,10 @@ import {
   type AuthCodesStore,
 } from "../store/persistent-auth-codes.js";
 import { InMemoryClientsStore } from "../store/persistent-clients-store.js";
+import {
+  InMemoryJtiStore,
+  type JtiStore,
+} from "../store/persistent-jti-store.js";
 
 let cachedSecret: Uint8Array | undefined;
 
@@ -48,15 +52,18 @@ export interface PendingAuthSession {
 export class MetaAdsOAuthProvider implements OAuthServerProvider {
   private clientsStoreImpl: OAuthRegisteredClientsStore = new InMemoryClientsStore();
   private authCodesImpl: AuthCodesStore = new InMemoryAuthCodesStore();
+  private refreshJtiStoreImpl: JtiStore = new InMemoryJtiStore();
   private pendingAuthResolver: () => PendingAuthSession | null = () => null;
 
   configure(opts: {
     clientsStore?: OAuthRegisteredClientsStore;
     authCodesStore?: AuthCodesStore;
+    refreshJtiStore?: JtiStore;
     resolvePendingAuth?: () => PendingAuthSession | null;
   }): void {
     if (opts.clientsStore) this.clientsStoreImpl = opts.clientsStore;
     if (opts.authCodesStore) this.authCodesImpl = opts.authCodesStore;
+    if (opts.refreshJtiStore) this.refreshJtiStoreImpl = opts.refreshJtiStore;
     if (opts.resolvePendingAuth) this.pendingAuthResolver = opts.resolvePendingAuth;
   }
 
@@ -115,22 +122,39 @@ export class MetaAdsOAuthProvider implements OAuthServerProvider {
   async exchangeAuthorizationCode(
     client: OAuthClientInformationFull,
     authorizationCode: string,
-    _codeVerifier?: string,
+    codeVerifier?: string,
     _redirectUri?: string,
     resource?: URL,
   ): Promise<OAuthTokens> {
-    const entry = await this.authCodesImpl.get(authorizationCode);
+    // Atomic get-and-delete: under concurrent exchange requests, only the
+    // first caller sees the entry. RFC 6749 §10.5: codes must be single-use.
+    const entry = await this.authCodesImpl.consume(authorizationCode);
     if (!entry) {
       throw new Error("Invalid authorization code");
     }
-
-    await this.authCodesImpl.delete(authorizationCode);
 
     if (entry.clientId !== client.client_id) {
       throw new Error("Authorization code was issued to a different client");
     }
     if (entry.expiresAt < Math.floor(Date.now() / 1000)) {
       throw new Error("Authorization code has expired");
+    }
+
+    // Defense-in-depth PKCE check. mcp-sdk's primary verification happens
+    // upstream via challengeForAuthorizationCode; we re-verify here when
+    // the verifier is supplied so the guarantee survives any future
+    // change in how mcp-sdk wires the calls. We don't *require* the
+    // verifier in this method (the SDK's flow sometimes passes it,
+    // sometimes hands the challenge upward), but if it's present it must
+    // match.
+    if (entry.codeChallenge && codeVerifier) {
+      const computed = crypto
+        .createHash("sha256")
+        .update(codeVerifier)
+        .digest("base64url");
+      if (computed !== entry.codeChallenge) {
+        throw new Error("PKCE verification failed");
+      }
     }
 
     return this.generateTokens({
@@ -159,6 +183,21 @@ export class MetaAdsOAuthProvider implements OAuthServerProvider {
     if (payload.sub !== client.client_id) {
       throw new Error("Refresh token was issued to a different client");
     }
+    // jti must be present in the allow-list — i.e. issued by us, not yet
+    // revoked, and not yet rotated. Old tokens issued before this code
+    // existed don't carry a jti and would be rejected here, which is the
+    // intended behaviour after rolling out the change.
+    const jti = typeof payload.jti === "string" ? payload.jti : null;
+    if (!jti) {
+      throw new Error("Refresh token missing jti");
+    }
+    if (!(await this.refreshJtiStoreImpl.has(jti))) {
+      throw new Error("Refresh token has been revoked or already used");
+    }
+    // Rotation: invalidate the old jti before minting a new pair. Even if
+    // generateTokens fails after this, the worst case is the user has to
+    // re-authorize — not a stuck-but-valid token sitting around.
+    await this.refreshJtiStoreImpl.delete(jti);
 
     return this.generateTokens({
       clientId: client.client_id,
@@ -199,9 +238,22 @@ export class MetaAdsOAuthProvider implements OAuthServerProvider {
 
   async revokeToken(
     _client: OAuthClientInformationFull,
-    _request: OAuthTokenRevocationRequest,
+    request: OAuthTokenRevocationRequest,
   ): Promise<void> {
-    logger.debug("Token revocation requested (no-op for stateless JWTs)");
+    // RFC 7009: best-effort revoke. We can only revoke refresh tokens (the
+    // ones we track jtis for). Access tokens are 1h TTL and stateless.
+    const token = request.token;
+    if (!token) return;
+    try {
+      const { payload } = await jwtVerify(token, getJwtSecret());
+      if (payload.type === "refresh" && typeof payload.jti === "string") {
+        await this.refreshJtiStoreImpl.delete(payload.jti);
+        logger.info({ jti: payload.jti }, "Refresh token revoked");
+      }
+    } catch {
+      // Silently ignore — RFC 7009 §2.2: revocation responses must succeed
+      // even on unrecognised tokens.
+    }
   }
 
   private async generateTokens(input: {
@@ -225,17 +277,31 @@ export class MetaAdsOAuthProvider implements OAuthServerProvider {
       .setExpirationTime(now + 3600)
       .sign(secret);
 
+    // Refresh tokens carry a jti recorded in the refresh allow-list.
+    // Exchange-refresh deletes the jti before minting a new pair (rotation),
+    // and revokeToken can wipe it on demand.
+    const refreshJti = crypto.randomBytes(16).toString("hex");
+    const refreshExpiresAt = now + 30 * 24 * 3600;
     const refreshClaims: Record<string, unknown> = {
       sub: input.clientId,
       type: "refresh",
+      jti: refreshJti,
     };
     if (input.fbUserId) refreshClaims.fb_user_id = input.fbUserId;
 
     const refreshToken = await new SignJWT(refreshClaims)
       .setProtectedHeader({ alg: "HS256" })
       .setIssuedAt(now)
-      .setExpirationTime(now + 30 * 24 * 3600)
+      .setExpirationTime(refreshExpiresAt)
       .sign(secret);
+
+    await this.refreshJtiStoreImpl.put(refreshJti, {
+      expiresAt: refreshExpiresAt,
+      meta: {
+        clientId: input.clientId,
+        fbUserId: input.fbUserId ?? null,
+      },
+    });
 
     logger.info(
       { clientId: input.clientId, fbUserId: input.fbUserId ?? null },
@@ -258,6 +324,7 @@ export function resetOAuthProviderForTests(): void {
   oauthProvider.configure({
     clientsStore: new InMemoryClientsStore(),
     authCodesStore: new InMemoryAuthCodesStore(),
+    refreshJtiStore: new InMemoryJtiStore(),
     resolvePendingAuth: () => null,
   });
 }

--- a/src/auth/session.ts
+++ b/src/auth/session.ts
@@ -1,6 +1,10 @@
 import crypto from "node:crypto";
 import { SignJWT, jwtVerify } from "jose";
 import type { Request, Response } from "express";
+import {
+  InMemoryJtiStore,
+  type JtiStore,
+} from "../store/persistent-jti-store.js";
 
 const COOKIE_NAME = "mcp_session";
 const SESSION_TTL_SECONDS = 30 * 24 * 60 * 60;
@@ -32,22 +36,41 @@ function getSecret(): Uint8Array {
   return cachedSecret;
 }
 
+// Session JWTs are revocable: the cookie carries a jti that must be
+// present in the allow-list. clearSession() deletes the jti, so even if
+// the cookie was stolen earlier, it stops working as soon as the user
+// signs out. Defaults to in-memory; configureSessionJtiStore() swaps it
+// for the Firestore impl in production.
+let sessionJtiStore: JtiStore = new InMemoryJtiStore();
+
+export function configureSessionJtiStore(store: JtiStore): void {
+  sessionJtiStore = store;
+}
+
 export async function setSession(
   res: Response,
   payload: SessionPayload,
 ): Promise<void> {
   const secret = getSecret();
   const now = Math.floor(Date.now() / 1000);
+  const jti = crypto.randomBytes(16).toString("hex");
+  const expiresAt = now + SESSION_TTL_SECONDS;
 
   const jwt = await new SignJWT({
     fb: payload.fbUserId,
     em: payload.email,
     nm: payload.name,
+    jti,
   })
     .setProtectedHeader({ alg: "HS256" })
     .setIssuedAt(now)
-    .setExpirationTime(now + SESSION_TTL_SECONDS)
+    .setExpirationTime(expiresAt)
     .sign(secret);
+
+  await sessionJtiStore.put(jti, {
+    expiresAt,
+    meta: { fbUserId: payload.fbUserId },
+  });
 
   res.cookie(COOKIE_NAME, jwt, {
     httpOnly: true,
@@ -69,6 +92,8 @@ export async function getSession(
   try {
     const { payload } = await jwtVerify(cookie, getSecret());
     if (typeof payload.fb !== "string") return null;
+    if (typeof payload.jti !== "string") return null;
+    if (!(await sessionJtiStore.has(payload.jti))) return null;
     return {
       fbUserId: payload.fb,
       email: typeof payload.em === "string" ? payload.em : null,
@@ -79,7 +104,23 @@ export async function getSession(
   }
 }
 
-export function clearSession(res: Response): void {
+export async function clearSession(req: Request, res: Response): Promise<void> {
+  // Best-effort: parse the existing cookie to get its jti and remove it
+  // from the allow-list. Even if parsing fails (expired/malformed), we
+  // still drop the cookie on the client.
+  const reqCookies = (req as Request & { cookies?: Record<string, string> })
+    .cookies;
+  const cookie = reqCookies?.[COOKIE_NAME];
+  if (cookie) {
+    try {
+      const { payload } = await jwtVerify(cookie, getSecret());
+      if (typeof payload.jti === "string") {
+        await sessionJtiStore.delete(payload.jti);
+      }
+    } catch {
+      /* ignore */
+    }
+  }
   res.clearCookie(COOKIE_NAME, {
     httpOnly: true,
     secure: process.env.NODE_ENV === "production",
@@ -90,4 +131,5 @@ export function clearSession(res: Response): void {
 
 export function resetSecretCacheForTests(): void {
   cachedSecret = undefined;
+  sessionJtiStore = new InMemoryJtiStore();
 }

--- a/src/store/persistent-auth-codes.ts
+++ b/src/store/persistent-auth-codes.ts
@@ -14,6 +14,13 @@ export interface AuthCodeEntry {
 export interface AuthCodesStore {
   set(code: string, entry: AuthCodeEntry): Promise<void>;
   get(code: string): Promise<AuthCodeEntry | undefined>;
+  /**
+   * Atomically read and delete the entry. Returns the entry if it
+   * existed (and only one caller wins the race), undefined otherwise.
+   * Used by the OAuth code-exchange path to prevent code reuse under
+   * concurrent requests (RFC 6749 §10.5).
+   */
+  consume(code: string): Promise<AuthCodeEntry | undefined>;
   delete(code: string): Promise<void>;
 }
 
@@ -32,6 +39,16 @@ export class FirestoreAuthCodesStore implements AuthCodesStore {
     return snap.data() as AuthCodeEntry;
   }
 
+  async consume(code: string): Promise<AuthCodeEntry | undefined> {
+    const ref = this.collection.doc(code);
+    return getFirestore().runTransaction(async (tx) => {
+      const snap = await tx.get(ref);
+      if (!snap.exists) return undefined;
+      tx.delete(ref);
+      return snap.data() as AuthCodeEntry;
+    });
+  }
+
   async delete(code: string): Promise<void> {
     await this.collection.doc(code).delete();
   }
@@ -46,6 +63,15 @@ export class InMemoryAuthCodesStore implements AuthCodesStore {
 
   async get(code: string): Promise<AuthCodeEntry | undefined> {
     return this.codes.get(code);
+  }
+
+  async consume(code: string): Promise<AuthCodeEntry | undefined> {
+    // JS event loop is single-threaded so this is atomic by construction;
+    // no real race possible in the in-memory implementation.
+    const entry = this.codes.get(code);
+    if (entry === undefined) return undefined;
+    this.codes.delete(code);
+    return entry;
   }
 
   async delete(code: string): Promise<void> {

--- a/src/store/persistent-jti-store.ts
+++ b/src/store/persistent-jti-store.ts
@@ -1,0 +1,74 @@
+import { getFirestore } from "./firestore.js";
+
+/**
+ * Allow-list / revocation store for JWT IDs (jti). The model is "must
+ * be present in the store to be valid": when issuing a token we record
+ * its jti, and when verifying we check it. To revoke a token we simply
+ * delete the jti — the next verification will fail.
+ *
+ * Each entry carries an absolute expiresAt (unix seconds) so we can
+ * lazily skip expired records. A TTL index in Firestore (configured
+ * out of band) reaps them; the in-memory impl evicts on read.
+ */
+export interface JtiEntry {
+  expiresAt: number;
+  /** Optional metadata: e.g. fb_user_id, client_id, kind. Never the secret. */
+  meta?: Record<string, string | number | boolean | null>;
+}
+
+export interface JtiStore {
+  put(jti: string, entry: JtiEntry): Promise<void>;
+  /** Returns true if the jti exists and is not expired. */
+  has(jti: string): Promise<boolean>;
+  delete(jti: string): Promise<void>;
+}
+
+export class FirestoreJtiStore implements JtiStore {
+  constructor(private readonly collectionName: string) {}
+
+  private get collection() {
+    return getFirestore().collection(this.collectionName);
+  }
+
+  async put(jti: string, entry: JtiEntry): Promise<void> {
+    await this.collection.doc(jti).set(entry);
+  }
+
+  async has(jti: string): Promise<boolean> {
+    const snap = await this.collection.doc(jti).get();
+    if (!snap.exists) return false;
+    const data = snap.data() as JtiEntry;
+    if (data.expiresAt < Math.floor(Date.now() / 1000)) {
+      // Lazy clean-up of expired records on read.
+      await snap.ref.delete().catch(() => {});
+      return false;
+    }
+    return true;
+  }
+
+  async delete(jti: string): Promise<void> {
+    await this.collection.doc(jti).delete();
+  }
+}
+
+export class InMemoryJtiStore implements JtiStore {
+  private map = new Map<string, JtiEntry>();
+
+  async put(jti: string, entry: JtiEntry): Promise<void> {
+    this.map.set(jti, entry);
+  }
+
+  async has(jti: string): Promise<boolean> {
+    const entry = this.map.get(jti);
+    if (!entry) return false;
+    if (entry.expiresAt < Math.floor(Date.now() / 1000)) {
+      this.map.delete(jti);
+      return false;
+    }
+    return true;
+  }
+
+  async delete(jti: string): Promise<void> {
+    this.map.delete(jti);
+  }
+}

--- a/src/store/persistent-jti-store.ts
+++ b/src/store/persistent-jti-store.ts
@@ -20,6 +20,13 @@ export interface JtiStore {
   put(jti: string, entry: JtiEntry): Promise<void>;
   /** Returns true if the jti exists and is not expired. */
   has(jti: string): Promise<boolean>;
+  /**
+   * Atomically: returns true and removes the jti if it existed (and is
+   * not expired); returns false otherwise. Used by refresh-token rotation
+   * to avoid races where two concurrent exchanges both pass a non-atomic
+   * has() check before either delete() lands.
+   */
+  consume(jti: string): Promise<boolean>;
   delete(jti: string): Promise<void>;
 }
 
@@ -46,6 +53,21 @@ export class FirestoreJtiStore implements JtiStore {
     return true;
   }
 
+  async consume(jti: string): Promise<boolean> {
+    const ref = this.collection.doc(jti);
+    return getFirestore().runTransaction(async (tx) => {
+      const snap = await tx.get(ref);
+      if (!snap.exists) return false;
+      const data = snap.data() as JtiEntry;
+      if (data.expiresAt < Math.floor(Date.now() / 1000)) {
+        tx.delete(ref);
+        return false;
+      }
+      tx.delete(ref);
+      return true;
+    });
+  }
+
   async delete(jti: string): Promise<void> {
     await this.collection.doc(jti).delete();
   }
@@ -65,6 +87,15 @@ export class InMemoryJtiStore implements JtiStore {
       this.map.delete(jti);
       return false;
     }
+    return true;
+  }
+
+  async consume(jti: string): Promise<boolean> {
+    // JS event loop is single-threaded so this is atomic by construction.
+    const entry = this.map.get(jti);
+    if (!entry) return false;
+    this.map.delete(jti);
+    if (entry.expiresAt < Math.floor(Date.now() / 1000)) return false;
     return true;
   }
 

--- a/src/transport/auth-routes.ts
+++ b/src/transport/auth-routes.ts
@@ -160,8 +160,8 @@ export function mountAuthRoutes(
     }
   });
 
-  app.post("/auth/logout", (_req, res) => {
-    clearSession(res);
+  app.post("/auth/logout", async (req, res) => {
+    await clearSession(req, res);
     res.redirect(302, "/authorize");
   });
 

--- a/src/transport/http.ts
+++ b/src/transport/http.ts
@@ -10,7 +10,7 @@ import { oauthProvider } from "../auth/oauth-provider.js";
 import { isApiKeyConfigured, validateApiKey } from "../auth/api-key.js";
 import { requestContext } from "../auth/token-store.js";
 import { tokenManager } from "../auth/token-manager.js";
-import { getSession } from "../auth/session.js";
+import { configureSessionJtiStore, getSession } from "../auth/session.js";
 import { resolveSecurityConfig } from "./security-config.js";
 import { mountAuthRoutes } from "./auth-routes.js";
 import { validateAuthorizeQuery } from "./authorize-validation.js";
@@ -22,6 +22,10 @@ import {
   FirestoreAuthCodesStore,
   InMemoryAuthCodesStore,
 } from "../store/persistent-auth-codes.js";
+import {
+  FirestoreJtiStore,
+  InMemoryJtiStore,
+} from "../store/persistent-jti-store.js";
 import {
   configureMetaTokenRepo,
   FirestoreMetaTokenRepo,
@@ -440,15 +444,19 @@ export async function startHttpTransport(
       oauthProvider.configure({
         clientsStore: new InMemoryClientsStore(),
         authCodesStore: new InMemoryAuthCodesStore(),
+        refreshJtiStore: new InMemoryJtiStore(),
         resolvePendingAuth: () => pendingAuthStorage.getStore() ?? null,
       });
+      configureSessionJtiStore(new InMemoryJtiStore());
       configureMetaTokenRepo(new InMemoryMetaTokenRepo());
     } else {
       oauthProvider.configure({
         clientsStore: new FirestoreClientsStore(),
         authCodesStore: new FirestoreAuthCodesStore(),
+        refreshJtiStore: new FirestoreJtiStore("mcp_refresh_jti"),
         resolvePendingAuth: () => pendingAuthStorage.getStore() ?? null,
       });
+      configureSessionJtiStore(new FirestoreJtiStore("mcp_session_jti"));
       configureMetaTokenRepo(new FirestoreMetaTokenRepo());
     }
   }

--- a/tests/auth/oauth-provider.test.ts
+++ b/tests/auth/oauth-provider.test.ts
@@ -233,6 +233,43 @@ describe("MetaAdsOAuthProvider", () => {
     ).rejects.toThrow(/revoked|already used/i);
   });
 
+  it("CODE-A2: refresh-token rotation is atomic under concurrent exchange", async () => {
+    // Two concurrent exchanges of the same refresh token must produce
+    // exactly one fulfilled and one rejected. Without atomic consume,
+    // both would see has=true before either delete and both would mint
+    // new pairs (replay window).
+    const res = fakeRes();
+    await oauthProvider.authorize(
+      fakeClient,
+      {
+        codeChallenge: "ch",
+        codeChallengeMethod: "S256",
+        redirectUri: "https://example.com/cb",
+        scopes: [],
+      },
+      res,
+    );
+    const code = new URL(
+      (res.redirect as never as ReturnType<typeof vi.fn>).mock.calls[0][1],
+    ).searchParams.get("code")!;
+    const tokens = await oauthProvider.exchangeAuthorizationCode(
+      fakeClient,
+      code,
+    );
+
+    const settled = await Promise.allSettled([
+      oauthProvider.exchangeRefreshToken(fakeClient, tokens.refresh_token!),
+      oauthProvider.exchangeRefreshToken(fakeClient, tokens.refresh_token!),
+    ]);
+    const fulfilled = settled.filter((s) => s.status === "fulfilled");
+    const rejected = settled.filter((s) => s.status === "rejected");
+    expect(fulfilled).toHaveLength(1);
+    expect(rejected).toHaveLength(1);
+    expect((rejected[0] as PromiseRejectedResult).reason.message).toMatch(
+      /revoked|already used/i,
+    );
+  });
+
   it("CODE-A2: revokeToken invalidates the refresh token (RFC 7009)", async () => {
     const res = fakeRes();
     await oauthProvider.authorize(

--- a/tests/auth/oauth-provider.test.ts
+++ b/tests/auth/oauth-provider.test.ts
@@ -105,6 +105,163 @@ describe("MetaAdsOAuthProvider", () => {
     ).rejects.toThrow(/different client/);
   });
 
+  it("CODE-A1: code consume() is single-use under concurrent exchange (race fix)", async () => {
+    const res = fakeRes();
+    await oauthProvider.authorize(
+      fakeClient,
+      {
+        codeChallenge: "ch",
+        codeChallengeMethod: "S256",
+        redirectUri: "https://example.com/cb",
+        scopes: [],
+      },
+      res,
+    );
+    const code = new URL(
+      (res.redirect as never as ReturnType<typeof vi.fn>).mock.calls[0][1],
+    ).searchParams.get("code")!;
+
+    // Two concurrent exchanges race. With the atomic consume(), exactly
+    // one wins.
+    const settled = await Promise.allSettled([
+      oauthProvider.exchangeAuthorizationCode(fakeClient, code),
+      oauthProvider.exchangeAuthorizationCode(fakeClient, code),
+    ]);
+    const fulfilled = settled.filter((s) => s.status === "fulfilled");
+    const rejected = settled.filter((s) => s.status === "rejected");
+    expect(fulfilled).toHaveLength(1);
+    expect(rejected).toHaveLength(1);
+    expect((rejected[0] as PromiseRejectedResult).reason.message).toMatch(
+      /Invalid authorization code/,
+    );
+  });
+
+  it("CODE-C3: rejects mismatched PKCE verifier when supplied", async () => {
+    const verifier = "a".repeat(64);
+    const challenge = (await import("node:crypto"))
+      .createHash("sha256")
+      .update(verifier)
+      .digest("base64url");
+
+    const res = fakeRes();
+    await oauthProvider.authorize(
+      fakeClient,
+      {
+        codeChallenge: challenge,
+        codeChallengeMethod: "S256",
+        redirectUri: "https://example.com/cb",
+        scopes: [],
+      },
+      res,
+    );
+    const code = new URL(
+      (res.redirect as never as ReturnType<typeof vi.fn>).mock.calls[0][1],
+    ).searchParams.get("code")!;
+
+    await expect(
+      oauthProvider.exchangeAuthorizationCode(
+        fakeClient,
+        code,
+        "wrong-verifier",
+      ),
+    ).rejects.toThrow(/PKCE verification failed/);
+  });
+
+  it("CODE-C3: accepts a matching PKCE verifier", async () => {
+    const verifier = "b".repeat(64);
+    const challenge = (await import("node:crypto"))
+      .createHash("sha256")
+      .update(verifier)
+      .digest("base64url");
+
+    const res = fakeRes();
+    await oauthProvider.authorize(
+      fakeClient,
+      {
+        codeChallenge: challenge,
+        codeChallengeMethod: "S256",
+        redirectUri: "https://example.com/cb",
+        scopes: [],
+      },
+      res,
+    );
+    const code = new URL(
+      (res.redirect as never as ReturnType<typeof vi.fn>).mock.calls[0][1],
+    ).searchParams.get("code")!;
+
+    const tokens = await oauthProvider.exchangeAuthorizationCode(
+      fakeClient,
+      code,
+      verifier,
+    );
+    expect(tokens.access_token).toBeTruthy();
+  });
+
+  it("CODE-A2: refresh token can only be used once (rotation)", async () => {
+    oauthProvider.configure({
+      resolvePendingAuth: () => ({ fbUserId: "fb-rotate" }),
+    });
+    const res = fakeRes();
+    await oauthProvider.authorize(
+      fakeClient,
+      {
+        codeChallenge: "ch",
+        codeChallengeMethod: "S256",
+        redirectUri: "https://example.com/cb",
+        scopes: [],
+      },
+      res,
+    );
+    const code = new URL(
+      (res.redirect as never as ReturnType<typeof vi.fn>).mock.calls[0][1],
+    ).searchParams.get("code")!;
+    const tokens = await oauthProvider.exchangeAuthorizationCode(
+      fakeClient,
+      code,
+    );
+
+    // First refresh succeeds and rotates the jti.
+    const refreshed = await oauthProvider.exchangeRefreshToken(
+      fakeClient,
+      tokens.refresh_token!,
+    );
+    expect(refreshed.access_token).toBeTruthy();
+
+    // Same refresh token again must fail (jti deleted on rotation).
+    await expect(
+      oauthProvider.exchangeRefreshToken(fakeClient, tokens.refresh_token!),
+    ).rejects.toThrow(/revoked|already used/i);
+  });
+
+  it("CODE-A2: revokeToken invalidates the refresh token (RFC 7009)", async () => {
+    const res = fakeRes();
+    await oauthProvider.authorize(
+      fakeClient,
+      {
+        codeChallenge: "ch",
+        codeChallengeMethod: "S256",
+        redirectUri: "https://example.com/cb",
+        scopes: [],
+      },
+      res,
+    );
+    const code = new URL(
+      (res.redirect as never as ReturnType<typeof vi.fn>).mock.calls[0][1],
+    ).searchParams.get("code")!;
+    const tokens = await oauthProvider.exchangeAuthorizationCode(
+      fakeClient,
+      code,
+    );
+
+    await oauthProvider.revokeToken(fakeClient, {
+      token: tokens.refresh_token!,
+    });
+
+    await expect(
+      oauthProvider.exchangeRefreshToken(fakeClient, tokens.refresh_token!),
+    ).rejects.toThrow(/revoked|already used/i);
+  });
+
   it("preserves fb_user_id across refresh-token exchange (token name is never in the JWT)", async () => {
     oauthProvider.configure({
       resolvePendingAuth: () => ({ fbUserId: "fb-9999" }),

--- a/tests/auth/session.test.ts
+++ b/tests/auth/session.test.ts
@@ -103,10 +103,57 @@ describe("session", () => {
     expect(got).toBeNull();
   });
 
-  it("clearSession clears the cookie", () => {
+  it("clearSession clears the cookie", async () => {
     const res = makeRes();
-    clearSession(res as never);
+    await clearSession({ cookies: {} } as never, res as never);
     expect(res.clearCalls).toHaveLength(1);
     expect(res.clearCalls[0].name).toBe("mcp_session");
+  });
+
+  it("clearSession invalidates the jti so the cookie no longer authenticates (CODE-M5)", async () => {
+    // Set a session
+    const res1 = makeRes();
+    await setSession(res1 as never, {
+      fbUserId: "fb-9",
+      email: null,
+      name: null,
+    });
+    const cookie = res1.cookieCalls[0].value;
+
+    // Cookie validates initially
+    expect(
+      await getSession({ cookies: { mcp_session: cookie } } as never),
+    ).toMatchObject({ fbUserId: "fb-9" });
+
+    // Logout
+    const res2 = makeRes();
+    await clearSession(
+      { cookies: { mcp_session: cookie } } as never,
+      res2 as never,
+    );
+
+    // Same cookie no longer authenticates — even if it was stolen earlier.
+    expect(
+      await getSession({ cookies: { mcp_session: cookie } } as never),
+    ).toBeNull();
+  });
+
+  it("rejects sessions whose jti is unknown (e.g. server restart with in-memory store)", async () => {
+    const res = makeRes();
+    await setSession(res as never, {
+      fbUserId: "fb-1",
+      email: null,
+      name: null,
+    });
+    const cookie = res.cookieCalls[0].value;
+
+    // Reset the in-memory jti store
+    resetSecretCacheForTests();
+    process.env.SESSION_COOKIE_SECRET = SECRET;
+
+    // The cookie is valid signature-wise but jti is gone.
+    expect(
+      await getSession({ cookies: { mcp_session: cookie } } as never),
+    ).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

Bundles four audit findings on the OAuth flow. All in `src/auth/` + `src/store/`. No infra changes.

### CODE-A1 — race in `exchangeAuthorizationCode` (RFC 6749 §10.5)
`authCodesStore.get()` + `.delete()` were two non-atomic Firestore calls. Two concurrent `/token` exchanges could both read the entry before either `delete` landed, letting a stolen code be replayed.

**Fix**: new `consume(code)` method that reads-and-deletes inside a Firestore `runTransaction` (and is trivially atomic on the in-memory variant). `exchangeAuthorizationCode` uses it and validates `clientId`/`expiresAt` only after removal — the loser of the race sees `Invalid authorization code`.

### CODE-C3 — PKCE not enforced locally
`exchangeAuthorizationCode` used to ignore `_codeVerifier`. mcp-sdk's `challengeForAuthorizationCode` is the primary verifier, but the local method was a soft spot if the SDK wiring ever changed.

**Fix**: when both `entry.codeChallenge` and `codeVerifier` are present, recompute `S256(codeVerifier)` and compare. Mismatch throws `PKCE verification failed`.

### CODE-A2 — refresh tokens stateless, no revocation
`revokeToken` was a no-op. Any leaked refresh token was valid for 30d or until `OAUTH_SECRET` rotated.

**Fix**: new `src/store/persistent-jti-store.ts` (Firestore `mcp_refresh_jti` + in-memory) is an allow-list keyed by `jti`, with TTL. `generateTokens` emits a fresh jti on every refresh and writes it to the store. `exchangeRefreshToken` requires the jti to be present and deletes it on success (rotation). `revokeToken` deletes the jti per RFC 7009 §2.2. Old refresh tokens issued before this change carry no jti and are rejected on next use — forces a re-auth.

### CODE-M5 — `clearSession` didn't invalidate the JWT
Cookie was deleted client-side but the signed JWT remained valid for 30d if previously stolen.

**Fix**: same pattern. `setSession` emits a jti, records it in a session-jti store (`mcp_session_jti`), and `getSession` requires presence. `clearSession` now reads the incoming cookie, deletes its jti, then drops the cookie. Sessions stop authenticating as soon as the user signs out. **API change**: `clearSession(req, res)` instead of `clearSession(res)`. Only caller (`POST /auth/logout`) updated.

## Operational note

Two new Firestore collections — `mcp_refresh_jti`, `mcp_session_jti`. The store reaps expired records lazily on read. For active environments, consider adding a TTL index out-of-band so old records clean up automatically:

```
gcloud firestore fields ttls update expiresAt --collection-group=mcp_refresh_jti --enable-ttl
gcloud firestore fields ttls update expiresAt --collection-group=mcp_session_jti --enable-ttl
```

Not required — just a nice-to-have. The runtime SA already has `roles/datastore.user` so writes work.

## Test plan

- [x] `npm run lint`, `npm run typecheck`, `npm test` (278 tests, +7), `npm run build` all green.
- [x] `gitleaks git --staged` clean.
- [x] New tests cover: race exchange (1 fulfilled / 1 rejected), PKCE accept + reject, refresh single-use rotation, `revokeToken` invalidation, session-jti revocation, server-restart wiping in-memory store.
- [x] Post-deploy: a Claude.ai re-login still works (JWT issued post-deploy carry the new jti); `meta_ads_list_tokens` shows the 3 tokens; logout invalidates the cookie immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)