### PR TITLE
fix(security): tighten input validation, returnTo, allowlist, error messages

### DIFF
--- a/src/auth/email-allowlist.ts
+++ b/src/auth/email-allowlist.ts
@@ -17,6 +17,14 @@ export function isAllowed(input: AllowlistInput): boolean {
   const fbIds = parseList(process.env.AUTH_ALLOWED_FB_USER_IDS);
 
   if (emails.length === 0 && domains.length === 0 && fbIds.length === 0) {
+    // Fail-closed when multi-tenant Meta OAuth is configured (CODE-M6).
+    // The deploy gate enforces this in production, but staging or local
+    // environments with META_APP_ID/SECRET set must not silently accept
+    // every login: an empty allowlist means "no one".
+    const multiTenantOn =
+      !!process.env.META_APP_ID?.trim() &&
+      !!process.env.META_APP_SECRET?.trim();
+    if (multiTenantOn) return false;
     return process.env.NODE_ENV !== "production";
   }
 

--- a/src/transport/auth-routes.ts
+++ b/src/transport/auth-routes.ts
@@ -21,10 +21,42 @@ import {
 } from "../store/meta-token-repo.js";
 import { logger } from "../utils/logger.js";
 
-function safeReturnTo(input: unknown): string {
+/**
+ * Sanitize a returnTo URL provided by callers (?return=… on /auth/meta).
+ *
+ * Defenses (CODE-M3):
+ *   - must start with a single "/" (no scheme, no protocol-relative "//")
+ *   - max length 2048 (avoid header smuggling and absurdly large redirects)
+ *   - control characters (CR, LF, NUL, etc.) rejected — prevents response
+ *     splitting / header injection if this ever ends up in a Location header
+ *     unencoded by a downstream proxy
+ *   - if it points at /authorize, the query must carry both client_id and
+ *     redirect_uri (otherwise it's the same dead-end the validation gate
+ *     guards against, just reached via a redirect chain)
+ *
+ * On any failure, fall back to "/authorize" — the landing page handles
+ * unauthenticated users.
+ */
+export function safeReturnTo(input: unknown): string {
   if (typeof input !== "string") return "/authorize";
+  if (input.length === 0 || input.length > 2048) return "/authorize";
   if (!input.startsWith("/")) return "/authorize";
   if (input.startsWith("//")) return "/authorize";
+  // Reject control characters (0x00–0x1f and DEL).
+  if (/[\x00-\x1f\x7f]/.test(input)) return "/authorize";
+
+  // If returnTo points at /authorize, make sure it has the OAuth params
+  // the GET handler now requires. A path like "/authorize" alone is
+  // valid and renders the landing page; anything matching "/authorize?…"
+  // must carry both client_id and redirect_uri.
+  if (input === "/authorize" || input.startsWith("/authorize?")) {
+    const qIdx = input.indexOf("?");
+    if (qIdx === -1) return input; // bare /authorize → landing page is fine
+    const params = new URLSearchParams(input.slice(qIdx + 1));
+    if (!params.get("client_id") || !params.get("redirect_uri")) {
+      return "/authorize";
+    }
+  }
   return input;
 }
 
@@ -90,7 +122,22 @@ export function mountAuthRoutes(
     const error = typeof req.query.error === "string" ? req.query.error : null;
 
     if (error) {
-      renderError(res, 400, `Meta returned an error: ${error}`);
+      // Don't reflect Meta's error code/message back to the user — log it
+      // server-side and show a generic message (CODE-M1).
+      logger.warn(
+        {
+          metaError: error,
+          metaErrorCode: req.query.error_code,
+          metaErrorReason: req.query.error_reason,
+          metaErrorDescription: req.query.error_description,
+        },
+        "Meta OAuth callback returned an error",
+      );
+      renderError(
+        res,
+        400,
+        "Login was cancelled or rejected by Meta. Please try again.",
+      );
       return;
     }
     if (!code || !state) {
@@ -216,10 +263,21 @@ export function mountAuthRoutes(
 
       const validation = await validateToken(token);
       if (!validation.valid || !validation.profile) {
+        // Don't echo Meta's validation error verbatim — it can carry
+        // trace IDs and Graph API messages we don't want surfaced to
+        // the operator's UI (CODE-M1).
+        logger.warn(
+          {
+            fbUserId: session.fbUserId,
+            tokenName: name,
+            error: validation.error ?? null,
+          },
+          "System User token validation failed",
+        );
         renderError(
           res,
           400,
-          `Token validation failed: ${validation.error ?? "unknown error"}`,
+          "Token validation failed. The token may be expired, revoked, or for a different Meta app. Check the server logs for details.",
         );
         return;
       }

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -1,8 +1,36 @@
 /**
  * Normalize a Meta ad account ID to always include the 'act_' prefix.
+ *
+ * Validates that the id is purely numeric (optionally with the act_ prefix)
+ * before normalizing. Rejects anything containing path-traversal characters,
+ * URL components, or whitespace so it can't be smuggled into the path of a
+ * subsequent fetch to Meta. CODE-A5 audit finding.
  */
 export function normalizeAccountId(id: string): string {
+  if (typeof id !== "string" || !/^(act_)?\d{1,30}$/.test(id)) {
+    throw new Error(
+      `Invalid Meta account_id: must be numeric, optionally prefixed with "act_". Got: ${JSON.stringify(id).slice(0, 80)}`,
+    );
+  }
   return id.startsWith("act_") ? id : `act_${id}`;
+}
+
+/**
+ * Validate a Meta resource ID (campaign, adset, ad, creative, page, business…).
+ * Meta IDs are always purely numeric strings of variable length.
+ *
+ * Use at the boundary of any tool that takes an id from a caller and
+ * forwards it into a Meta API path or a rate-limiter bucket key. Throws
+ * with a clear error so the agent can report a meaningful failure rather
+ * than letting a malformed id leak into a path segment or bucket name.
+ */
+export function validateMetaId(id: string, kind = "id"): string {
+  if (typeof id !== "string" || !/^\d{1,30}$/.test(id)) {
+    throw new Error(
+      `Invalid Meta ${kind}: must be a numeric string. Got: ${JSON.stringify(id).slice(0, 80)}`,
+    );
+  }
+  return id;
 }
 
 /**

--- a/tests/auth/email-allowlist.test.ts
+++ b/tests/auth/email-allowlist.test.ts
@@ -9,6 +9,8 @@ const KEYS = [
   "AUTH_ALLOWED_DOMAINS",
   "AUTH_ALLOWED_FB_USER_IDS",
   "NODE_ENV",
+  "META_APP_ID",
+  "META_APP_SECRET",
 ] as const;
 
 const original: Record<(typeof KEYS)[number], string | undefined> =
@@ -61,5 +63,16 @@ describe("email-allowlist", () => {
     expect(isAllowlistConfigured()).toBe(false);
     process.env.AUTH_ALLOWED_EMAILS = "x@y.com";
     expect(isAllowlistConfigured()).toBe(true);
+  });
+
+  it("CODE-M6: fails closed even outside production when multi-tenant OAuth is configured", () => {
+    process.env.NODE_ENV = "development";
+    process.env.META_APP_ID = "1234567890";
+    process.env.META_APP_SECRET = "a".repeat(32);
+    // No allowlist sources configured — must reject anyway because
+    // multi-tenant is on. Without this fix, dev/staging would silently
+    // accept any Meta login.
+    expect(isAllowed({ email: "anyone@anywhere.com" })).toBe(false);
+    expect(isAllowed({ fbUserId: "9999" })).toBe(false);
   });
 });

--- a/tests/transport/safe-return-to.test.ts
+++ b/tests/transport/safe-return-to.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import { safeReturnTo } from "../../src/transport/auth-routes.js";
+
+describe("safeReturnTo (CODE-M3)", () => {
+  it("accepts an internal path", () => {
+    expect(safeReturnTo("/foo/bar")).toBe("/foo/bar");
+  });
+
+  it("accepts /authorize on its own", () => {
+    expect(safeReturnTo("/authorize")).toBe("/authorize");
+  });
+
+  it("accepts /authorize with both client_id and redirect_uri", () => {
+    const url =
+      "/authorize?response_type=code&client_id=abc&redirect_uri=https%3A%2F%2Fclaude.ai%2Fcb&state=x";
+    expect(safeReturnTo(url)).toBe(url);
+  });
+
+  it("rejects non-strings", () => {
+    expect(safeReturnTo(undefined)).toBe("/authorize");
+    expect(safeReturnTo(null)).toBe("/authorize");
+    expect(safeReturnTo({ foo: "bar" })).toBe("/authorize");
+  });
+
+  it("rejects external URLs", () => {
+    expect(safeReturnTo("https://evil.example/")).toBe("/authorize");
+    expect(safeReturnTo("http://localhost:3000/")).toBe("/authorize");
+  });
+
+  it("rejects protocol-relative URLs", () => {
+    expect(safeReturnTo("//evil.example/")).toBe("/authorize");
+  });
+
+  it("rejects /authorize with one of the OAuth params missing", () => {
+    expect(safeReturnTo("/authorize?client_id=abc")).toBe("/authorize");
+    expect(safeReturnTo("/authorize?redirect_uri=https://x")).toBe(
+      "/authorize",
+    );
+  });
+
+  it("rejects control characters (header injection defense)", () => {
+    expect(safeReturnTo("/foo\nLocation: https://evil.example")).toBe(
+      "/authorize",
+    );
+    expect(safeReturnTo("/foo\rbar")).toBe("/authorize");
+    expect(safeReturnTo("/foo\x00bar")).toBe("/authorize");
+  });
+
+  it("rejects empty strings", () => {
+    expect(safeReturnTo("")).toBe("/authorize");
+  });
+
+  it("rejects oversize values", () => {
+    expect(safeReturnTo("/" + "a".repeat(3000))).toBe("/authorize");
+  });
+});

--- a/tests/utils/format.test.ts
+++ b/tests/utils/format.test.ts
@@ -3,6 +3,7 @@ import {
   normalizeAccountId,
   formatBudget,
   truncateResponse,
+  validateMetaId,
 } from "../../src/utils/format.js";
 
 describe("normalizeAccountId", () => {
@@ -14,12 +15,53 @@ describe("normalizeAccountId", () => {
     expect(normalizeAccountId("act_123456")).toBe("act_123456");
   });
 
-  it("handles empty string", () => {
-    expect(normalizeAccountId("")).toBe("act_");
+  it("rejects empty string", () => {
+    expect(() => normalizeAccountId("")).toThrow(/Invalid Meta account_id/);
   });
 
-  it("does not double-prefix", () => {
-    expect(normalizeAccountId("act_act_123")).toBe("act_act_123");
+  it("rejects double prefix", () => {
+    expect(() => normalizeAccountId("act_act_123")).toThrow(
+      /Invalid Meta account_id/,
+    );
+  });
+
+  it("rejects path traversal attempts (CODE-A5)", () => {
+    expect(() => normalizeAccountId("../foo")).toThrow();
+    expect(() => normalizeAccountId("123/insights")).toThrow();
+    expect(() => normalizeAccountId("act_123?fields=id")).toThrow();
+    expect(() => normalizeAccountId("act_ 123")).toThrow();
+    expect(() => normalizeAccountId("act_123\n")).toThrow();
+  });
+
+  it("rejects non-string", () => {
+    // @ts-expect-error testing runtime guard
+    expect(() => normalizeAccountId(undefined)).toThrow();
+    // @ts-expect-error testing runtime guard
+    expect(() => normalizeAccountId(123)).toThrow();
+  });
+});
+
+describe("validateMetaId", () => {
+  it("accepts a numeric id", () => {
+    expect(validateMetaId("23843234567")).toBe("23843234567");
+    expect(validateMetaId("1", "campaign_id")).toBe("1");
+  });
+
+  it("rejects act_ prefixed ids (use normalizeAccountId for those)", () => {
+    expect(() => validateMetaId("act_123")).toThrow(/Invalid Meta id/);
+  });
+
+  it("rejects junk", () => {
+    expect(() => validateMetaId("../foo")).toThrow();
+    expect(() => validateMetaId("123/x")).toThrow();
+    expect(() => validateMetaId("")).toThrow();
+    expect(() => validateMetaId("123 456")).toThrow();
+  });
+
+  it("propagates the kind label in the error", () => {
+    expect(() => validateMetaId("bad", "campaign_id")).toThrow(
+      /Invalid Meta campaign_id/,
+    );
   });
 });
 


### PR DESCRIPTION
## Summary

Four medium-severity audit findings, all at the validation / auth boundary. No infra changes.

| ID | Title | File |
|---|---|---|
| CODE-A5 | Validate Meta IDs (no path-traversal in path segments / rate-limit bucket keys) | [src/utils/format.ts](src/utils/format.ts) |
| CODE-M1 | Don't reflect Meta's error text back to the user | [src/transport/auth-routes.ts](src/transport/auth-routes.ts) |
| CODE-M3 | Tighten safeReturnTo (max length, control chars, /authorize coherence) | [src/transport/auth-routes.ts](src/transport/auth-routes.ts) |
| CODE-M6 | isAllowed fail-closed when multi-tenant Meta OAuth is configured | [src/auth/email-allowlist.ts](src/auth/email-allowlist.ts) |

## CODE-A5 — Meta ID validation

`normalizeAccountId` previously accepted anything (it just prepended `act_`). Path-traversal characters, query strings, and whitespace flowed straight into Meta API URL paths. Tighten to require `^(act_)?\d{1,30}$` and throw on anything else. Add `validateMetaId(id, kind)` for non-account ids that callers can wire in opportunistically — for now it's just defined and tested; broader rollout to every individual tool is a follow-up.

## CODE-M1 — Generic error messages, structured server-side logs

Two paths echoed Meta's response verbatim:

```
"Meta returned an error: ${error}"
"Token validation failed: ${validation.error ?? 'unknown error'}"
```

Replaced with generic UI messages plus a `logger.warn({ metaError, metaErrorCode, ... })` capturing the full payload server-side. The operator still has full diagnostic info; the user-facing UI doesn't surface trace ids.

## CODE-M3 — safeReturnTo defenses

Was only blocking protocol-relative `//` + missing leading `/`. Added:
- max length 2048 (avoid absurd redirects + header smuggling)
- reject control characters (`\x00-\x1f` and DEL — defends against header injection if a downstream proxy ever forwards this value unencoded into a Location header)
- if the value targets `/authorize`, require both `client_id` and `redirect_uri` in the query — otherwise it lands users on the dead-end the PR #43 validation gate guards against, just reached via a redirect chain

Made the function exported so it has a real test file.

## CODE-M6 — Fail-closed allowlist when multi-tenant OAuth is on

`isAllowed()` returned `true` outside production when no allowlist sources were configured. The deploy gate already enforces the allowlist for prod, but staging or self-hosted setups with `META_APP_ID/SECRET` set would silently accept every Meta login. Now: if multi-tenant is on, an empty allowlist always rejects regardless of `NODE_ENV`.

## Test plan

- [x] `npm run lint`, `npm run typecheck`, `npm test` (296 tests, +17), `npm run build` all green.
- [x] `gitleaks git --staged` clean.
- New tests cover the tightened normalizeAccountId behaviour, validateMetaId, every safeReturnTo branch, and the new fail-closed path in isAllowed.
- [ ] Post-deploy: Claude.ai re-login still works; logout still redirects to `/authorize` landing; an existing token re-registration with a bogus token still succeeds via the new generic error path; an account_id with bad characters in any tool now throws a clean error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)