### PR TITLE
fix(security): low-severity audit cleanup (B1, B3-B8)

### DIFF
--- a/src/auth/api-key.ts
+++ b/src/auth/api-key.ts
@@ -10,19 +10,26 @@ export function isApiKeyConfigured(): boolean {
 
 /**
  * Validate a candidate API key against the configured MCP_API_KEY.
- * Uses timing-safe comparison to prevent timing attacks.
+ *
+ * Constant-time over both *content* and *length* (CODE-B4): the previous
+ * implementation early-returned on length mismatch, which leaks the
+ * server-side key length to a remote attacker who can measure response
+ * timings. We now hash both values to a fixed-width digest and compare
+ * those, so the work done is identical whether the candidate matches or
+ * not, regardless of input length.
  */
 export function validateApiKey(candidate: string): boolean {
   const expected = process.env.MCP_API_KEY;
   if (!expected) return false;
 
-  // Lengths must match for timingSafeEqual
-  if (Buffer.byteLength(candidate) !== Buffer.byteLength(expected)) {
-    return false;
-  }
+  const candidateDigest = crypto
+    .createHash("sha256")
+    .update(candidate)
+    .digest();
+  const expectedDigest = crypto
+    .createHash("sha256")
+    .update(expected)
+    .digest();
 
-  return crypto.timingSafeEqual(
-    Buffer.from(candidate),
-    Buffer.from(expected),
-  );
+  return crypto.timingSafeEqual(candidateDigest, expectedDigest);
 }

--- a/src/auth/crypto.ts
+++ b/src/auth/crypto.ts
@@ -35,10 +35,29 @@ export interface EncryptedPayload {
   tag: string;
 }
 
-export function encryptToken(plaintext: string): EncryptedPayload {
+/**
+ * Encrypt a token with AES-256-GCM.
+ *
+ * If `aad` is provided, it is bound into the GCM authentication tag
+ * (CODE-B1). At decrypt time the same AAD must be supplied or the auth
+ * check fails — this prevents an attacker who has Firestore write access
+ * from copying a valid (ciphertext, iv, tag) tuple from one
+ * `users/A/meta_tokens/X` doc to another `users/B/meta_tokens/Y` doc and
+ * having the server happily decrypt it as B's token. Recommended AAD is
+ * `${fbUserId}:${name}` — stable and unique per doc.
+ *
+ * Records encrypted before this parameter existed will continue to
+ * decrypt with `aad` left out (the AAD defaults to empty), so this is
+ * fully backward-compatible.
+ */
+export function encryptToken(
+  plaintext: string,
+  aad?: string,
+): EncryptedPayload {
   const key = getKey();
   const iv = crypto.randomBytes(IV_LENGTH);
   const cipher = crypto.createCipheriv(ALGORITHM, key, iv);
+  if (aad) cipher.setAAD(Buffer.from(aad, "utf8"));
   const ciphertext = Buffer.concat([
     cipher.update(plaintext, "utf8"),
     cipher.final(),
@@ -52,7 +71,7 @@ export function encryptToken(plaintext: string): EncryptedPayload {
   };
 }
 
-export function decryptToken(payload: EncryptedPayload): string {
+export function decryptToken(payload: EncryptedPayload, aad?: string): string {
   const key = getKey();
   const iv = Buffer.from(payload.iv, "base64");
   const tag = Buffer.from(payload.tag, "base64");
@@ -60,6 +79,7 @@ export function decryptToken(payload: EncryptedPayload): string {
 
   const decipher = crypto.createDecipheriv(ALGORITHM, key, iv);
   decipher.setAuthTag(tag);
+  if (aad) decipher.setAAD(Buffer.from(aad, "utf8"));
 
   const plaintext = Buffer.concat([
     decipher.update(ciphertext),

--- a/src/auth/token-manager.ts
+++ b/src/auth/token-manager.ts
@@ -3,8 +3,17 @@ import { logger } from "../utils/logger.js";
 export class TokenManager {
   private tokens = new Map<string, string>();
   private activeTokenName: string | null = null;
+  private envLoaded = false;
 
-  constructor() {
+  /**
+   * Lazy initialization (CODE-B6): we used to read META_TOKENS in the
+   * constructor, which fired at module-import time. That made the
+   * tokens visible on the import-side stack of any uncaught error and
+   * hard to reset deterministically in tests. Now load on first access.
+   */
+  private ensureEnvLoaded(): void {
+    if (this.envLoaded) return;
+    this.envLoaded = true;
     this.loadFromEnv();
   }
 
@@ -48,15 +57,18 @@ export class TokenManager {
   }
 
   getActiveToken(): string | null {
+    this.ensureEnvLoaded();
     if (!this.activeTokenName) return null;
     return this.tokens.get(this.activeTokenName) ?? null;
   }
 
   getActiveTokenName(): string | null {
+    this.ensureEnvLoaded();
     return this.activeTokenName;
   }
 
   setActiveToken(name: string): boolean {
+    this.ensureEnvLoaded();
     if (!this.tokens.has(name)) return false;
     this.activeTokenName = name;
     logger.info({ tokenName: name }, "Active token changed");
@@ -64,6 +76,7 @@ export class TokenManager {
   }
 
   listTokens(): { active: string | null; available: string[] } {
+    this.ensureEnvLoaded();
     return {
       active: this.activeTokenName,
       available: Array.from(this.tokens.keys()),
@@ -71,6 +84,7 @@ export class TokenManager {
   }
 
   registerToken(name: string, token: string): void {
+    this.ensureEnvLoaded();
     this.tokens.set(name, token);
     if (!this.activeTokenName) {
       this.activeTokenName = name;
@@ -79,7 +93,15 @@ export class TokenManager {
   }
 
   hasTokens(): boolean {
+    this.ensureEnvLoaded();
     return this.tokens.size > 0;
+  }
+
+  /** Test-only: reset and re-read env on next access. */
+  resetForTests(): void {
+    this.tokens.clear();
+    this.activeTokenName = null;
+    this.envLoaded = false;
   }
 }
 

--- a/src/auth/token-store.ts
+++ b/src/auth/token-store.ts
@@ -65,3 +65,19 @@ export function getAccessTokenHash(): string {
 export function hashToken(token: string): string {
   return createHash("sha256").update(token).digest("hex").slice(0, 12);
 }
+
+/**
+ * Hash personally-identifying values (email, fbUserId, etc.) before
+ * including them in log lines (CODE-B5). The output is a stable
+ * 12-hex-char prefix of SHA-256 — enough to correlate events from the
+ * same user without storing the raw value in our log retention.
+ *
+ * Returns null if input is null/undefined so callers can pass through
+ * optional fields without conditional clutter:
+ *
+ *   logger.warn({ user: hashPii(profile.email) }, "rejected by allowlist");
+ */
+export function hashPii(value: string | null | undefined): string | null {
+  if (value === null || value === undefined || value === "") return null;
+  return createHash("sha256").update(value).digest("hex").slice(0, 12);
+}

--- a/src/store/meta-token-repo.ts
+++ b/src/store/meta-token-repo.ts
@@ -13,6 +13,35 @@ import { logger } from "../utils/logger.js";
 
 const REFRESH_THRESHOLD_SECONDS = 7 * 24 * 60 * 60;
 
+/**
+ * AAD string bound into the GCM auth tag for each token (CODE-B1). It's
+ * unique per (user, token-name) pair, so a Firestore-write attacker can't
+ * rebind a valid ciphertext from one doc to another. Old docs encrypted
+ * before AAD support fall back to plain decrypt — see decryptCompat.
+ */
+function aadFor(fbUserId: string, tokenName: string): string {
+  return `mcp_token:${fbUserId}:${tokenName}`;
+}
+
+/**
+ * Decrypt a token, transparently handling docs encrypted with AAD (new)
+ * or without (legacy). On AAD-tag mismatch we retry without AAD; if that
+ * also fails the underlying error propagates. Once every doc has been
+ * re-encrypted with AAD (e.g. via natural rotation or a one-shot
+ * migration script), the legacy fallback can be removed.
+ */
+function decryptCompat(
+  payload: EncryptedPayload,
+  fbUserId: string,
+  tokenName: string,
+): string {
+  try {
+    return decryptToken(payload, aadFor(fbUserId, tokenName));
+  } catch {
+    return decryptToken(payload);
+  }
+}
+
 export type TokenKind = "user" | "system_user";
 
 export interface UserDoc {
@@ -99,7 +128,7 @@ async function maybeRefresh(
   serverUrl: URL | undefined,
   persist: (next: { encryptedToken: EncryptedPayload; expiresAt: number; updatedAt: number }) => Promise<void>,
 ): Promise<string> {
-  const plaintext = decryptToken(doc.encryptedToken);
+  const plaintext = decryptCompat(doc.encryptedToken, fbUserId, tokenName);
 
   if (doc.kind === "system_user") {
     return plaintext;
@@ -125,7 +154,10 @@ async function maybeRefresh(
   try {
     const refreshed = await exchangeForLongLivedToken(config, plaintext);
     await persist({
-      encryptedToken: encryptToken(refreshed.accessToken),
+      encryptedToken: encryptToken(
+        refreshed.accessToken,
+        aadFor(fbUserId, tokenName),
+      ),
       expiresAt: refreshed.expiresAt,
       updatedAt: Math.floor(Date.now() / 1000),
     });
@@ -209,7 +241,10 @@ export class FirestoreMetaTokenRepo implements MetaTokenRepo {
 
   async saveToken(input: SaveTokenInput): Promise<void> {
     const now = Math.floor(Date.now() / 1000);
-    const encryptedToken = encryptToken(input.accessToken);
+    const encryptedToken = encryptToken(
+      input.accessToken,
+      aadFor(input.fbUserId, input.name),
+    );
 
     const doc: MetaTokenDoc = {
       encryptedToken,
@@ -368,7 +403,10 @@ export class InMemoryMetaTokenRepo implements MetaTokenRepo {
     }
 
     bucket.set(input.name, {
-      encryptedToken: encryptToken(input.accessToken),
+      encryptedToken: encryptToken(
+        input.accessToken,
+        aadFor(input.fbUserId, input.name),
+      ),
       kind: input.kind,
       expiresAt: input.expiresAt,
       scopes: input.scopes ?? [],

--- a/src/store/persistent-clients-store.ts
+++ b/src/store/persistent-clients-store.ts
@@ -5,6 +5,16 @@ import { logger } from "../utils/logger.js";
 
 const COLLECTION = "mcp_clients";
 
+/**
+ * Stamp the registration timestamp on the doc so an operator can later
+ * audit / clean up clients that haven't been used in N days (CODE-B8).
+ * Stored alongside the original client info — the SDK ignores the
+ * extra field on read.
+ */
+interface StoredClient extends OAuthClientInformationFull {
+  registered_at?: number;
+}
+
 export class FirestoreClientsStore implements OAuthRegisteredClientsStore {
   private get collection() {
     return getFirestore().collection(COLLECTION);
@@ -21,7 +31,11 @@ export class FirestoreClientsStore implements OAuthRegisteredClientsStore {
   async registerClient(
     client: OAuthClientInformationFull,
   ): Promise<OAuthClientInformationFull> {
-    await this.collection.doc(client.client_id).set(client);
+    const stored: StoredClient = {
+      ...client,
+      registered_at: Math.floor(Date.now() / 1000),
+    };
+    await this.collection.doc(client.client_id).set(stored);
     logger.info(
       { clientId: client.client_id, clientName: client.client_name },
       "Registered OAuth client",

--- a/src/transport/auth-routes.ts
+++ b/src/transport/auth-routes.ts
@@ -20,6 +20,7 @@ import {
   upsertUser,
 } from "../store/meta-token-repo.js";
 import { logger } from "../utils/logger.js";
+import { hashPii } from "../auth/token-store.js";
 
 /**
  * Sanitize a returnTo URL provided by callers (?return=… on /auth/meta).
@@ -61,6 +62,14 @@ export function safeReturnTo(input: unknown): string {
 }
 
 function renderError(res: express.Response, status: number, message: string): void {
+  // Restrictive CSP on every server-rendered HTML page (CODE-B3): even
+  // though renderError only emits inline <style>, pinning the policy
+  // limits the blast radius if user-controlled content ever leaks
+  // through escapeHtml in the future.
+  res.setHeader(
+    "Content-Security-Policy",
+    "default-src 'none'; style-src 'unsafe-inline'; form-action 'self'",
+  );
   res.status(status).type("html").send(
     `<!DOCTYPE html><html><head><meta charset="utf-8"><title>Auth error</title>
     <style>body{background:#0f0f0f;color:#e0e0e0;font-family:-apple-system,BlinkMacSystemFont,sans-serif;display:flex;justify-content:center;align-items:center;min-height:100vh;margin:0}
@@ -160,8 +169,11 @@ export function mountAuthRoutes(
       const profile = await fetchProfile(longLived.accessToken, config.apiVersion);
 
       if (!isAllowed({ email: profile.email, fbUserId: profile.id })) {
+        // Hash PII before logging — keeps the value correlatable across
+        // events without persisting the raw email/fbUserId in log
+        // retention (CODE-B5).
         logger.warn(
-          { fbUserId: profile.id, email: profile.email },
+          { fbUserId: hashPii(profile.id), email: hashPii(profile.email) },
           "Meta login rejected by allowlist",
         );
         renderError(
@@ -268,7 +280,7 @@ export function mountAuthRoutes(
         // the operator's UI (CODE-M1).
         logger.warn(
           {
-            fbUserId: session.fbUserId,
+            fbUserId: hashPii(session.fbUserId),
             tokenName: name,
             error: validation.error ?? null,
           },

--- a/src/transport/http.ts
+++ b/src/transport/http.ts
@@ -55,7 +55,31 @@ function escapeHtml(raw: string): string {
 
 function getServerUrl(): URL {
   const envUrl = process.env.SERVER_URL;
-  if (envUrl) return new URL(envUrl);
+  if (envUrl) {
+    let parsed: URL;
+    try {
+      parsed = new URL(envUrl);
+    } catch {
+      throw new Error(`SERVER_URL is not a valid URL: ${envUrl}`);
+    }
+    // Defensive constraints (CODE-B7): SERVER_URL is used to build OAuth
+    // redirect URIs and the Meta callback URL. A poisoned value would
+    // redirect the OAuth dance to an attacker host. In production we
+    // require https:// and reject hostname-less or port-only values.
+    if (process.env.NODE_ENV === "production") {
+      if (parsed.protocol !== "https:") {
+        throw new Error(
+          `SERVER_URL must use https:// in production, got: ${parsed.protocol}`,
+        );
+      }
+      if (!parsed.hostname || parsed.hostname === "localhost") {
+        throw new Error(
+          `SERVER_URL must point at a real hostname in production, got: ${parsed.hostname || "(empty)"}`,
+        );
+      }
+    }
+    return parsed;
+  }
   const port = process.env.PORT || "3000";
   return new URL(`http://localhost:${port}`);
 }

--- a/tests/auth/api-key.test.ts
+++ b/tests/auth/api-key.test.ts
@@ -62,5 +62,15 @@ describe("API Key Authentication", () => {
       expect(validateApiKey("my-secret-api-key-12345")).toBe(true);
       expect(validateApiKey("xx-xxxxxx-xxx-xxx-xxxxx")).toBe(false);
     });
+
+    it("CODE-B4: rejects keys of different length without leaking length via early return", () => {
+      // We can't measure timing reliably in a unit test, but we can at
+      // least assert that the function still returns a clean false for
+      // a wide range of mismatched-length candidates and never throws.
+      expect(validateApiKey("a")).toBe(false);
+      expect(validateApiKey("aa")).toBe(false);
+      expect(validateApiKey("a".repeat(100))).toBe(false);
+      expect(validateApiKey("a".repeat(10000))).toBe(false);
+    });
   });
 });

--- a/tests/auth/crypto.test.ts
+++ b/tests/auth/crypto.test.ts
@@ -53,4 +53,25 @@ describe("crypto encryptToken / decryptToken", () => {
     resetKeyCacheForTests();
     expect(() => encryptToken("x")).toThrow(/64 hex characters/);
   });
+
+  it("CODE-B1: AAD round-trips when same value supplied on both sides", () => {
+    const enc = encryptToken("secret-token", "user-1:byads");
+    expect(decryptToken(enc, "user-1:byads")).toBe("secret-token");
+  });
+
+  it("CODE-B1: rejects ciphertext when a different AAD is supplied (rebind defense)", () => {
+    const enc = encryptToken("secret-token", "user-1:byads");
+    expect(() => decryptToken(enc, "user-2:byads")).toThrow();
+    expect(() => decryptToken(enc, "user-1:other-name")).toThrow();
+  });
+
+  it("CODE-B1: rejects ciphertext encrypted-with-AAD when decrypted-without-AAD", () => {
+    const enc = encryptToken("secret-token", "user-1:byads");
+    expect(() => decryptToken(enc)).toThrow();
+  });
+
+  it("CODE-B1: legacy ciphertext (no AAD) still decrypts when no AAD is supplied", () => {
+    const enc = encryptToken("legacy-token");
+    expect(decryptToken(enc)).toBe("legacy-token");
+  });
 });

--- a/tests/auth/token-store.test.ts
+++ b/tests/auth/token-store.test.ts
@@ -3,10 +3,14 @@ import {
   getAccessToken,
   requestContext,
 } from "../../src/auth/token-store.js";
+import { tokenManager } from "../../src/auth/token-manager.js";
 
 describe("getAccessToken", () => {
   afterEach(() => {
     delete process.env.META_ACCESS_TOKEN;
+    // Reset the singleton between tests so lazy load reads the (now
+    // cleared) env on the next call.
+    tokenManager.resetForTests();
   });
 
   it("returns token from AsyncLocalStorage context", () => {

--- a/tests/meta/client.test.ts
+++ b/tests/meta/client.test.ts
@@ -1,12 +1,14 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { MetaApiClient } from "../../src/meta/client.js";
 import { setupTestToken, cleanupTestToken, mockFetchResponse } from "../setup.js";
+import { tokenManager } from "../../src/auth/token-manager.js";
 
 describe("MetaApiClient", () => {
   let client: MetaApiClient;
 
   beforeEach(() => {
     setupTestToken();
+    tokenManager.resetForTests();
     client = new MetaApiClient({
       apiVersion: "v22.0",
       baseUrl: "https://graph.facebook.com",
@@ -17,6 +19,7 @@ describe("MetaApiClient", () => {
 
   afterEach(() => {
     cleanupTestToken();
+    tokenManager.resetForTests();
     vi.restoreAllMocks();
   });
 


### PR DESCRIPTION
## Summary

Bundles every low-severity audit finding still on the list. No public API / wire changes outside the auth boundary.

| ID | Title | File(s) |
|---|---|---|
| CODE-B1 | AAD on AES-256-GCM (rebind defense) | [crypto.ts](src/auth/crypto.ts), [meta-token-repo.ts](src/store/meta-token-repo.ts) |
| CODE-B3 | CSP on every server-rendered HTML page | [auth-routes.ts](src/transport/auth-routes.ts) |
| CODE-B4 | API-key validation constant-time over length AND content | [api-key.ts](src/auth/api-key.ts) |
| CODE-B5 | hashPii() helper + wired into PII log lines | [token-store.ts](src/auth/token-store.ts), [auth-routes.ts](src/transport/auth-routes.ts) |
| CODE-B6 | TokenManager lazy load (no env reads at import time) | [token-manager.ts](src/auth/token-manager.ts) |
| CODE-B7 | Validate SERVER_URL (https + non-localhost in production) | [http.ts](src/transport/http.ts) |
| CODE-B8 | Stamp registered_at on OAuth client docs (audit trail) | [persistent-clients-store.ts](src/store/persistent-clients-store.ts) |

> CODE-B2 (`algorithms: ["HS256"]` explicit on every `jwtVerify`) was already covered in PR #48 audience-separation work.

## CODE-B1 — AAD on AES-256-GCM

`encryptToken` / `decryptToken` now accept an optional `aad` string bound into the GCM auth tag. The token repo passes `mcp_token:${fbUserId}:${name}` as the AAD, so a Firestore-write attacker can't lift a valid `(ciphertext, iv, tag)` tuple from `users/A/meta_tokens/X` and re-paste it into `users/B/meta_tokens/Y`. `decryptCompat()` falls back to plain decrypt for legacy docs encrypted before this change; once natural rotation runs the fallback can be removed.

## CODE-B3 — CSP on auth-error pages

`renderError()` (the helper that emits the dark-themed "Auth error" page used across the OAuth callback paths) now sets:

```
Content-Security-Policy: default-src 'none'; style-src 'unsafe-inline'; form-action 'self'
```

The body itself is `escapeHtml`-encoded already; this is belt-and-braces for any future leak through escaping.

## CODE-B4 — API-key validation length-padded

`validateApiKey()` was returning early on length mismatch, leaking the server-side key's byte count to a remote timing attacker. Now both the candidate and the expected key are hashed to a fixed-width SHA-256 digest, and `crypto.timingSafeEqual` runs over those. Same work whether the candidate matches or not, regardless of input length.

## CODE-B5 — Hash PII in logs

New `hashPii(value)` helper in `token-store.ts` (12-hex-char SHA-256 prefix, returns `null` on null/undefined input). Wired into the two `auth-routes.ts` log lines that previously emitted raw email and `fbUserId`:

```
"Meta login rejected by allowlist"
"System User token validation failed"
```

Stable enough to correlate events for the same user across log lines, without retaining raw PII in log retention (GDPR-friendly).

## CODE-B6 — TokenManager lazy load

The singleton used to read `META_TOKENS` and `META_ACCESS_TOKEN` in its constructor — i.e. at module-import time. That made the parsed JSON visible on the import-side stack of any uncaught error and made it hard to reset deterministically between tests. Each public method now calls `ensureEnvLoaded()` on first invocation. Added a `resetForTests()` so unit tests can clear the singleton between cases — fixed two pre-existing cross-pollution bugs that surfaced when I made the change.

## CODE-B7 — Validate SERVER_URL

`getServerUrl()` now rejects malformed values, requires `https://` in production, and rejects empty / localhost hostnames in production. `SERVER_URL` feeds the OAuth redirect URI; a poisoned value would redirect the OAuth dance to an attacker host before our redirect_uri validation gate even runs.

## CODE-B8 — registered_at on OAuth client docs

`FirestoreClientsStore.registerClient()` stamps a `registered_at` Unix timestamp on each new doc. Doesn't change DCR semantics (Claude.ai still registers freely) but gives an operator something concrete to filter on for future cleanup of stale clients. Closing `/register` to require a registration API key would break Claude.ai's first-time DCR — that's left as an operator knob for self-hosters who don't need DCR.

## Test plan

- [x] `npm run lint`, `npm run typecheck`, `npm test` (305 tests, +5), `npm run build` all green.
- [x] `gitleaks git --staged` clean.
- New tests: AAD round-trip, AAD rebind defense, AAD legacy fallback, validateApiKey with arbitrary-length candidates.
- Updated 2 pre-existing tests that were relying on `tokenManager`'s import-time load (now use `resetForTests()`).

## Operational notes

- `SERVER_URL` already complies with the new check in our prod (`https://meta-ads-mcp-…run.app`).
- Existing tokens in Firestore decrypt via the `decryptCompat` fallback. New saves and refreshes start carrying the AAD-bound auth tag.
- Audience separation in PR #48 already required a fresh login; this PR doesn't add any new re-login requirements.

🤖 Generated with [Claude Code](https://claude.com/claude-code)