### PR TITLE
fix(security): preview HTML, cookie __Host- prefix, JWT audience separation

### DIFF
--- a/src/auth/oauth-provider.ts
+++ b/src/auth/oauth-provider.ts
@@ -23,6 +23,14 @@ import {
   type JtiStore,
 } from "../store/persistent-jti-store.js";
 
+// Audience separation (CODE-M7): every JWT we mint is tagged with its
+// purpose. Verifiers pin the audience so an attacker can't smuggle a
+// session JWT into the access-token slot or vice versa, even if a single
+// secret rotates and starts being shared. Combined with `type` claim
+// checks already in place, this is belt-and-braces.
+const ACCESS_AUDIENCE = "mcp-oauth-access";
+const REFRESH_AUDIENCE = "mcp-oauth-refresh";
+
 let cachedSecret: Uint8Array | undefined;
 
 function getJwtSecret(): Uint8Array {
@@ -173,7 +181,10 @@ export class MetaAdsOAuthProvider implements OAuthServerProvider {
   ): Promise<OAuthTokens> {
     const secret = getJwtSecret();
 
-    const { payload } = await jwtVerify(refreshToken, secret).catch(() => {
+    const { payload } = await jwtVerify(refreshToken, secret, {
+      algorithms: ["HS256"],
+      audience: REFRESH_AUDIENCE,
+    }).catch(() => {
       throw new Error("Invalid refresh token");
     });
 
@@ -212,7 +223,10 @@ export class MetaAdsOAuthProvider implements OAuthServerProvider {
   async verifyAccessToken(token: string): Promise<AuthInfo> {
     const secret = getJwtSecret();
 
-    const { payload } = await jwtVerify(token, secret).catch(() => {
+    const { payload } = await jwtVerify(token, secret, {
+      algorithms: ["HS256"],
+      audience: ACCESS_AUDIENCE,
+    }).catch(() => {
       throw new Error("Invalid access token");
     });
 
@@ -247,14 +261,18 @@ export class MetaAdsOAuthProvider implements OAuthServerProvider {
     const token = request.token;
     if (!token) return;
     try {
-      const { payload } = await jwtVerify(token, getJwtSecret());
+      const { payload } = await jwtVerify(token, getJwtSecret(), {
+        algorithms: ["HS256"],
+        audience: REFRESH_AUDIENCE,
+      });
       if (payload.type === "refresh" && typeof payload.jti === "string") {
         await this.refreshJtiStoreImpl.delete(payload.jti);
         logger.info({ jti: payload.jti }, "Refresh token revoked");
       }
     } catch {
       // Silently ignore — RFC 7009 §2.2: revocation responses must succeed
-      // even on unrecognised tokens.
+      // even on unrecognised tokens. Tokens that aren't a refresh JWT fall
+      // through here and we treat them as already revoked / unknown.
     }
   }
 
@@ -277,6 +295,7 @@ export class MetaAdsOAuthProvider implements OAuthServerProvider {
       .setProtectedHeader({ alg: "HS256" })
       .setIssuedAt(now)
       .setExpirationTime(now + 3600)
+      .setAudience(ACCESS_AUDIENCE)
       .sign(secret);
 
     // Refresh tokens carry a jti recorded in the refresh allow-list.
@@ -295,6 +314,7 @@ export class MetaAdsOAuthProvider implements OAuthServerProvider {
       .setProtectedHeader({ alg: "HS256" })
       .setIssuedAt(now)
       .setExpirationTime(refreshExpiresAt)
+      .setAudience(REFRESH_AUDIENCE)
       .sign(secret);
 
     await this.refreshJtiStoreImpl.put(refreshJti, {

--- a/src/auth/oauth-state.ts
+++ b/src/auth/oauth-state.ts
@@ -52,6 +52,7 @@ export async function verifyOAuthState(
 ): Promise<OAuthStatePayload | null> {
   try {
     const { payload } = await jwtVerify(token, getSecret(), {
+      algorithms: ["HS256"],
       audience: STATE_AUDIENCE,
     });
     if (typeof payload.rt !== "string") return null;

--- a/src/auth/session.ts
+++ b/src/auth/session.ts
@@ -6,8 +6,15 @@ import {
   type JtiStore,
 } from "../store/persistent-jti-store.js";
 
-const COOKIE_NAME = "mcp_session";
+// Use the __Host- prefix in production: requires Secure, requires path=/,
+// forbids the Domain attribute. Together they prevent a sibling subdomain
+// from setting or overwriting our cookie. The cookie name *is* part of the
+// prefix contract; switching it on/off based on production silently lets
+// dev work over plain http while prod gets the strongest guarantee.
+const COOKIE_NAME =
+  process.env.NODE_ENV === "production" ? "__Host-mcp_session" : "mcp_session";
 const SESSION_TTL_SECONDS = 30 * 24 * 60 * 60;
+const SESSION_AUDIENCE = "mcp-session";
 
 export interface SessionPayload {
   fbUserId: string;
@@ -65,6 +72,7 @@ export async function setSession(
     .setProtectedHeader({ alg: "HS256" })
     .setIssuedAt(now)
     .setExpirationTime(expiresAt)
+    .setAudience(SESSION_AUDIENCE)
     .sign(secret);
 
   await sessionJtiStore.put(jti, {
@@ -75,6 +83,12 @@ export async function setSession(
   res.cookie(COOKIE_NAME, jwt, {
     httpOnly: true,
     secure: process.env.NODE_ENV === "production",
+    // Lax is required because the OAuth callback from Meta is a top-level
+    // navigation from a different origin; Strict would drop the cookie on
+    // that hop and the user would land back at /authorize without a
+    // session. Lax is enough — JWTs are not cookie-only-protected (the
+    // jti allow-list still gates them) and CSRF is mitigated by SameSite
+    // for non-GET state-changing routes.
     sameSite: "lax",
     maxAge: SESSION_TTL_SECONDS * 1000,
     path: "/",
@@ -90,7 +104,14 @@ export async function getSession(
   if (!cookie) return null;
 
   try {
-    const { payload } = await jwtVerify(cookie, getSecret());
+    // Pin the algorithm and the audience so the verifier can't be fooled
+    // into accepting a token signed with a different alg (alg confusion)
+    // or a token issued for a different purpose with the same secret
+    // (e.g. an oauth-state JWT — token confusion / CODE-M7).
+    const { payload } = await jwtVerify(cookie, getSecret(), {
+      algorithms: ["HS256"],
+      audience: SESSION_AUDIENCE,
+    });
     if (typeof payload.fb !== "string") return null;
     if (typeof payload.jti !== "string") return null;
     if (!(await sessionJtiStore.has(payload.jti))) return null;
@@ -113,7 +134,10 @@ export async function clearSession(req: Request, res: Response): Promise<void> {
   const cookie = reqCookies?.[COOKIE_NAME];
   if (cookie) {
     try {
-      const { payload } = await jwtVerify(cookie, getSecret());
+      const { payload } = await jwtVerify(cookie, getSecret(), {
+        algorithms: ["HS256"],
+        audience: SESSION_AUDIENCE,
+      });
       if (typeof payload.jti === "string") {
         await sessionJtiStore.delete(payload.jti);
       }

--- a/src/tools/previews.ts
+++ b/src/tools/previews.ts
@@ -68,7 +68,11 @@ export function registerPreviewTools(server: McpServer): void {
         };
       }
 
-      // Extract iframe src URL from the HTML body if possible
+      // Extract iframe src URL from the HTML body. We deliberately do NOT
+      // forward the raw Meta HTML to the agent (CODE-A4 audit finding) —
+      // a browser-based MCP client that renders text content as HTML
+      // would execute scripts inside the iframe. The shareable URL is
+      // sufficient for every documented use case.
       const html = previews[0].body;
       const iframeSrcMatch = html.match(/src="([^"]+)"/);
       const previewUrl = iframeSrcMatch ? iframeSrcMatch[1].replace(/&amp;/g, "&") : null;
@@ -78,14 +82,13 @@ export function registerPreviewTools(server: McpServer): void {
       ];
       if (previewUrl) {
         lines.push(`\nPreview URL: ${previewUrl}`);
+        lines.push(`\nShareable — copy the URL above to share with clients without Business Manager access.`);
+      } else {
+        lines.push(`\nMeta returned a preview but no shareable URL could be extracted from it.`);
       }
-      lines.push(`\nShareable — copy the URL above to share with clients without Business Manager access.`);
 
       return {
-        content: [
-          { type: "text", text: lines.join("\n") },
-          { type: "text", text: `Raw HTML:\n${html}` },
-        ],
+        content: [{ type: "text", text: lines.join("\n") }],
       };
     },
   );
@@ -166,9 +169,8 @@ export function registerPreviewTools(server: McpServer): void {
             type: "text",
             text: previewUrl
               ? `Preview generated (${ad_format}):\n\nPreview URL: ${previewUrl}`
-              : `Preview generated (${ad_format}).`,
+              : `Preview generated (${ad_format}). Meta did not return a shareable URL.`,
           },
-          { type: "text", text: `Raw HTML:\n${html}` },
         ],
       };
     },

--- a/tests/auth/oauth-provider.test.ts
+++ b/tests/auth/oauth-provider.test.ts
@@ -299,6 +299,58 @@ describe("MetaAdsOAuthProvider", () => {
     ).rejects.toThrow(/revoked|already used/i);
   });
 
+  it("CODE-M7: rejects an access token offered as a refresh token (audience separation)", async () => {
+    const res = fakeRes();
+    await oauthProvider.authorize(
+      fakeClient,
+      {
+        codeChallenge: "ch",
+        codeChallengeMethod: "S256",
+        redirectUri: "https://example.com/cb",
+        scopes: [],
+      },
+      res,
+    );
+    const code = new URL(
+      (res.redirect as never as ReturnType<typeof vi.fn>).mock.calls[0][1],
+    ).searchParams.get("code")!;
+    const tokens = await oauthProvider.exchangeAuthorizationCode(
+      fakeClient,
+      code,
+    );
+
+    // Pass the access token where a refresh is expected.
+    await expect(
+      oauthProvider.exchangeRefreshToken(fakeClient, tokens.access_token),
+    ).rejects.toThrow(/Invalid refresh token/);
+  });
+
+  it("CODE-M7: rejects a refresh token offered as an access token (audience separation)", async () => {
+    const res = fakeRes();
+    await oauthProvider.authorize(
+      fakeClient,
+      {
+        codeChallenge: "ch",
+        codeChallengeMethod: "S256",
+        redirectUri: "https://example.com/cb",
+        scopes: [],
+      },
+      res,
+    );
+    const code = new URL(
+      (res.redirect as never as ReturnType<typeof vi.fn>).mock.calls[0][1],
+    ).searchParams.get("code")!;
+    const tokens = await oauthProvider.exchangeAuthorizationCode(
+      fakeClient,
+      code,
+    );
+
+    // Pass the refresh token where an access verifier is expected.
+    await expect(
+      oauthProvider.verifyAccessToken(tokens.refresh_token!),
+    ).rejects.toThrow(/Invalid access token/);
+  });
+
   it("preserves fb_user_id across refresh-token exchange (token name is never in the JWT)", async () => {
     oauthProvider.configure({
       resolvePendingAuth: () => ({ fbUserId: "fb-9999" }),

--- a/tests/auth/session.test.ts
+++ b/tests/auth/session.test.ts
@@ -138,6 +138,47 @@ describe("session", () => {
     ).toBeNull();
   });
 
+  it("CODE-M7: rejects a JWT signed with the same secret but for a different audience (token confusion)", async () => {
+    // Forge a JWT with the same secret + structure as a session, but with
+    // the audience of an oauth-state. getSession must reject it because
+    // it pins audience: "mcp-session".
+    const { SignJWT } = await import("jose");
+    const secret = new TextEncoder().encode(SECRET);
+    const forged = await new SignJWT({ fb: "fb-evil", jti: "x".repeat(32) })
+      .setProtectedHeader({ alg: "HS256" })
+      .setAudience("meta-oauth-state") // wrong audience for getSession
+      .setIssuedAt()
+      .setExpirationTime("1h")
+      .sign(secret);
+
+    expect(
+      await getSession({ cookies: { mcp_session: forged } } as never),
+    ).toBeNull();
+  });
+
+  it("CODE-M2: uses the __Host- cookie prefix in production", async () => {
+    const original = process.env.NODE_ENV;
+    try {
+      process.env.NODE_ENV = "production";
+      // Force re-import so the COOKIE_NAME constant picks up production.
+      const fresh = await import(
+        "../../src/auth/session.ts?prod=" + Date.now()
+      );
+      const res = makeRes();
+      await fresh.setSession(res as never, {
+        fbUserId: "fb-prod",
+        email: null,
+        name: null,
+      });
+      expect(res.cookieCalls[0].name).toBe("__Host-mcp_session");
+      expect(res.cookieCalls[0].options.secure).toBe(true);
+      expect(res.cookieCalls[0].options.path).toBe("/");
+    } finally {
+      if (original === undefined) delete process.env.NODE_ENV;
+      else process.env.NODE_ENV = original;
+    }
+  });
+
   it("rejects sessions whose jti is unknown (e.g. server restart with in-memory store)", async () => {
     const res = makeRes();
     await setSession(res as never, {


### PR DESCRIPTION
## Summary

Three medium-severity audit findings, all in `src/auth/` + `src/tools/previews.ts`. No infra changes.

| ID | Title | Severity |
|---|---|---|
| CODE-A4 | Strip raw Meta HTML from preview tools | 🟠 Alto |
| CODE-M2 | Use `__Host-` prefix for session cookie in production | 🟡 Medio |
| CODE-M7 | Audience separation across JWTs + explicit algorithm pinning | 🟡 Medio |

## CODE-A4 — Drop raw HTML from preview tools

`meta_ads_get_ad_preview` and `meta_ads_generate_preview` returned Meta's raw HTML (`<iframe>` wrapper) as a `Raw HTML:\n…` content block alongside the extracted preview URL. Most MCP clients render text content as plain text, so it's inert there — but a browser-based MCP client that interprets text as HTML would execute scripts inside the Meta iframe. The shareable URL is the only documented use case, so drop the body entirely.

## CODE-M2 — `__Host-` cookie prefix

In production the session cookie is now `__Host-mcp_session`. Browsers enforce the prefix contract: `Secure` required, `Path=/` required, `Domain` forbidden. A sibling subdomain can no longer set or overwrite our cookie.

Why **not** also flip to `SameSite=Strict`: the Meta OAuth callback is a top-level navigation from a different origin (`facebook.com` → our server). `Strict` drops the cookie on that hop, the post-callback handler can't read the session, and the user lands back on `/authorize` without a session. `Lax` is sufficient given the jti allow-list and the post-PR-#43 CSRF mitigations.

## CODE-M7 — Audience separation + algorithm pinning

Every JWT we mint is now tagged with an explicit `aud` claim:

| Token type | Audience |
|---|---|
| Session cookie | `mcp-session` |
| OAuth access token | `mcp-oauth-access` |
| OAuth refresh token | `mcp-oauth-refresh` |
| OAuth state (signed `state` param) | `meta-oauth-state` (already existed) |

Verifiers pin both the audience **and** `algorithms: ["HS256"]`. This closes:
- **alg confusion**: a forged token with `alg: "none"` (or asymmetric) would otherwise sail past a verifier that defaults to "whatever the header declares".
- **token confusion**: even if a single secret got shared between two endpoints (e.g. `OAUTH_SECRET` and `SESSION_COOKIE_SECRET` accidentally rotated to the same value), a session JWT couldn't be presented where an access token is expected, and vice versa.

`type` claim checks already in place (`type: "access"`, `type: "refresh"`) stay as a second layer.

## Test plan

- [x] `npm run lint`, `npm run typecheck`, `npm test` (300 tests, +4), `npm run build` all green.
- [x] `gitleaks git --staged` clean.
- New tests cover: session JWT with wrong audience rejected, `__Host-` cookie name in production, access token rejected as refresh, refresh token rejected as access verifier.
- [ ] Post-deploy: re-login from Claude.ai works (a new session cookie with the new audience is issued); existing in-flight sessions get a clean re-auth (their cookies pre-date the audience claim).

## Note

This PR shifts cookie name in production from `mcp_session` to `__Host-mcp_session`. Browsers will treat them as different cookies; the user will need to log in once after deploy. Same one-shot re-login the previous PRs already required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)