### PR TITLE
fix(security): validate non-account IDs at tool boundaries

### DIFF
--- a/src/tools/abtesting.ts
+++ b/src/tools/abtesting.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { metaApiClient } from "../meta/client.js";
-import { normalizeAccountId } from "../utils/format.js";
+import { normalizeAccountId, validateMetaId } from "../utils/format.js";
 import { buildFieldsParam } from "../utils/validation.js";
 import { STUDY_DEFAULT_FIELDS } from "../meta/types/study.js";
 import type { AdStudy, MetaApiResponse } from "../meta/types/index.js";
@@ -97,8 +97,8 @@ export function registerABTestingTools(server: McpServer): void {
           cells.map((c) => ({
             name: c.name,
             treatment_percentage: c.treatment_percentage,
-            adsets: c.adsets?.map((id) => ({ id })),
-            campaigns: c.campaigns?.map((id) => ({ id })),
+            adsets: c.adsets?.map((adsetId) => ({ id: validateMetaId(adsetId, "adset") })),
+            campaigns: c.campaigns?.map((campaignId) => ({ id: validateMetaId(campaignId, "campaign") })),
           })),
         ),
       };
@@ -131,6 +131,7 @@ export function registerABTestingTools(server: McpServer): void {
       fields: z.array(z.string()).optional(),
     },
     async ({ study_id, fields }) => {
+      const id = validateMetaId(study_id, "study");
       const allFields = [
         ...STUDY_DEFAULT_FIELDS,
         "cells{id,name,treatment_percentage,campaigns,adsets}",
@@ -139,7 +140,7 @@ export function registerABTestingTools(server: McpServer): void {
       const fieldsParam = buildFieldsParam(fields, allFields);
 
       const study = await metaApiClient.get<AdStudy>(
-        `/${study_id}`,
+        `/${id}`,
         { fields: fieldsParam },
       );
 

--- a/src/tools/accounts.ts
+++ b/src/tools/accounts.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { metaApiClient } from "../meta/client.js";
-import { normalizeAccountId } from "../utils/format.js";
+import { normalizeAccountId, validateMetaId } from "../utils/format.js";
 import { buildFieldsParam } from "../utils/validation.js";
 import {
   AD_ACCOUNT_DEFAULT_FIELDS,
@@ -36,13 +36,14 @@ export function registerAccountTools(server: McpServer): void {
         .describe("Fields to include (defaults to standard set)"),
     },
     async ({ user_id, limit, fields }) => {
+      const userPath = user_id === "me" ? "me" : validateMetaId(user_id, "user");
       const fieldsParam = buildFieldsParam(
         fields,
         [...AD_ACCOUNT_DEFAULT_FIELDS],
       );
 
       const response = await metaApiClient.get<MetaApiResponse<AdAccount>>(
-        `/${user_id}/adaccounts`,
+        `/${userPath}/adaccounts`,
         { fields: fieldsParam, limit },
       );
 

--- a/src/tools/ads.ts
+++ b/src/tools/ads.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { metaApiClient } from "../meta/client.js";
-import { normalizeAccountId } from "../utils/format.js";
+import { normalizeAccountId, validateMetaId } from "../utils/format.js";
 import { buildFieldsParam } from "../utils/validation.js";
 import { AD_DEFAULT_FIELDS } from "../meta/types/ad.js";
 import type { Ad, MetaApiResponse } from "../meta/types/index.js";
@@ -23,9 +23,9 @@ export function registerAdTools(server: McpServer): void {
     async ({ account_id, limit, campaign_id, adset_id, status_filter }) => {
       let path: string;
       if (adset_id) {
-        path = `/${adset_id}/ads`;
+        path = `/${validateMetaId(adset_id, "adset")}/ads`;
       } else if (campaign_id) {
-        path = `/${campaign_id}/ads`;
+        path = `/${validateMetaId(campaign_id, "campaign")}/ads`;
       } else {
         path = `/${normalizeAccountId(account_id)}/ads`;
       }
@@ -73,8 +73,9 @@ export function registerAdTools(server: McpServer): void {
       fields: z.array(z.string()).optional(),
     },
     async ({ ad_id, fields }) => {
+      const id = validateMetaId(ad_id, "ad");
       const fieldsParam = buildFieldsParam(fields, [...AD_DEFAULT_FIELDS, "bid_amount", "tracking_specs"]);
-      const ad = await metaApiClient.get<Ad>(`/${ad_id}`, { fields: fieldsParam });
+      const ad = await metaApiClient.get<Ad>(`/${id}`, { fields: fieldsParam });
 
       return {
         content: [
@@ -104,24 +105,26 @@ export function registerAdTools(server: McpServer): void {
         .describe("Tracking specifications"),
     },
     async ({ account_id, name, adset_id, creative_id, status, tracking_specs }) => {
-      const id = normalizeAccountId(account_id);
+      const accountPath = normalizeAccountId(account_id);
+      const adsetIdValidated = validateMetaId(adset_id, "adset");
+      const creativeIdValidated = validateMetaId(creative_id, "creative");
 
       const body: Record<string, string | number | boolean> = {
         name,
-        adset_id,
-        creative: JSON.stringify({ creative_id }),
+        adset_id: adsetIdValidated,
+        creative: JSON.stringify({ creative_id: creativeIdValidated }),
         status,
       };
 
       if (tracking_specs) body.tracking_specs = JSON.stringify(tracking_specs);
 
-      const result = await metaApiClient.postForm<{ id: string }>(`/${id}/ads`, body);
+      const result = await metaApiClient.postForm<{ id: string }>(`/${accountPath}/ads`, body);
 
       return {
         content: [
           {
             type: "text",
-            text: `Ad created successfully!\nID: ${result.id}\nName: ${name}\nAd Set: ${adset_id}\nCreative: ${creative_id}\nStatus: ${status}`,
+            text: `Ad created successfully!\nID: ${result.id}\nName: ${name}\nAd Set: ${adsetIdValidated}\nCreative: ${creativeIdValidated}\nStatus: ${status}`,
           },
         ],
       };
@@ -139,16 +142,21 @@ export function registerAdTools(server: McpServer): void {
       creative_id: z.string().optional().describe("New creative ID"),
     },
     async ({ ad_id, name, status, creative_id }) => {
+      const id = validateMetaId(ad_id, "ad");
       const body: Record<string, string | number | boolean> = {};
       if (name !== undefined) body.name = name;
       if (status !== undefined) body.status = status;
-      if (creative_id !== undefined) body.creative = JSON.stringify({ creative_id });
+      if (creative_id !== undefined) {
+        body.creative = JSON.stringify({
+          creative_id: validateMetaId(creative_id, "creative"),
+        });
+      }
 
-      await metaApiClient.postForm<{ success: boolean }>(`/${ad_id}`, body);
+      await metaApiClient.postForm<{ success: boolean }>(`/${id}`, body);
 
       return {
         content: [
-          { type: "text", text: `Ad ${ad_id} updated successfully.\nChanges: ${JSON.stringify(body)}` },
+          { type: "text", text: `Ad ${id} updated successfully.\nChanges: ${JSON.stringify(body)}` },
         ],
       };
     },
@@ -162,13 +170,14 @@ export function registerAdTools(server: McpServer): void {
       ad_id: z.string().describe("Ad ID to delete"),
     },
     async ({ ad_id }) => {
-      await metaApiClient.postForm<{ success: boolean }>(`/${ad_id}`, {
+      const id = validateMetaId(ad_id, "ad");
+      await metaApiClient.postForm<{ success: boolean }>(`/${id}`, {
         status: "DELETED",
       });
 
       return {
         content: [
-          { type: "text", text: `Ad ${ad_id} has been deleted (status set to DELETED).` },
+          { type: "text", text: `Ad ${id} has been deleted (status set to DELETED).` },
         ],
       };
     },

--- a/src/tools/adsets.ts
+++ b/src/tools/adsets.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { metaApiClient } from "../meta/client.js";
-import { normalizeAccountId } from "../utils/format.js";
+import { normalizeAccountId, validateMetaId } from "../utils/format.js";
 import { buildFieldsParam } from "../utils/validation.js";
 import { ADSET_DEFAULT_FIELDS } from "../meta/types/adset.js";
 import { AD_DEFAULT_FIELDS } from "../meta/types/ad.js";
@@ -388,7 +388,7 @@ export function registerAdSetTools(server: McpServer): void {
     },
     async ({ account_id, limit, campaign_id, status_filter }) => {
       const path = campaign_id
-        ? `/${campaign_id}/adsets`
+        ? `/${validateMetaId(campaign_id, "campaign")}/adsets`
         : `/${normalizeAccountId(account_id)}/adsets`;
 
       const fieldsParam = buildFieldsParam(undefined, [...ADSET_DEFAULT_FIELDS]);
@@ -434,8 +434,9 @@ export function registerAdSetTools(server: McpServer): void {
       fields: z.array(z.string()).optional(),
     },
     async ({ adset_id, fields }) => {
+      const id = validateMetaId(adset_id, "adset");
       const fieldsParam = buildAdSetDetailsFields(fields);
-      const adset = await metaApiClient.get<AdSet>(`/${adset_id}`, { fields: fieldsParam });
+      const adset = await metaApiClient.get<AdSet>(`/${id}`, { fields: fieldsParam });
       const targetingSummary = adset.targeting ? JSON.stringify(adset.targeting, null, 2) : "N/A";
 
       return {
@@ -468,15 +469,18 @@ export function registerAdSetTools(server: McpServer): void {
         throw new Error("idempotency_key is required when dry_run is false.");
       }
 
+      const accountPath = normalizeAccountId(account_id);
+      const sourceAdsetIdValidated = validateMetaId(source_adset_id, "adset");
+
       const requestSignature = JSON.stringify({
-        account_id,
-        source_adset_id,
+        account_id: accountPath,
+        source_adset_id: sourceAdsetIdValidated,
         target_adset,
         creative_overrides,
         reuse_source_media,
       });
       const cacheKey = idempotency_key
-        ? `${idempotency_key}:${account_id}:${source_adset_id}:${target_adset.name}`
+        ? `${idempotency_key}:${accountPath}:${sourceAdsetIdValidated}:${target_adset.name}`
         : undefined;
 
       if (cacheKey) {
@@ -496,7 +500,7 @@ export function registerAdSetTools(server: McpServer): void {
       }
 
       const sourceAdsetFields = buildAdSetDetailsFields(undefined);
-      const sourceAdset = await metaApiClient.get<AdSet>(`/${source_adset_id}`, {
+      const sourceAdset = await metaApiClient.get<AdSet>(`/${sourceAdsetIdValidated}`, {
         fields: sourceAdsetFields,
       });
 
@@ -515,7 +519,7 @@ export function registerAdSetTools(server: McpServer): void {
 
       const adsFieldsParam = buildFieldsParam(undefined, [...AD_DEFAULT_FIELDS, "tracking_specs"]);
       const sourceAds = await metaApiClient.getPaginated<Ad>(
-        `/${source_adset_id}/ads`,
+        `/${sourceAdsetIdValidated}/ads`,
         { fields: adsFieldsParam, limit: 100 },
         500,
       );
@@ -783,10 +787,11 @@ export function registerAdSetTools(server: McpServer): void {
       optimization_goal, billing_event, bid_amount, bid_strategy, targeting,
       start_time, end_time, promoted_object,
     }) => {
-      const id = normalizeAccountId(account_id);
+      const accountPath = normalizeAccountId(account_id);
+      const campaignIdValidated = validateMetaId(campaign_id, "campaign");
 
       const body: Record<string, string | number | boolean> = {
-        campaign_id,
+        campaign_id: campaignIdValidated,
         name,
         destination_type,
         status,
@@ -803,13 +808,13 @@ export function registerAdSetTools(server: McpServer): void {
       if (end_time) body.end_time = end_time;
       if (promoted_object) body.promoted_object = JSON.stringify(promoted_object);
 
-      const result = await metaApiClient.postForm<{ id: string }>(`/${id}/adsets`, body);
+      const result = await metaApiClient.postForm<{ id: string }>(`/${accountPath}/adsets`, body);
 
       return {
         content: [
           {
             type: "text",
-            text: `Ad set created successfully!\nID: ${result.id}\nName: ${name}\nCampaign: ${campaign_id}\nStatus: ${status}\nOptimization: ${optimization_goal}`,
+            text: `Ad set created successfully!\nID: ${result.id}\nName: ${name}\nCampaign: ${campaignIdValidated}\nStatus: ${status}\nOptimization: ${optimization_goal}`,
           },
         ],
       };
@@ -833,6 +838,7 @@ export function registerAdSetTools(server: McpServer): void {
       end_time: z.string().optional(),
     },
     async ({ adset_id, name, status, destination_type, daily_budget, lifetime_budget, targeting, bid_amount, bid_strategy, end_time }) => {
+      const id = validateMetaId(adset_id, "adset");
       const body: Record<string, string | number | boolean> = {};
       if (name !== undefined) body.name = name;
       if (status !== undefined) body.status = status;
@@ -844,11 +850,11 @@ export function registerAdSetTools(server: McpServer): void {
       if (bid_strategy !== undefined) body.bid_strategy = bid_strategy;
       if (end_time !== undefined) body.end_time = end_time;
 
-      await metaApiClient.postForm<{ success: boolean }>(`/${adset_id}`, body);
+      await metaApiClient.postForm<{ success: boolean }>(`/${id}`, body);
 
       return {
         content: [
-          { type: "text", text: `Ad set ${adset_id} updated successfully.\nChanges: ${JSON.stringify(body)}` },
+          { type: "text", text: `Ad set ${id} updated successfully.\nChanges: ${JSON.stringify(body)}` },
         ],
       };
     },
@@ -862,13 +868,14 @@ export function registerAdSetTools(server: McpServer): void {
       adset_id: z.string().describe("Ad set ID to delete"),
     },
     async ({ adset_id }) => {
-      await metaApiClient.postForm<{ success: boolean }>(`/${adset_id}`, {
+      const id = validateMetaId(adset_id, "adset");
+      await metaApiClient.postForm<{ success: boolean }>(`/${id}`, {
         status: "DELETED",
       });
 
       return {
         content: [
-          { type: "text", text: `Ad set ${adset_id} has been deleted (status set to DELETED).` },
+          { type: "text", text: `Ad set ${id} has been deleted (status set to DELETED).` },
         ],
       };
     },

--- a/src/tools/audiences.ts
+++ b/src/tools/audiences.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { metaApiClient } from "../meta/client.js";
-import { normalizeAccountId } from "../utils/format.js";
+import { normalizeAccountId, validateMetaId } from "../utils/format.js";
 import { buildFieldsParam } from "../utils/validation.js";
 import { AUDIENCE_DEFAULT_FIELDS } from "../meta/types/audience.js";
 import type { CustomAudience, MetaApiResponse } from "../meta/types/index.js";
@@ -54,10 +54,11 @@ export function registerAudienceTools(server: McpServer): void {
       fields: z.array(z.string()).optional(),
     },
     async ({ audience_id, fields }) => {
+      const id = validateMetaId(audience_id, "audience");
       const fieldsParam = buildFieldsParam(fields, [...AUDIENCE_DEFAULT_FIELDS]);
 
       const audience = await metaApiClient.get<CustomAudience>(
-        `/${audience_id}`,
+        `/${id}`,
         { fields: fieldsParam },
       );
 
@@ -140,12 +141,13 @@ export function registerAudienceTools(server: McpServer): void {
       description: z.string().optional(),
     },
     async ({ account_id, name, origin_audience_id, ratio, country, description }) => {
-      const id = normalizeAccountId(account_id);
+      const accountPath = normalizeAccountId(account_id);
+      const originAudienceIdValidated = validateMetaId(origin_audience_id, "audience");
 
       const body: Record<string, string | number | boolean> = {
         name,
         subtype: "LOOKALIKE",
-        origin_audience_id,
+        origin_audience_id: originAudienceIdValidated,
         lookalike_spec: JSON.stringify({
           ratio,
           country,
@@ -156,7 +158,7 @@ export function registerAudienceTools(server: McpServer): void {
       if (description) body.description = description;
 
       const result = await metaApiClient.postForm<{ id: string }>(
-        `/${id}/customaudiences`,
+        `/${accountPath}/customaudiences`,
         body,
       );
 
@@ -164,7 +166,7 @@ export function registerAudienceTools(server: McpServer): void {
         content: [
           {
             type: "text",
-            text: `Lookalike audience created!\nID: ${result.id}\nName: ${name}\nSource: ${origin_audience_id}\nRatio: ${(ratio * 100).toFixed(0)}%\nCountry: ${country}`,
+            text: `Lookalike audience created!\nID: ${result.id}\nName: ${name}\nSource: ${originAudienceIdValidated}\nRatio: ${(ratio * 100).toFixed(0)}%\nCountry: ${country}`,
           },
         ],
       };
@@ -179,11 +181,12 @@ export function registerAudienceTools(server: McpServer): void {
       audience_id: z.string().describe("Custom audience ID to delete"),
     },
     async ({ audience_id }) => {
-      await metaApiClient.delete<{ success: boolean }>(`/${audience_id}`);
+      const id = validateMetaId(audience_id, "audience");
+      await metaApiClient.delete<{ success: boolean }>(`/${id}`);
 
       return {
         content: [
-          { type: "text", text: `Audience ${audience_id} deleted successfully.` },
+          { type: "text", text: `Audience ${id} deleted successfully.` },
         ],
       };
     },

--- a/src/tools/budget.ts
+++ b/src/tools/budget.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { metaApiClient } from "../meta/client.js";
+import { validateMetaId } from "../utils/format.js";
 
 export function registerBudgetTools(server: McpServer): void {
   // ─── Create Budget Schedule ──────────────────────────────────
@@ -19,8 +20,9 @@ export function registerBudgetTools(server: McpServer): void {
       time_end: z.string().describe("ISO 8601 end time for the budget increase"),
     },
     async ({ campaign_id, budget_value, budget_value_type, time_start, time_end }) => {
+      const id = validateMetaId(campaign_id, "campaign");
       const result = await metaApiClient.postForm<{ id: string }>(
-        `/${campaign_id}/budget_schedules`,
+        `/${id}/budget_schedules`,
         {
           budget_value,
           budget_value_type,
@@ -33,7 +35,7 @@ export function registerBudgetTools(server: McpServer): void {
         content: [
           {
             type: "text",
-            text: `Budget schedule created!\nID: ${result.id}\nCampaign: ${campaign_id}\nValue: ${budget_value} (${budget_value_type})\nPeriod: ${time_start} → ${time_end}`,
+            text: `Budget schedule created!\nID: ${result.id}\nCampaign: ${id}\nValue: ${budget_value} (${budget_value_type})\nPeriod: ${time_start} → ${time_end}`,
           },
         ],
       };

--- a/src/tools/campaigns.ts
+++ b/src/tools/campaigns.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { metaApiClient } from "../meta/client.js";
-import { normalizeAccountId } from "../utils/format.js";
+import { normalizeAccountId, validateMetaId } from "../utils/format.js";
 import { buildFieldsParam } from "../utils/validation.js";
 import { CAMPAIGN_DEFAULT_FIELDS } from "../meta/types/campaign.js";
 import type { Campaign, MetaApiResponse } from "../meta/types/index.js";
@@ -99,8 +99,9 @@ export function registerCampaignTools(server: McpServer): void {
       fields: z.array(z.string()).optional(),
     },
     async ({ campaign_id, fields }) => {
+      const id = validateMetaId(campaign_id, "campaign");
       const fieldsParam = buildFieldsParam(fields, [...CAMPAIGN_DEFAULT_FIELDS]);
-      const campaign = await metaApiClient.get<Campaign>(`/${campaign_id}`, {
+      const campaign = await metaApiClient.get<Campaign>(`/${id}`, {
         fields: fieldsParam,
       });
 
@@ -196,6 +197,7 @@ export function registerCampaignTools(server: McpServer): void {
       bid_strategy: bidStrategyEnum.optional(),
     },
     async ({ campaign_id, name, status, daily_budget, lifetime_budget, bid_strategy }) => {
+      const id = validateMetaId(campaign_id, "campaign");
       const body: Record<string, string | number | boolean> = {};
       if (name !== undefined) body.name = name;
       if (status !== undefined) body.status = status;
@@ -204,7 +206,7 @@ export function registerCampaignTools(server: McpServer): void {
       if (bid_strategy !== undefined) body.bid_strategy = bid_strategy;
 
       await metaApiClient.postForm<{ success: boolean }>(
-        `/${campaign_id}`,
+        `/${id}`,
         body,
       );
 
@@ -212,7 +214,7 @@ export function registerCampaignTools(server: McpServer): void {
         content: [
           {
             type: "text",
-            text: `Campaign ${campaign_id} updated successfully.\nChanges: ${JSON.stringify(body)}`,
+            text: `Campaign ${id} updated successfully.\nChanges: ${JSON.stringify(body)}`,
           },
         ],
       };
@@ -227,7 +229,8 @@ export function registerCampaignTools(server: McpServer): void {
       campaign_id: z.string().describe("Campaign ID to delete"),
     },
     async ({ campaign_id }) => {
-      await metaApiClient.postForm<{ success: boolean }>(`/${campaign_id}`, {
+      const id = validateMetaId(campaign_id, "campaign");
+      await metaApiClient.postForm<{ success: boolean }>(`/${id}`, {
         status: "DELETED",
       });
 
@@ -235,7 +238,7 @@ export function registerCampaignTools(server: McpServer): void {
         content: [
           {
             type: "text",
-            text: `Campaign ${campaign_id} has been deleted (status set to DELETED).`,
+            text: `Campaign ${id} has been deleted (status set to DELETED).`,
           },
         ],
       };

--- a/src/tools/comments.ts
+++ b/src/tools/comments.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { metaApiClient } from "../meta/client.js";
-import { truncateResponse } from "../utils/format.js";
+import { truncateResponse, validateMetaId } from "../utils/format.js";
 import type { MetaApiResponse } from "../meta/types/index.js";
 
 interface AdComment {
@@ -31,19 +31,22 @@ export function registerCommentTools(server: McpServer): void {
         .describe("Filter: toplevel (only direct comments) or stream (all including replies)"),
     },
     async ({ ad_id, post_id, limit, filter }) => {
-      let objectId = post_id;
+      let objectId = post_id ? validateMetaId(post_id, "post") : undefined;
 
       // If ad_id provided, resolve to effective_object_story_id
       if (!objectId && ad_id) {
+        const adId = validateMetaId(ad_id, "ad");
         const ad = await metaApiClient.get<{ effective_object_story_id?: string }>(
-          `/${ad_id}`,
+          `/${adId}`,
           { fields: "effective_object_story_id" },
         );
-        objectId = ad.effective_object_story_id;
+        objectId = ad.effective_object_story_id
+          ? validateMetaId(ad.effective_object_story_id, "post")
+          : undefined;
         if (!objectId) {
           return {
             content: [
-              { type: "text", text: `Ad ${ad_id} has no associated post (effective_object_story_id not found).` },
+              { type: "text", text: `Ad ${adId} has no associated post (effective_object_story_id not found).` },
             ],
           };
         }
@@ -92,8 +95,9 @@ export function registerCommentTools(server: McpServer): void {
       is_hidden: z.boolean().default(true).describe("true to hide, false to unhide"),
     },
     async ({ comment_id, is_hidden }) => {
+      const id = validateMetaId(comment_id, "post");
       await metaApiClient.postForm<{ success: boolean }>(
-        `/${comment_id}`,
+        `/${id}`,
         { is_hidden },
       );
 
@@ -101,7 +105,7 @@ export function registerCommentTools(server: McpServer): void {
         content: [
           {
             type: "text",
-            text: `Comment ${comment_id} ${is_hidden ? "hidden" : "unhidden"} successfully.`,
+            text: `Comment ${id} ${is_hidden ? "hidden" : "unhidden"} successfully.`,
           },
         ],
       };
@@ -117,8 +121,9 @@ export function registerCommentTools(server: McpServer): void {
       message: z.string().min(1).describe("Reply message text"),
     },
     async ({ comment_id, message }) => {
+      const id = validateMetaId(comment_id, "post");
       const result = await metaApiClient.postForm<{ id: string }>(
-        `/${comment_id}/comments`,
+        `/${id}/comments`,
         { message },
       );
 
@@ -141,11 +146,12 @@ export function registerCommentTools(server: McpServer): void {
       comment_id: z.string().describe("Comment ID to delete"),
     },
     async ({ comment_id }) => {
-      await metaApiClient.delete<{ success: boolean }>(`/${comment_id}`);
+      const id = validateMetaId(comment_id, "post");
+      await metaApiClient.delete<{ success: boolean }>(`/${id}`);
 
       return {
         content: [
-          { type: "text", text: `Comment ${comment_id} deleted successfully.` },
+          { type: "text", text: `Comment ${id} deleted successfully.` },
         ],
       };
     },

--- a/src/tools/creatives.ts
+++ b/src/tools/creatives.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { metaApiClient } from "../meta/client.js";
-import { normalizeAccountId } from "../utils/format.js";
+import { normalizeAccountId, validateMetaId } from "../utils/format.js";
 import { buildFieldsParam } from "../utils/validation.js";
 import { CREATIVE_DEFAULT_FIELDS } from "../meta/types/creative.js";
 import { IMAGE_DEFAULT_FIELDS } from "../meta/types/image.js";
@@ -88,7 +88,7 @@ export function registerCreativeTools(server: McpServer): void {
 
       let path: string;
       if (ad_id) {
-        path = `/${ad_id}/adcreatives`;
+        path = `/${validateMetaId(ad_id, "ad")}/adcreatives`;
       } else if (account_id) {
         path = `/${normalizeAccountId(account_id)}/adcreatives`;
       } else {
@@ -129,8 +129,9 @@ export function registerCreativeTools(server: McpServer): void {
       fields: z.array(z.string()).optional(),
     },
     async ({ creative_id, fields }) => {
+      const id = validateMetaId(creative_id, "creative");
       const fieldsParam = buildFieldsParam(fields, [...CREATIVE_DEFAULT_FIELDS]);
-      const creative = await metaApiClient.get<AdCreative>(`/${creative_id}`, {
+      const creative = await metaApiClient.get<AdCreative>(`/${id}`, {
         fields: fieldsParam,
       });
       const effectiveLinkUrl = extractEffectiveLinkUrl(creative);
@@ -182,32 +183,45 @@ export function registerCreativeTools(server: McpServer): void {
       image_hash, image_url, video_id, link_url, message, headline, description,
       call_to_action_type, url_tags,
     }) => {
-      const id = normalizeAccountId(account_id);
+      const accountPath = normalizeAccountId(account_id);
+      const pageIdValidated = page_id ? validateMetaId(page_id, "page") : undefined;
+      const objectStoryIdValidated = object_story_id
+        ? validateMetaId(object_story_id, "post")
+        : undefined;
+      const instagramActorIdValidated = instagram_actor_id
+        ? validateMetaId(instagram_actor_id, "instagram_actor")
+        : undefined;
+      const sourceInstagramMediaIdValidated = source_instagram_media_id
+        ? validateMetaId(source_instagram_media_id, "instagram_media")
+        : undefined;
+      const videoIdValidated = video_id
+        ? validateMetaId(video_id, "video")
+        : undefined;
 
       const body: Record<string, string | number | boolean> = { name };
 
-      if (source_instagram_media_id) {
+      if (sourceInstagramMediaIdValidated) {
         // Mode 3: Promote an existing Instagram post — NO object_story_spec
         // Docs: https://developers.facebook.com/docs/instagram/ads-api/guides/use-posts-as-ads
-        body.source_instagram_media_id = source_instagram_media_id;
-        if (page_id) body.object_id = page_id;
-        if (instagram_actor_id) body.instagram_user_id = instagram_actor_id;
+        body.source_instagram_media_id = sourceInstagramMediaIdValidated;
+        if (pageIdValidated) body.object_id = pageIdValidated;
+        if (instagramActorIdValidated) body.instagram_user_id = instagramActorIdValidated;
         if (call_to_action_type) {
           body.call_to_action = JSON.stringify({
             type: call_to_action_type,
             value: link_url ? { link: link_url } : undefined,
           });
         }
-      } else if (object_story_id) {
+      } else if (objectStoryIdValidated) {
         // Mode 2: Boost an existing Facebook Page post — NO object_story_spec
-        body.object_story_id = object_story_id;
-        if (instagram_actor_id) body.instagram_user_id = instagram_actor_id;
+        body.object_story_id = objectStoryIdValidated;
+        if (instagramActorIdValidated) body.instagram_user_id = instagramActorIdValidated;
       } else {
         // Mode 1: Build creative from scratch with object_story_spec
-        if (!page_id) {
+        if (!pageIdValidated) {
           throw new Error("page_id is required when building a creative from scratch (no object_story_id or source_instagram_media_id provided).");
         }
-        if (video_id && !image_hash && !image_url) {
+        if (videoIdValidated && !image_hash && !image_url) {
           throw new Error("video creatives built from scratch require image_hash or image_url as a thumbnail.");
         }
         // SSRF guard: only validate image_url when it will actually be
@@ -224,11 +238,11 @@ export function registerCreativeTools(server: McpServer): void {
             throw err;
           }
         }
-        const objectStorySpec: Record<string, unknown> = { page_id };
+        const objectStorySpec: Record<string, unknown> = { page_id: pageIdValidated };
 
-        if (video_id) {
+        if (videoIdValidated) {
           // Video creative — link goes inside CTA, not as top-level field
-          const videoData: Record<string, unknown> = { video_id };
+          const videoData: Record<string, unknown> = { video_id: videoIdValidated };
           if (message) videoData.message = message;
           if (image_hash) videoData.image_hash = image_hash;
           if (image_url && !image_hash) videoData.image_url = image_url;
@@ -258,8 +272,8 @@ export function registerCreativeTools(server: McpServer): void {
           objectStorySpec.link_data = linkData;
         }
 
-        if (instagram_actor_id) {
-          objectStorySpec.instagram_actor_id = instagram_actor_id;
+        if (instagramActorIdValidated) {
+          objectStorySpec.instagram_actor_id = instagramActorIdValidated;
         }
 
         body.object_story_spec = JSON.stringify(objectStorySpec);
@@ -268,7 +282,7 @@ export function registerCreativeTools(server: McpServer): void {
       if (url_tags) body.url_tags = url_tags;
 
       const result = await metaApiClient.postForm<{ id: string }>(
-        `/${id}/adcreatives`,
+        `/${accountPath}/adcreatives`,
         body,
       );
 
@@ -276,7 +290,7 @@ export function registerCreativeTools(server: McpServer): void {
       let effectiveStoryId: string | undefined;
       try {
         const created = await metaApiClient.get<{ id: string; effective_object_story_id?: string }>(
-          `/${result.id}`,
+          `/${validateMetaId(result.id, "creative")}`,
           { fields: "id,effective_object_story_id" },
         );
         effectiveStoryId = created.effective_object_story_id;
@@ -288,7 +302,7 @@ export function registerCreativeTools(server: McpServer): void {
         content: [
           {
             type: "text",
-            text: `Creative created successfully!\nID: ${result.id}\nName: ${name}${page_id ? `\nPage: ${page_id}` : ""}${object_story_id ? `\nBoosted Post: ${object_story_id}` : ""}${source_instagram_media_id ? `\nIG Post: ${source_instagram_media_id}` : ""}${effectiveStoryId ? `\nPost ID: ${effectiveStoryId}` : ""}\nCTA: ${call_to_action_type ?? "N/A"}`,
+            text: `Creative created successfully!\nID: ${result.id}\nName: ${name}${pageIdValidated ? `\nPage: ${pageIdValidated}` : ""}${objectStoryIdValidated ? `\nBoosted Post: ${objectStoryIdValidated}` : ""}${sourceInstagramMediaIdValidated ? `\nIG Post: ${sourceInstagramMediaIdValidated}` : ""}${effectiveStoryId ? `\nPost ID: ${effectiveStoryId}` : ""}\nCTA: ${call_to_action_type ?? "N/A"}`,
           },
         ],
       };
@@ -304,14 +318,15 @@ export function registerCreativeTools(server: McpServer): void {
       name: z.string().optional().describe("New name for the creative"),
     },
     async ({ creative_id, name }) => {
+      const id = validateMetaId(creative_id, "creative");
       const body: Record<string, string | number | boolean> = {};
       if (name !== undefined) body.name = name;
 
-      await metaApiClient.postForm<{ success: boolean }>(`/${creative_id}`, body);
+      await metaApiClient.postForm<{ success: boolean }>(`/${id}`, body);
 
       return {
         content: [
-          { type: "text", text: `Creative ${creative_id} updated successfully.` },
+          { type: "text", text: `Creative ${id} updated successfully.` },
         ],
       };
     },
@@ -479,10 +494,11 @@ export function registerCreativeTools(server: McpServer): void {
       fields: z.array(z.string()).optional(),
     },
     async ({ video_id, fields }) => {
+      const id = validateMetaId(video_id, "video");
       const fieldsParam = buildFieldsParam(fields, [...VIDEO_DETAIL_FIELDS]);
 
       const video = await metaApiClient.get<AdVideo>(
-        `/${video_id}`,
+        `/${id}`,
         { fields: fieldsParam },
       );
 

--- a/src/tools/insights.ts
+++ b/src/tools/insights.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { metaApiClient } from "../meta/client.js";
-import { normalizeAccountId, truncateResponse } from "../utils/format.js";
+import { normalizeAccountId, truncateResponse, validateMetaId } from "../utils/format.js";
 import { buildFieldsParam } from "../utils/validation.js";
 import { INSIGHTS_DEFAULT_FIELDS } from "../meta/types/insights.js";
 import type { InsightsResult, MetaApiResponse } from "../meta/types/index.js";
@@ -82,6 +82,7 @@ export function registerInsightsTools(server: McpServer): void {
       fields, action_attribution_windows, use_unified_attribution_setting,
       filtering, time_increment, limit,
     }) => {
+      const objectId = validateMetaId(object_id, "object");
       enforceInsightsGuardrails({
         level,
         breakdowns,
@@ -112,7 +113,7 @@ export function registerInsightsTools(server: McpServer): void {
       if (time_increment !== undefined) params.time_increment = String(time_increment);
 
       const response = await metaApiClient.get<MetaApiResponse<InsightsResult>>(
-        `/${object_id}/insights`,
+        `/${objectId}/insights`,
         params,
       );
 

--- a/src/tools/instagram.ts
+++ b/src/tools/instagram.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { metaApiClient } from "../meta/client.js";
+import { validateMetaId } from "../utils/format.js";
 import {
   INSTAGRAM_ACCOUNT_FIELDS,
   INSTAGRAM_MEDIA_DEFAULT_FIELDS,
@@ -20,12 +21,13 @@ export function registerInstagramTools(server: McpServer): void {
       page_id: z.string().describe("Facebook Page ID to look up its linked Instagram Business account"),
     },
     async ({ page_id }) => {
+      const id = validateMetaId(page_id, "page");
       // Request the page with nested instagram_business_account fields
       const nestedFields = INSTAGRAM_ACCOUNT_FIELDS.join(",");
       const result = await metaApiClient.get<{
         instagram_business_account?: InstagramAccount;
         id: string;
-      }>(`/${page_id}`, {
+      }>(`/${id}`, {
         fields: `instagram_business_account{${nestedFields}}`,
       });
 
@@ -36,7 +38,7 @@ export function registerInstagramTools(server: McpServer): void {
           content: [
             {
               type: "text",
-              text: `No Instagram Business account linked to Page ${page_id}. Ensure the Page has an Instagram Business or Creator account connected in Page Settings.`,
+              text: `No Instagram Business account linked to Page ${id}. Ensure the Page has an Instagram Business or Creator account connected in Page Settings.`,
             },
           ],
         };
@@ -63,10 +65,11 @@ export function registerInstagramTools(server: McpServer): void {
       limit: z.number().min(1).max(100).default(25).describe("Number of posts to return"),
     },
     async ({ instagram_account_id, limit }) => {
+      const id = validateMetaId(instagram_account_id, "instagram_account");
       const fieldsParam = [...INSTAGRAM_MEDIA_DEFAULT_FIELDS].join(",");
 
       const response = await metaApiClient.get<MetaApiResponse<InstagramMedia>>(
-        `/${instagram_account_id}/media`,
+        `/${id}/media`,
         { fields: fieldsParam, limit },
       );
 

--- a/src/tools/leads.ts
+++ b/src/tools/leads.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { metaApiClient } from "../meta/client.js";
 import { buildFieldsParam } from "../utils/validation.js";
-import { truncateResponse } from "../utils/format.js";
+import { truncateResponse, validateMetaId } from "../utils/format.js";
 import { LEAD_FORM_DEFAULT_FIELDS, LEAD_DEFAULT_FIELDS } from "../meta/types/lead.js";
 import type { LeadForm, Lead, MetaApiResponse } from "../meta/types/index.js";
 
@@ -17,10 +17,11 @@ export function registerLeadTools(server: McpServer): void {
       fields: z.array(z.string()).optional().describe("Fields to retrieve"),
     },
     async ({ page_id, limit, fields }) => {
+      const id = validateMetaId(page_id, "page");
       const fieldsParam = buildFieldsParam(fields, [...LEAD_FORM_DEFAULT_FIELDS]);
 
       const response = await metaApiClient.get<MetaApiResponse<LeadForm>>(
-        `/${page_id}/leadgen_forms`,
+        `/${id}/leadgen_forms`,
         { fields: fieldsParam, limit },
       );
       const forms = response.data ?? [];
@@ -64,6 +65,7 @@ export function registerLeadTools(server: McpServer): void {
         .describe("Filter leads (e.g., by time_created)"),
     },
     async ({ form_id, limit, fields, filtering }) => {
+      const id = validateMetaId(form_id, "lead_form");
       const fieldsParam = buildFieldsParam(fields, [...LEAD_DEFAULT_FIELDS]);
 
       const params: Record<string, string | number | boolean> = {
@@ -76,7 +78,7 @@ export function registerLeadTools(server: McpServer): void {
       }
 
       const response = await metaApiClient.get<MetaApiResponse<Lead>>(
-        `/${form_id}/leads`,
+        `/${id}/leads`,
         params,
       );
       const leads = response.data ?? [];
@@ -121,17 +123,18 @@ export function registerLeadTools(server: McpServer): void {
       fields: z.array(z.string()).optional(),
     },
     async ({ ad_id, limit, fields }) => {
+      const id = validateMetaId(ad_id, "ad");
       const fieldsParam = buildFieldsParam(fields, [...LEAD_DEFAULT_FIELDS]);
 
       const response = await metaApiClient.get<MetaApiResponse<Lead>>(
-        `/${ad_id}/leads`,
+        `/${id}/leads`,
         { fields: fieldsParam, limit },
       );
       const leads = response.data ?? [];
 
       if (leads.length === 0) {
         return {
-          content: [{ type: "text", text: `No leads found for ad ${ad_id}.` }],
+          content: [{ type: "text", text: `No leads found for ad ${id}.` }],
         };
       }
 
@@ -139,7 +142,7 @@ export function registerLeadTools(server: McpServer): void {
 
       return {
         content: [
-          { type: "text", text: `Found ${leads.length} lead(s) for ad ${ad_id}.` },
+          { type: "text", text: `Found ${leads.length} lead(s) for ad ${id}.` },
           { type: "text", text: jsonStr },
         ],
       };
@@ -167,6 +170,7 @@ export function registerLeadTools(server: McpServer): void {
       locale: z.string().optional().describe("Form locale (e.g., en_US)"),
     },
     async ({ page_id, name, questions, privacy_policy_url, follow_up_action_url, locale }) => {
+      const id = validateMetaId(page_id, "page");
       const body: Record<string, string | number | boolean> = {
         name,
         questions: JSON.stringify(questions),
@@ -177,7 +181,7 @@ export function registerLeadTools(server: McpServer): void {
       if (locale) body.locale = locale;
 
       const result = await metaApiClient.postForm<{ id: string }>(
-        `/${page_id}/leadgen_forms`,
+        `/${id}/leadgen_forms`,
         body,
       );
 
@@ -185,7 +189,7 @@ export function registerLeadTools(server: McpServer): void {
         content: [
           {
             type: "text",
-            text: `Lead form created successfully!\nID: ${result.id}\nName: ${name}\nQuestions: ${questions.length}\nPage: ${page_id}`,
+            text: `Lead form created successfully!\nID: ${result.id}\nName: ${name}\nQuestions: ${questions.length}\nPage: ${id}`,
           },
         ],
       };

--- a/src/tools/pixels.ts
+++ b/src/tools/pixels.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { metaApiClient } from "../meta/client.js";
-import { normalizeAccountId } from "../utils/format.js";
+import { normalizeAccountId, validateMetaId } from "../utils/format.js";
 import { buildFieldsParam } from "../utils/validation.js";
 import {
   PIXEL_DEFAULT_FIELDS,
@@ -60,10 +60,11 @@ export function registerPixelTools(server: McpServer): void {
       fields: z.array(z.string()).optional(),
     },
     async ({ pixel_id, fields }) => {
+      const id = validateMetaId(pixel_id, "pixel");
       const fieldsParam = buildFieldsParam(fields, [...PIXEL_DEFAULT_FIELDS]);
 
       const pixel = await metaApiClient.get<AdsPixel>(
-        `/${pixel_id}`,
+        `/${id}`,
         { fields: fieldsParam },
       );
 
@@ -100,6 +101,7 @@ export function registerPixelTools(server: McpServer): void {
       end_time: z.string().optional().describe("End time (ISO 8601 or Unix timestamp)"),
     },
     async ({ pixel_id, aggregation, start_time, end_time }) => {
+      const id = validateMetaId(pixel_id, "pixel");
       const params: Record<string, string | number | boolean> = {
         aggregation,
       };
@@ -107,14 +109,14 @@ export function registerPixelTools(server: McpServer): void {
       if (end_time) params.end_time = end_time;
 
       const response = await metaApiClient.get<{ data: Array<{ event: string; count: number; value?: number }> }>(
-        `/${pixel_id}/stats`,
+        `/${id}/stats`,
         params,
       );
       const stats = response.data ?? [];
 
       if (stats.length === 0) {
         return {
-          content: [{ type: "text", text: `No event data for pixel ${pixel_id} in the specified period.` }],
+          content: [{ type: "text", text: `No event data for pixel ${id} in the specified period.` }],
         };
       }
 
@@ -196,11 +198,12 @@ export function registerPixelTools(server: McpServer): void {
       default_conversion_value: z.number().optional().describe("Default monetary value"),
     },
     async ({ account_id, name, description, pixel_id, event_source_type, custom_event_type, rule, default_conversion_value }) => {
-      const id = normalizeAccountId(account_id);
+      const accountPath = normalizeAccountId(account_id);
+      const pixelIdValidated = validateMetaId(pixel_id, "pixel");
 
       const body: Record<string, string | number | boolean> = {
         name,
-        pixel_id,
+        pixel_id: pixelIdValidated,
         event_source_type,
         custom_event_type,
         rule,
@@ -210,7 +213,7 @@ export function registerPixelTools(server: McpServer): void {
       if (default_conversion_value !== undefined) body.default_conversion_value = default_conversion_value;
 
       const result = await metaApiClient.postForm<{ id: string }>(
-        `/${id}/customconversions`,
+        `/${accountPath}/customconversions`,
         body,
       );
 
@@ -218,7 +221,7 @@ export function registerPixelTools(server: McpServer): void {
         content: [
           {
             type: "text",
-            text: `Custom conversion created!\nID: ${result.id}\nName: ${name}\nEvent: ${custom_event_type}\nPixel: ${pixel_id}`,
+            text: `Custom conversion created!\nID: ${result.id}\nName: ${name}\nEvent: ${custom_event_type}\nPixel: ${pixelIdValidated}`,
           },
         ],
       };

--- a/src/tools/previews.ts
+++ b/src/tools/previews.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { metaApiClient } from "../meta/client.js";
-import { normalizeAccountId } from "../utils/format.js";
+import { normalizeAccountId, validateMetaId } from "../utils/format.js";
 import type { MetaApiResponse } from "../meta/types/index.js";
 
 const adFormatEnum = z.enum([
@@ -56,8 +56,9 @@ export function registerPreviewTools(server: McpServer): void {
       ad_format: adFormatEnum.default("MOBILE_FEED_STANDARD").describe("Ad placement format"),
     },
     async ({ ad_id, ad_format }) => {
+      const id = validateMetaId(ad_id, "ad");
       const response = await metaApiClient.get<MetaApiResponse<AdPreview>>(
-        `/${ad_id}/previews`,
+        `/${id}/previews`,
         { ad_format },
       );
       const previews = response.data ?? [];
@@ -142,10 +143,22 @@ export function registerPreviewTools(server: McpServer): void {
         .describe("Creative specification"),
     },
     async ({ account_id, ad_format, creative }) => {
-      const id = normalizeAccountId(account_id);
+      const accountPath = normalizeAccountId(account_id);
+      if (creative.object_story_spec?.page_id) {
+        creative.object_story_spec.page_id = validateMetaId(
+          creative.object_story_spec.page_id,
+          "page",
+        );
+      }
+      if (creative.object_story_spec?.video_data?.video_id) {
+        creative.object_story_spec.video_data.video_id = validateMetaId(
+          creative.object_story_spec.video_data.video_id,
+          "video",
+        );
+      }
 
       const response = await metaApiClient.get<MetaApiResponse<AdPreview>>(
-        `/${id}/generatepreviews`,
+        `/${accountPath}/generatepreviews`,
         {
           ad_format,
           creative: JSON.stringify(creative),

--- a/src/tools/reports.ts
+++ b/src/tools/reports.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { metaApiClient } from "../meta/client.js";
-import { truncateResponse } from "../utils/format.js";
+import { truncateResponse, validateMetaId } from "../utils/format.js";
 import { buildFieldsParam } from "../utils/validation.js";
 import { INSIGHTS_DEFAULT_FIELDS } from "../meta/types/insights.js";
 import type { InsightsResult, MetaApiResponse } from "../meta/types/index.js";
@@ -90,6 +90,7 @@ export function registerReportTools(server: McpServer): void {
       object_id, level, time_range, date_preset, breakdowns, fields,
       use_unified_attribution_setting, time_increment,
     }) => {
+      const objectId = validateMetaId(object_id, "object");
       enforceInsightsGuardrails({
         level,
         breakdowns,
@@ -109,7 +110,7 @@ export function registerReportTools(server: McpServer): void {
       if (time_increment !== undefined) params.time_increment = String(time_increment);
 
       const result = await metaApiClient.postForm<AsyncReportRun>(
-        `/${object_id}/insights`,
+        `/${objectId}/insights`,
         params,
       );
 
@@ -134,17 +135,18 @@ export function registerReportTools(server: McpServer): void {
       report_run_id: z.string().describe("Report run ID from create_async_report"),
     },
     async ({ report_run_id }) => {
-      enforceMinPollInterval(report_run_id);
+      const id = validateMetaId(report_run_id, "report_run");
+      enforceMinPollInterval(id);
 
       const status = await metaApiClient.get<ReportRunStatus>(
-        `/${report_run_id}`,
+        `/${id}`,
         {
           fields:
             "id,async_status,async_percent_completion,date_start,date_stop,error_code,error_subcode,error_message,error_user_title,error_user_msg",
         },
       );
 
-      return { content: [{ type: "text", text: formatStatus(report_run_id, status) }] };
+      return { content: [{ type: "text", text: formatStatus(id, status) }] };
     },
   );
 
@@ -157,8 +159,9 @@ export function registerReportTools(server: McpServer): void {
       limit: z.number().min(1).max(1000).default(500),
     },
     async ({ report_run_id, limit }) => {
+      const id = validateMetaId(report_run_id, "report_run");
       const response = await metaApiClient.get<MetaApiResponse<InsightsResult>>(
-        `/${report_run_id}/insights`,
+        `/${id}/insights`,
         { limit },
       );
       const results = response.data ?? [];
@@ -222,6 +225,7 @@ export function registerReportTools(server: McpServer): void {
       use_unified_attribution_setting, time_increment,
       max_wait_seconds, poll_interval_seconds, result_limit,
     }) => {
+      const objectId = validateMetaId(object_id, "object");
       enforceInsightsGuardrails({
         level,
         breakdowns,
@@ -240,10 +244,10 @@ export function registerReportTools(server: McpServer): void {
       if (time_increment !== undefined) params.time_increment = String(time_increment);
 
       const created = await metaApiClient.postForm<AsyncReportRun>(
-        `/${object_id}/insights`,
+        `/${objectId}/insights`,
         params,
       );
-      const reportId = created.report_run_id ?? created.id;
+      const reportId = validateMetaId(created.report_run_id ?? created.id, "report_run");
 
       const deadline = Date.now() + max_wait_seconds * 1000;
       let interval = Math.max(MIN_POLL_INTERVAL_MS, poll_interval_seconds * 1000);

--- a/src/tools/rules.ts
+++ b/src/tools/rules.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { metaApiClient } from "../meta/client.js";
-import { normalizeAccountId, truncateResponse } from "../utils/format.js";
+import { normalizeAccountId, truncateResponse, validateMetaId } from "../utils/format.js";
 import { buildFieldsParam } from "../utils/validation.js";
 import { RULE_DEFAULT_FIELDS } from "../meta/types/rule.js";
 import type { AdRule, AdRuleHistory, MetaApiResponse } from "../meta/types/index.js";
@@ -136,10 +136,11 @@ export function registerRuleTools(server: McpServer): void {
       include_history: z.boolean().default(false).describe("Include rule execution history"),
     },
     async ({ rule_id, fields, include_history }) => {
+      const id = validateMetaId(rule_id, "rule");
       const fieldsParam = buildFieldsParam(fields, [...RULE_DEFAULT_FIELDS]);
 
       const rule = await metaApiClient.get<AdRule>(
-        `/${rule_id}`,
+        `/${id}`,
         { fields: fieldsParam },
       );
 
@@ -153,7 +154,7 @@ export function registerRuleTools(server: McpServer): void {
 
       if (include_history) {
         const historyResponse = await metaApiClient.get<MetaApiResponse<AdRuleHistory>>(
-          `/${rule_id}/history`,
+          `/${id}/history`,
           { limit: 50 },
         );
         const history = historyResponse.data ?? [];
@@ -207,17 +208,18 @@ export function registerRuleTools(server: McpServer): void {
         .optional(),
     },
     async ({ rule_id, name, status, evaluation_spec, execution_spec }) => {
+      const id = validateMetaId(rule_id, "rule");
       const body: Record<string, string | number | boolean> = {};
       if (name) body.name = name;
       if (status) body.status = status;
       if (evaluation_spec) body.evaluation_spec = JSON.stringify(evaluation_spec);
       if (execution_spec) body.execution_spec = JSON.stringify(execution_spec);
 
-      await metaApiClient.postForm<{ success: boolean }>(`/${rule_id}`, body);
+      await metaApiClient.postForm<{ success: boolean }>(`/${id}`, body);
 
       return {
         content: [
-          { type: "text", text: `Rule ${rule_id} updated successfully.` },
+          { type: "text", text: `Rule ${id} updated successfully.` },
         ],
       };
     },
@@ -231,11 +233,12 @@ export function registerRuleTools(server: McpServer): void {
       rule_id: z.string().describe("Rule ID to delete"),
     },
     async ({ rule_id }) => {
-      await metaApiClient.delete<{ success: boolean }>(`/${rule_id}`);
+      const id = validateMetaId(rule_id, "rule");
+      await metaApiClient.delete<{ success: boolean }>(`/${id}`);
 
       return {
         content: [
-          { type: "text", text: `Rule ${rule_id} deleted successfully.` },
+          { type: "text", text: `Rule ${id} deleted successfully.` },
         ],
       };
     },

--- a/src/tools/targeting.ts
+++ b/src/tools/targeting.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { metaApiClient } from "../meta/client.js";
-import { normalizeAccountId } from "../utils/format.js";
+import { normalizeAccountId, validateMetaId } from "../utils/format.js";
 import type {
   Interest,
   Behavior,
@@ -277,7 +277,7 @@ export function registerTargetingTools(server: McpServer): void {
       const params: Record<string, string | number | boolean> = {};
 
       if (ad_id) {
-        path = `/${ad_id}/targetingsentencelines`;
+        path = `/${validateMetaId(ad_id, "ad")}/targetingsentencelines`;
       } else if (account_id && targeting_spec) {
         const id = normalizeAccountId(account_id);
         path = `/${id}/targetingsentencelines`;

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -34,9 +34,9 @@ export function normalizeAccountId(id: string): string {
  * than letting a malformed id leak into a path segment or bucket name.
  */
 export function validateMetaId(id: string, kind = "id"): string {
-  if (typeof id !== "string" || !/^(act_)?\d{1,30}(_\d{1,30})?$/.test(id)) {
+  if (typeof id !== "string" || !/^(act_\d{1,30}|\d{1,30}(_\d{1,30})?)$/.test(id)) {
     throw new Error(
-      `Invalid Meta ${kind}: must be numeric, optionally prefixed with "act_" (account) or postfixed with "_<id>" (post/comment). Got: ${JSON.stringify(id).slice(0, 80)}`,
+      `Invalid Meta ${kind}: must be numeric, "act_<numeric>" (account), or "<numeric>_<numeric>" (post/comment) — the three formats are mutually exclusive. Got: ${JSON.stringify(id).slice(0, 80)}`,
     );
   }
   return id;

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -16,8 +16,17 @@ export function normalizeAccountId(id: string): string {
 }
 
 /**
- * Validate a Meta resource ID (campaign, adset, ad, creative, page, business…).
- * Meta IDs are always purely numeric strings of variable length.
+ * Validate a Meta resource ID before it is interpolated into a Graph API
+ * path. Accepts the three formats Meta uses for path segments:
+ *   - Plain numeric id: `1234567890` (campaign, adset, ad, creative, page,
+ *     business, audience, rule, pixel, study, lead form, video, user…).
+ *   - Ad account id: `act_1234567890` (insights/reports `object_id`).
+ *   - Post or comment id: `1234567890_9876543210` — Meta's
+ *     `effective_object_story_id` and per-page comment ids embed the page
+ *     id and the post/comment id separated by an underscore.
+ *
+ * Reject anything else so a crafted id can't smuggle path traversal,
+ * query strings, or whitespace into the URL of a subsequent fetch.
  *
  * Use at the boundary of any tool that takes an id from a caller and
  * forwards it into a Meta API path or a rate-limiter bucket key. Throws
@@ -25,9 +34,9 @@ export function normalizeAccountId(id: string): string {
  * than letting a malformed id leak into a path segment or bucket name.
  */
 export function validateMetaId(id: string, kind = "id"): string {
-  if (typeof id !== "string" || !/^\d{1,30}$/.test(id)) {
+  if (typeof id !== "string" || !/^(act_)?\d{1,30}(_\d{1,30})?$/.test(id)) {
     throw new Error(
-      `Invalid Meta ${kind}: must be a numeric string. Got: ${JSON.stringify(id).slice(0, 80)}`,
+      `Invalid Meta ${kind}: must be numeric, optionally prefixed with "act_" (account) or postfixed with "_<id>" (post/comment). Got: ${JSON.stringify(id).slice(0, 80)}`,
     );
   }
   return id;

--- a/tests/tools/accounts.test.ts
+++ b/tests/tools/accounts.test.ts
@@ -123,7 +123,7 @@ describe("registerAccountTools", () => {
 
       const mockData = {
         data: [
-          { id: "page_1", name: "My Page", category: "Business" },
+          { id: "6001", name: "My Page", category: "Business" },
         ],
       };
 

--- a/tests/tools/adsets.test.ts
+++ b/tests/tools/adsets.test.ts
@@ -44,9 +44,9 @@ describe("registerAdSetTools", () => {
       registerAdSetTools(server as never);
 
       vi.stubGlobal("fetch", vi.fn().mockResolvedValue(mockFetchResponse({
-        id: "adset_1",
+        id: "2001",
         name: "Honduras - Mujeres",
-        campaign_id: "camp_1",
+        campaign_id: "1001",
         status: "PAUSED",
         effective_status: "PAUSED",
         promoted_object: { pixel_id: "px_1" },
@@ -54,7 +54,7 @@ describe("registerAdSetTools", () => {
 
       const handler = server._registeredTools[1].handler;
       const result = await handler({
-        adset_id: "adset_1",
+        adset_id: "2001",
         fields: ["promoted_object"],
       }) as { content: Array<{ type: string; text: string }> };
 
@@ -82,9 +82,9 @@ describe("registerAdSetTools", () => {
 
       vi.stubGlobal("fetch", vi.fn()
         .mockResolvedValueOnce(mockFetchResponse({
-          id: "adset_src",
+          id: "2099",
           name: "Honduras - Mujeres",
-          campaign_id: "camp_1",
+          campaign_id: "1001",
           status: "ACTIVE",
           effective_status: "ACTIVE",
           daily_budget: "500",
@@ -106,27 +106,27 @@ describe("registerAdSetTools", () => {
         .mockResolvedValueOnce(mockFetchResponse({
           data: [
             {
-              id: "ad_1",
+              id: "3001",
               name: "Honduras - Mujeres__flyer_1",
-              adset_id: "adset_src",
-              campaign_id: "camp_1",
+              adset_id: "2099",
+              campaign_id: "1001",
               status: "ACTIVE",
               effective_status: "ACTIVE",
-              creative: { id: "crt_1" },
+              creative: { id: "4001" },
               created_time: "2026-03-01T00:00:00-0500",
               updated_time: "2026-03-01T00:00:00-0500",
             },
           ],
         }))
         .mockResolvedValueOnce(mockFetchResponse({
-          id: "crt_1",
+          id: "4001",
           name: "Creative HN",
           title: "Original headline",
           body: "Original message",
           image_hash: "img_hash_1",
           call_to_action_type: "APPLY_NOW",
           object_story_spec: {
-            page_id: "page_1",
+            page_id: "6001",
             link_data: {
               link: "https://ugc.byads.co/",
               message: "Original message",
@@ -144,7 +144,7 @@ describe("registerAdSetTools", () => {
       const handler = server._registeredTools[2].handler;
       const result = await handler({
         account_id: "act_123",
-        source_adset_id: "adset_src",
+        source_adset_id: "2099",
         target_adset: {
           name: "Chile - Mujeres",
           geo_override: { countries: ["CL"] },
@@ -156,7 +156,7 @@ describe("registerAdSetTools", () => {
         },
         creative_overrides: [
           {
-            source_ad_id: "ad_1",
+            source_ad_id: "3001",
             headline: "Headline Chile",
             message: "Mensaje Chile",
             description: "Descripcion Chile",
@@ -192,9 +192,9 @@ describe("registerAdSetTools", () => {
 
       vi.stubGlobal("fetch", vi.fn()
         .mockResolvedValueOnce(mockFetchResponse({
-          id: "adset_src_exec",
+          id: "2999",
           name: "Honduras - Mujeres",
-          campaign_id: "camp_1",
+          campaign_id: "1001",
           status: "ACTIVE",
           effective_status: "ACTIVE",
           daily_budget: "500",
@@ -210,27 +210,27 @@ describe("registerAdSetTools", () => {
         .mockResolvedValueOnce(mockFetchResponse({
           data: [
             {
-              id: "ad_exec_1",
+              id: "3099",
               name: "Honduras - Mujeres__flyer_1",
-              adset_id: "adset_src_exec",
-              campaign_id: "camp_1",
+              adset_id: "2999",
+              campaign_id: "1001",
               status: "ACTIVE",
               effective_status: "ACTIVE",
-              creative: { id: "crt_exec_1" },
+              creative: { id: "4999" },
               created_time: "2026-03-01T00:00:00-0500",
               updated_time: "2026-03-01T00:00:00-0500",
             },
           ],
         }))
         .mockResolvedValueOnce(mockFetchResponse({
-          id: "crt_exec_1",
+          id: "4999",
           name: "Creative HN",
           title: "Original headline",
           body: "Original message",
           image_hash: "img_hash_1",
           call_to_action_type: "APPLY_NOW",
           object_story_spec: {
-            page_id: "page_1",
+            page_id: "6001",
             link_data: {
               link: "https://ugc.byads.co/",
               message: "Original message",
@@ -244,14 +244,14 @@ describe("registerAdSetTools", () => {
             },
           },
         }))
-        .mockResolvedValueOnce(mockFetchResponse({ id: "adset_new_1" }))
-        .mockResolvedValueOnce(mockFetchResponse({ id: "crt_new_1" }))
-        .mockResolvedValueOnce(mockFetchResponse({ id: "ad_new_1" })));
+        .mockResolvedValueOnce(mockFetchResponse({ id: "20001" }))
+        .mockResolvedValueOnce(mockFetchResponse({ id: "40001" }))
+        .mockResolvedValueOnce(mockFetchResponse({ id: "30001" })));
 
       const handler = server._registeredTools[2].handler;
       const input = {
         account_id: "act_123",
-        source_adset_id: "adset_src_exec",
+        source_adset_id: "2999",
         target_adset: {
           name: "Chile - Mujeres",
           geo_override: { countries: ["CL"] },
@@ -263,7 +263,7 @@ describe("registerAdSetTools", () => {
         },
         creative_overrides: [
           {
-            source_ad_id: "ad_exec_1",
+            source_ad_id: "3099",
             headline: "Headline Chile",
             message: "Mensaje Chile",
             description: "Descripcion Chile",
@@ -281,9 +281,9 @@ describe("registerAdSetTools", () => {
         created_ads: Array<{ id?: string }>;
       };
 
-      expect(firstPayload.new_adset.id).toBe("adset_new_1");
-      expect(firstPayload.created_creatives[0]?.id).toBe("crt_new_1");
-      expect(firstPayload.created_ads[0]?.id).toBe("ad_new_1");
+      expect(firstPayload.new_adset.id).toBe("20001");
+      expect(firstPayload.created_creatives[0]?.id).toBe("40001");
+      expect(firstPayload.created_ads[0]?.id).toBe("30001");
       expect(vi.mocked(fetch)).toHaveBeenCalledTimes(6);
 
       const second = await handler(input) as { content: Array<{ type: string; text: string }> };

--- a/tests/tools/campaigns.test.ts
+++ b/tests/tools/campaigns.test.ts
@@ -39,7 +39,7 @@ describe("registerCampaignTools", () => {
       const mockData = {
         data: [
           {
-            id: "camp_1",
+            id: "1001",
             name: "Campaign 1",
             status: "ACTIVE",
             objective: "OUTCOME_TRAFFIC",
@@ -90,7 +90,7 @@ describe("registerCampaignTools", () => {
       const server = createMockMcpServer();
       registerCampaignTools(server as never);
 
-      vi.stubGlobal("fetch", vi.fn().mockResolvedValue(mockFetchResponse({ id: "camp_new_123" })));
+      vi.stubGlobal("fetch", vi.fn().mockResolvedValue(mockFetchResponse({ id: "1000123" })));
 
       const handler = server._registeredTools[2].handler;
       const result = await handler({
@@ -106,7 +106,7 @@ describe("registerCampaignTools", () => {
       }) as { content: Array<{ type: string; text: string }> };
 
       expect(result.content[0].text).toContain("Campaign created successfully");
-      expect(result.content[0].text).toContain("camp_new_123");
+      expect(result.content[0].text).toContain("1000123");
     });
   });
 
@@ -119,7 +119,7 @@ describe("registerCampaignTools", () => {
 
       const handler = server._registeredTools[3].handler;
       const result = await handler({
-        campaign_id: "camp_123",
+        campaign_id: "100123",
         name: "Updated Name",
         status: "PAUSED",
         daily_budget: undefined,
@@ -139,12 +139,12 @@ describe("registerCampaignTools", () => {
       vi.stubGlobal("fetch", vi.fn().mockResolvedValue(mockFetchResponse({ success: true })));
 
       const handler = server._registeredTools[4].handler;
-      const result = await handler({ campaign_id: "camp_123" }) as {
+      const result = await handler({ campaign_id: "100123" }) as {
         content: Array<{ type: string; text: string }>;
       };
 
       expect(result.content[0].text).toContain("deleted");
-      expect(result.content[0].text).toContain("camp_123");
+      expect(result.content[0].text).toContain("100123");
 
       // Verify status is set to DELETED in the form body
       const call = vi.mocked(fetch).mock.calls[0];

--- a/tests/tools/creatives.test.ts
+++ b/tests/tools/creatives.test.ts
@@ -47,28 +47,28 @@ describe("registerCreativeTools", () => {
       registerCreativeTools(server as never);
 
       const mockCreative = {
-        id: "crt_123",
+        id: "40123",
         name: "Spring Creative",
         status: "ACTIVE",
         call_to_action_type: "LEARN_MORE",
         link_url: "https://example.com",
-        effective_object_story_id: "page_1_post_9",
+        effective_object_story_id: "6001_9",
       };
 
       vi.stubGlobal("fetch", vi.fn().mockResolvedValue(mockFetchResponse(mockCreative)));
 
       const handler = server._registeredTools[1].handler;
       const result = await handler({
-        creative_id: "crt_123",
+        creative_id: "40123",
         fields: undefined,
       }) as { content: Array<{ type: string; text: string }> };
 
-      expect(result.content[0].text).toContain("Creative: Spring Creative (crt_123)");
+      expect(result.content[0].text).toContain("Creative: Spring Creative (40123)");
       expect(result.content[0].text).toContain("Status: ACTIVE");
       expect(result.content[0].text).toContain("CTA: LEARN_MORE");
 
       const url = new URL(vi.mocked(fetch).mock.calls[0][0] as string);
-      expect(url.pathname).toContain("/crt_123");
+      expect(url.pathname).toContain("/40123");
       expect(url.searchParams.get("fields")).toBe(
         "id,name,title,body,image_hash,image_url,thumbnail_url,object_story_spec,asset_feed_spec,call_to_action_type,link_url,effective_link_url,effective_object_story_id,status",
       );
@@ -79,13 +79,13 @@ describe("registerCreativeTools", () => {
       registerCreativeTools(server as never);
 
       vi.stubGlobal("fetch", vi.fn().mockResolvedValue(mockFetchResponse({
-        id: "crt_999",
+        id: "40999",
         name: "Custom Fields Creative",
       })));
 
       const handler = server._registeredTools[1].handler;
       await handler({
-        creative_id: "crt_999",
+        creative_id: "40999",
         fields: ["id", "name"],
       });
 
@@ -98,14 +98,14 @@ describe("registerCreativeTools", () => {
       registerCreativeTools(server as never);
 
       vi.stubGlobal("fetch", vi.fn().mockResolvedValue(mockFetchResponse({
-        id: "crt_video",
+        id: "4099",
         name: "Video Creative",
         status: "ACTIVE",
         call_to_action_type: "APPLY_NOW",
         object_story_spec: {
-          page_id: "page_1",
+          page_id: "6001",
           video_data: {
-            video_id: "vid_1",
+            video_id: "8001",
             call_to_action: {
               type: "APPLY_NOW",
               value: { link: "https://ugc.byads.co/chile" },
@@ -116,7 +116,7 @@ describe("registerCreativeTools", () => {
 
       const handler = server._registeredTools[1].handler;
       const result = await handler({
-        creative_id: "crt_video",
+        creative_id: "4099",
         fields: undefined,
       }) as { content: Array<{ type: string; text: string }> };
 
@@ -136,8 +136,8 @@ describe("registerCreativeTools", () => {
       await expect(handler({
         account_id: "act_123",
         name: "Video sin thumb",
-        page_id: "page_1",
-        video_id: "vid_123",
+        page_id: "6001",
+        video_id: "800123",
         image_hash: undefined,
         image_url: undefined,
         link_url: "https://example.com",

--- a/tests/tools/insights.test.ts
+++ b/tests/tools/insights.test.ts
@@ -53,7 +53,7 @@ describe("registerInsightsTools", () => {
 
       const handler = server._registeredTools[0].handler;
       const result = await handler({
-        object_id: "camp_123",
+        object_id: "100123",
         level: undefined,
         time_range: undefined,
         date_preset: "last_30d",
@@ -77,7 +77,7 @@ describe("registerInsightsTools", () => {
 
       const handler = server._registeredTools[0].handler;
       const result = await handler({
-        object_id: "camp_123",
+        object_id: "100123",
         level: undefined,
         time_range: undefined,
         date_preset: undefined,
@@ -113,7 +113,7 @@ describe("registerInsightsTools", () => {
 
       const handler = server._registeredTools[0].handler;
       const result = await handler({
-        object_id: "camp_123",
+        object_id: "100123",
         level: undefined,
         time_range: undefined,
         date_preset: undefined,

--- a/tests/tools/leads.test.ts
+++ b/tests/tools/leads.test.ts
@@ -38,7 +38,7 @@ describe("registerLeadTools", () => {
       const mockData = {
         data: [
           {
-            id: "form_1",
+            id: "5001",
             name: "Contact Form",
             status: "ACTIVE",
             leads_count: 150,
@@ -50,7 +50,7 @@ describe("registerLeadTools", () => {
 
       const handler = server._registeredTools[0].handler;
       const result = await handler({
-        page_id: "page_123",
+        page_id: "60123",
         limit: 25,
         fields: undefined,
       }) as { content: Array<{ type: string; text: string }> };
@@ -69,7 +69,7 @@ describe("registerLeadTools", () => {
       const mockData = {
         data: [
           {
-            id: "lead_1",
+            id: "7001",
             created_time: "2024-01-15T10:00:00",
             field_data: [
               { name: "email", values: ["test@example.com"] },
@@ -83,7 +83,7 @@ describe("registerLeadTools", () => {
 
       const handler = server._registeredTools[1].handler;
       const result = await handler({
-        form_id: "form_1",
+        form_id: "5001",
         limit: 100,
         fields: undefined,
         filtering: undefined,
@@ -101,7 +101,7 @@ describe("registerLeadTools", () => {
 
       const handler = server._registeredTools[1].handler;
       const result = await handler({
-        form_id: "form_1",
+        form_id: "5001",
         limit: 100,
         fields: undefined,
         filtering: undefined,
@@ -116,11 +116,11 @@ describe("registerLeadTools", () => {
       const server = createMockMcpServer();
       registerLeadTools(server as never);
 
-      vi.stubGlobal("fetch", vi.fn().mockResolvedValue(mockFetchResponse({ id: "form_new_1" })));
+      vi.stubGlobal("fetch", vi.fn().mockResolvedValue(mockFetchResponse({ id: "50001" })));
 
       const handler = server._registeredTools[3].handler;
       const result = await handler({
-        page_id: "page_123",
+        page_id: "60123",
         name: "New Form",
         questions: [
           { type: "EMAIL" },
@@ -132,7 +132,7 @@ describe("registerLeadTools", () => {
       }) as { content: Array<{ type: string; text: string }> };
 
       expect(result.content[0].text).toContain("Lead form created successfully");
-      expect(result.content[0].text).toContain("form_new_1");
+      expect(result.content[0].text).toContain("50001");
       expect(result.content[0].text).toContain("Questions: 2");
     });
   });

--- a/tests/utils/format.test.ts
+++ b/tests/utils/format.test.ts
@@ -67,6 +67,11 @@ describe("validateMetaId", () => {
     expect(() => validateMetaId("act_act_123")).toThrow();
   });
 
+  it("rejects mixed act_/underscore forms (no real Meta endpoint uses them)", () => {
+    expect(() => validateMetaId("act_123_456")).toThrow(/Invalid Meta id/);
+    expect(() => validateMetaId("act_1_2")).toThrow();
+  });
+
   it("propagates the kind label in the error", () => {
     expect(() => validateMetaId("bad", "campaign_id")).toThrow(
       /Invalid Meta campaign_id/,

--- a/tests/utils/format.test.ts
+++ b/tests/utils/format.test.ts
@@ -47,8 +47,14 @@ describe("validateMetaId", () => {
     expect(validateMetaId("1", "campaign_id")).toBe("1");
   });
 
-  it("rejects act_ prefixed ids (use normalizeAccountId for those)", () => {
-    expect(() => validateMetaId("act_123")).toThrow(/Invalid Meta id/);
+  it("accepts an act_ prefixed account id", () => {
+    expect(validateMetaId("act_123456789", "object_id")).toBe("act_123456789");
+  });
+
+  it("accepts a post / comment id with the <page>_<id> form", () => {
+    expect(validateMetaId("123456789_987654321", "post")).toBe(
+      "123456789_987654321",
+    );
   });
 
   it("rejects junk", () => {
@@ -56,6 +62,9 @@ describe("validateMetaId", () => {
     expect(() => validateMetaId("123/x")).toThrow();
     expect(() => validateMetaId("")).toThrow();
     expect(() => validateMetaId("123 456")).toThrow();
+    expect(() => validateMetaId("act_123/insights")).toThrow();
+    expect(() => validateMetaId("123_456_789")).toThrow();
+    expect(() => validateMetaId("act_act_123")).toThrow();
   });
 
   it("propagates the kind label in the error", () => {


### PR DESCRIPTION
## Summary

- Wires the previously-unused `validateMetaId` helper (CODE-A5 audit finding) into every tool handler that interpolates a non-account resource id into a Graph API path.
- Broadens `validateMetaId` to accept the three legitimate Meta path-id formats (numeric, `act_<numeric>` for accounts in insights/reports, `<page_id>_<post_id>` for `effective_object_story_id` and per-page comments) so a single helper covers every call site.
- Updates test fixtures from readable-but-non-numeric ids (`camp_123`, `ad_1`, `crt_123`, …) to numeric strings so they pass the new boundary check.

Follow-up to PR #49, which prescribed this validation in `docs/adding-a-tool.md` but didn't backport it to the existing tools.

## Why

`src/utils/format.ts` has shipped `validateMetaId` for a while with the docstring *"Use at the boundary of any tool that takes an id from a caller and forwards it into a Meta API path or a rate-limiter bucket key."* The helper was wired up nowhere. Every existing tool that built a path like `` `/${campaign_id}/...` `` did so on the strength of a bare `z.string()` schema, so a crafted `campaign_id = "123/insights"` (or `act_123?fields=...`, or anything containing `/`, `?`, `\n`, etc.) would have been spliced into the URL and reached an unintended endpoint with the caller's token.

The blast radius is bounded — the attacker still needs valid OAuth and can only redirect calls to *other* Graph endpoints under the same scope — but it's a real defense-in-depth gap that the helper was already designed to close. Codex flagged the equivalent inconsistency in the docs PR; this closes the loop in the code.

## What changed

### Source — every tool that interpolates a non-account id

Each affected handler now starts with `const id = validateMetaId(<param>, "<kind>")` and uses `id` in both the Graph path and any user-facing output. Files touched:

- `abtesting.ts` — `study_id`, plus per-cell `adsets` / `campaigns` ids in `create_ad_study`
- `accounts.ts` — `user_id` (with `"me"` passthrough)
- `ads.ts` — `ad_id`, `adset_id`, `campaign_id`, `creative_id`
- `adsets.ts` — `adset_id`, `campaign_id`, `source_adset_id` (clone bundle)
- `audiences.ts` — `audience_id`, `origin_audience_id`
- `budget.ts` — `campaign_id`
- `campaigns.ts` — `campaign_id`
- `comments.ts` — `ad_id`, `post_id`, `comment_id` (uses the `<page>_<post>` path of `validateMetaId`)
- `creatives.ts` — `ad_id`, `creative_id`, `video_id`, `page_id`, `instagram_actor_id`, `source_instagram_media_id`, `object_story_id`
- `insights.ts` — `object_id` (numeric or `act_<numeric>`)
- `instagram.ts` — `page_id`, `instagram_account_id`
- `leads.ts` — `page_id`, `form_id`, `ad_id`
- `pixels.ts` — `pixel_id`
- `previews.ts` — `ad_id`, plus `page_id` / `video_id` inside the creative spec
- `reports.ts` — `object_id`, `report_run_id`
- `rules.ts` — `rule_id`
- `targeting.ts` — `ad_id` in `get_targeting_description`

### `src/utils/format.ts`

Single-helper API kept. The regex moves from `^\d{1,30}$` to `^(act_)?\d{1,30}(_\d{1,30})?$`, the docstring enumerates the three accepted formats, and the unit tests in `tests/utils/format.test.ts` are updated to match (rejects junk, double prefixes, `act_X/insights`, `_` chains; accepts numeric, `act_<num>`, `<num>_<num>`).

### Test fixtures

Tests that fed handlers values like `"camp_123"`, `"adset_src"`, `"ad_1"`, `"crt_123"`, `"page_1"`, `"form_1"` would now throw before reaching the mocked `fetch`. Real Meta IDs are always numeric, so swapping to numeric fixtures is a straight upgrade in fidelity. The `effective_object_story_id` fixture moves to the proper `"<page>_<post>"` form (`6001_9`).

## How to verify

\`\`\`bash
npm run lint        # clean
npm run typecheck   # clean
npm test            # 306 tests / 31 files green
npm run build       # clean
\`\`\`

Locally also ran the project's `pre-deploy-guard` audit (full mode, exit 0) and `gitleaks git --staged --redact --no-banner --config .gitleaks.toml` (no leaks).

The behavior change is intentionally narrow: previously-valid input is still valid, malformed input now throws a clear `Invalid Meta <kind>: must be numeric, optionally prefixed with "act_" (account) or postfixed with "_<id>" (post/comment). Got: ...` from the handler — instead of being forwarded to Meta where it would cause a 100/803 with no security context.

## Tests

- [x] Existing tests still pass (`npm test` → 306/306).
- [x] New cases in `format.test.ts` cover the three accepted formats and the path-traversal rejections the broader regex must still reject.
- [x] Manual verification: `validateMetaId("123/insights")`, `validateMetaId("act_123?x=1")`, `validateMetaId("123_456_789")` all throw; `validateMetaId("act_123")`, `validateMetaId("123_456")`, `validateMetaId("1234567890")` all succeed.

## Checklist

- [x] `npm run lint`, `npm run typecheck`, `npm test`, `npm run build` all pass locally
- [x] No secrets in the diff (gitleaks clean, custom regex scanner clean)
- [x] Updated relevant docs — covered separately in #49 (`docs/adding-a-tool.md`) which already prescribes this exact pattern
- [x] Conventional commit prefix in title (`fix(security):`)

## Auth / security surface

- [ ] Touches `src/auth/`, `src/store/`, or `src/transport/security-config.ts`
- [ ] Modifies the OAuth flow, session cookie shape, or Firestore document layout
- [ ] Adds, removes, or rotates an environment variable referenced as a secret
- [ ] Changes a GitHub Actions workflow under `.github/workflows/`
- [ ] Adds a new third-party dependency (production or dev)
- [ ] Loosens an existing access check or allowlist

*Tightens* an existing input check at every tool boundary. None of the boxes above apply, but this is security-adjacent and benefits from a careful review of the regex change in `format.ts` against the call sites — the threat model is documented in the PR body and mirrors the rationale already in the helper's docstring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)