### PR TITLE
feat(security): enhance OAuth validation and error handling

### DIFF
--- a/src/transport/auth-routes.ts
+++ b/src/transport/auth-routes.ts
@@ -290,7 +290,21 @@ export function mountAuthRoutes(
 
   app.post("/auth/logout", async (req, res) => {
     await clearSession(req, res);
-    res.redirect(302, "/authorize");
+    res.setHeader(
+      "Content-Security-Policy",
+      "default-src 'none'; style-src 'unsafe-inline'; form-action 'self'",
+    );
+    res.status(200).type("html").send(
+      `<!DOCTYPE html><html><head><meta charset="utf-8"><title>Sesión cerrada</title>
+      <style>body{background:#0f0f0f;color:#e0e0e0;font-family:-apple-system,BlinkMacSystemFont,sans-serif;display:flex;justify-content:center;align-items:center;min-height:100vh;margin:0;padding:1rem}
+      .card{background:#1a1a1a;border:1px solid #333;border-radius:12px;padding:2rem;max-width:480px;text-align:center}
+      h1{color:#fff;margin:0 0 1rem;font-size:1.3rem}
+      p{color:#aaa;margin:0.5rem 0;font-size:0.95rem;line-height:1.5}</style></head>
+      <body><div class="card">
+        <h1>Sesión cerrada</h1>
+        <p>Tu sesión se cerró correctamente. Puedes cerrar esta pestaña y volver a iniciar la autorización desde tu cliente MCP.</p>
+      </div></body></html>`,
+    );
   });
 
   app.post(

--- a/src/transport/auth-routes.ts
+++ b/src/transport/auth-routes.ts
@@ -1,4 +1,5 @@
 import express from "express";
+import type { OAuthClientInformationFull } from "@modelcontextprotocol/sdk/shared/auth.js";
 import {
   buildAuthorizeUrl,
   exchangeCodeForToken,
@@ -25,6 +26,7 @@ import {
 } from "../store/meta-token-repo.js";
 import { logger } from "../utils/logger.js";
 import { hashPii } from "../auth/token-store.js";
+import { validateAuthorizeQuery } from "./authorize-validation.js";
 
 const OAUTH_STATE_COOKIE_NAME =
   process.env.NODE_ENV === "production" ? "__Host-meta_oauth_state" : "meta_oauth_state";
@@ -124,6 +126,32 @@ function clearOAuthStateCookie(res: express.Response): void {
 
 export interface AuthRoutesOptions {
   serverUrl: URL;
+  getClient: (
+    clientId: string,
+  ) => OAuthClientInformationFull | undefined | Promise<OAuthClientInformationFull | undefined>;
+}
+
+export async function validateMetaAuthReturn(
+  input: unknown,
+  getClient: AuthRoutesOptions["getClient"],
+): Promise<string | null> {
+  if (typeof input !== "string") return null;
+  const returnTo = safeReturnTo(input);
+  if (returnTo !== input) return null;
+
+  let parsed: URL;
+  try {
+    parsed = new URL(returnTo, "http://mcp.local");
+  } catch {
+    return null;
+  }
+  if (parsed.pathname !== "/authorize") return null;
+
+  const query = Object.fromEntries(parsed.searchParams.entries());
+  const validation = await validateAuthorizeQuery(query, async (clientId) =>
+    getClient(clientId),
+  );
+  return validation.ok ? returnTo : null;
 }
 
 function getMetaConfigOr500(
@@ -142,15 +170,18 @@ export function mountAuthRoutes(
   app: express.Application,
   options: AuthRoutesOptions,
 ): void {
-  const { serverUrl } = options;
+  const { serverUrl, getClient } = options;
 
   app.get("/auth/meta", async (req, res) => {
+    const returnTo = await validateMetaAuthReturn(req.query.return, getClient);
+    if (!returnTo) {
+      renderError(res, 400, "Invalid OAuth request.");
+      return;
+    }
+
     const config = getMetaConfigOr500(serverUrl, res);
     if (!config) return;
 
-    const returnTo = safeReturnTo(
-      typeof req.query.return === "string" ? req.query.return : req.originalUrl,
-    );
     const nonce = generateOAuthStateNonce();
     const state = await signOAuthState({ returnTo, nonce });
     setOAuthStateCookie(res, nonce);

--- a/src/transport/authorize-validation.ts
+++ b/src/transport/authorize-validation.ts
@@ -2,7 +2,7 @@ import type { OAuthClientInformationFull } from "@modelcontextprotocol/sdk/share
 
 export type AuthorizeValidationResult =
   | { ok: true; redirectUri: string; redirectOrigin: string }
-  | { ok: false; kind: "no-params"; status: 200 }
+  | { ok: false; kind: "no-params"; status: 400; message: string }
   | {
       ok: false;
       kind: "missing-field" | "unknown-client" | "redirect-mismatch" | "malformed-redirect";
@@ -44,12 +44,15 @@ export async function validateAuthorizeQuery(
   const clientId = single(query.client_id);
   const redirectUri = single(query.redirect_uri);
 
-  // Both missing → not an OAuth attempt, just a user landing here from an
-  // internal redirect (logout, expired-session message, etc.). Return a
-  // soft "no-params" so the caller can render a landing page instead of a
-  // hostile 400.
+  // Both missing → not a valid OAuth attempt. Keep the response generic so
+  // this endpoint does not become a public product landing page.
   if (!clientId && !redirectUri) {
-    return { ok: false, kind: "no-params", status: 200 };
+    return {
+      ok: false,
+      kind: "no-params",
+      status: 400,
+      message: "OAuth authorization parameters are required.",
+    };
   }
   // One present, the other missing → a malformed OAuth request from a
   // client. This is a real validation error.

--- a/src/transport/http.ts
+++ b/src/transport/http.ts
@@ -13,7 +13,7 @@ import { requestContext } from "../auth/token-store.js";
 import { tokenManager } from "../auth/token-manager.js";
 import { configureSessionJtiStore, getSession } from "../auth/session.js";
 import { resolveSecurityConfig } from "./security-config.js";
-import { mountAuthRoutes } from "./auth-routes.js";
+import { mountAuthRoutes, safeReturnTo } from "./auth-routes.js";
 import { validateAuthorizeQuery } from "./authorize-validation.js";
 import {
   FirestoreClientsStore,
@@ -588,9 +588,12 @@ export async function startHttpTransport(
       async (req, res, next) => {
         const session = await getSession(req);
         if (!session) {
-          res.status(401).type("html").send(
-            "<p>Sesión expirada. <a href=\"/authorize\">Inicia de nuevo</a>.</p>",
-          );
+          const recoverTo = safeReturnTo(req.body?.return);
+          const link =
+            recoverTo === "/authorize"
+              ? "Vuelve a iniciar la autorización desde tu cliente MCP."
+              : `<a href="${escapeHtml(recoverTo)}">Inicia de nuevo</a>.`;
+          res.status(401).type("html").send(`<p>Sesión expirada. ${link}</p>`);
           return;
         }
 
@@ -607,8 +610,13 @@ export async function startHttpTransport(
         }
 
         if (!activeName) {
+          const recoverTo = safeReturnTo(req.body?.return);
+          const link =
+            recoverTo === "/authorize"
+              ? "Vuelve a iniciar la autorización desde tu cliente MCP."
+              : `Vuelve a <a href="${escapeHtml(recoverTo)}">/authorize</a>.`;
           res.status(400).type("html").send(
-            "<p>No hay token de Meta conectado. Vuelve a <a href=\"/authorize\">/authorize</a>.</p>",
+            `<p>No hay token de Meta conectado. ${link}</p>`,
           );
           return;
         }

--- a/src/transport/http.ts
+++ b/src/transport/http.ts
@@ -101,6 +101,10 @@ export function getServerUrl(): URL {
   return new URL(`http://localhost:${port}`);
 }
 
+export function healthPayload(): { status: "ok" } {
+  return { status: "ok" };
+}
+
 interface ConsentContext {
   query: Record<string, string>;
   user: { fbUserId: string; email: string | null; name: string | null };
@@ -504,11 +508,14 @@ export async function startHttpTransport(
   }
 
   app.get("/health", (_req, res) => {
-    res.json({ status: "ok", server: "meta-ads-mcp", version: "1.0.0" });
+    res.json(healthPayload());
   });
 
   if (config.multiTenantEnabled) {
-    mountAuthRoutes(app, { serverUrl });
+    mountAuthRoutes(app, {
+      serverUrl,
+      getClient: (id) => oauthProvider.clientsStore.getClient(id),
+    });
 
     app.get("/authorize", async (req, res) => {
       const query = req.query as Record<string, string>;
@@ -522,25 +529,15 @@ export async function startHttpTransport(
       );
       if (!validation.ok) {
         if (validation.kind === "no-params") {
-          // Internal redirect (logout, expired-session, no-token messages).
-          // Render a friendly landing page so users can recover.
-          const session = await getSession(req);
-          const sessionLine = session
-            ? `<p>You're signed in as <code>${escapeHtml(session.email ?? session.name ?? session.fbUserId)}</code>.</p>`
-            : `<p><a href="/auth/meta">Sign in with Meta</a> to start a session.</p>`;
-          res.status(200).type("html").send(
-            `<!DOCTYPE html><html><head><meta charset="utf-8"><title>Meta Ads MCP</title>
+          res.status(validation.status).type("html").send(
+            `<!DOCTYPE html><html><head><meta charset="utf-8"><title>Invalid request</title>
             <style>body{background:#0f0f0f;color:#e0e0e0;font-family:-apple-system,BlinkMacSystemFont,sans-serif;display:flex;justify-content:center;align-items:center;min-height:100vh;margin:0;padding:1rem}
             .card{background:#1a1a1a;border:1px solid #333;border-radius:12px;padding:2rem;max-width:480px;text-align:center}
             h1{color:#fff;margin:0 0 1rem;font-size:1.3rem}
-            p{color:#aaa;margin:0.5rem 0;font-size:0.95rem;line-height:1.5}
-            a{color:#6cb4ee;text-decoration:none}a:hover{text-decoration:underline}
-            code{background:#222;padding:0.1rem 0.4rem;border-radius:4px;color:#ccc;font-size:0.85rem}</style></head>
+            p{color:#aaa;margin:0.5rem 0;font-size:0.95rem;line-height:1.5}</style></head>
             <body><div class="card">
-              <h1>Meta Ads MCP</h1>
-              <p>This is the OAuth authorization endpoint for the Meta Ads MCP server.</p>
-              <p>To authorize an MCP client, point it at this server's MCP URL — the client will land on this endpoint with the right query parameters.</p>
-              ${sessionLine}
+              <h1>Invalid request</h1>
+              <p>${escapeHtml(validation.message)}</p>
             </div></body></html>`,
           );
           return;

--- a/tests/transport/authorize-validation.test.ts
+++ b/tests/transport/authorize-validation.test.ts
@@ -32,9 +32,14 @@ describe("validateAuthorizeQuery", () => {
     }
   });
 
-  it("returns no-params landing signal when both client_id and redirect_uri are missing (logout/expired-session recovery)", async () => {
+  it("rejects when both client_id and redirect_uri are missing", async () => {
     const r = await validateAuthorizeQuery({}, makeGetClient({}));
-    expect(r).toEqual({ ok: false, kind: "no-params", status: 200 });
+    expect(r).toEqual({
+      ok: false,
+      kind: "no-params",
+      status: 400,
+      message: "OAuth authorization parameters are required.",
+    });
   });
 
   it("rejects with missing-field when only client_id is missing", async () => {

--- a/tests/transport/safe-return-to.test.ts
+++ b/tests/transport/safe-return-to.test.ts
@@ -1,5 +1,23 @@
 import { describe, expect, it } from "vitest";
-import { safeReturnTo } from "../../src/transport/auth-routes.js";
+import type { OAuthClientInformationFull } from "@modelcontextprotocol/sdk/shared/auth.js";
+import {
+  safeReturnTo,
+  validateMetaAuthReturn,
+} from "../../src/transport/auth-routes.js";
+
+const claudeClient: OAuthClientInformationFull = {
+  client_id: "claude-client",
+  client_name: "Claude.ai",
+  redirect_uris: ["https://claude.ai/api/mcp/auth_callback"],
+  grant_types: ["authorization_code", "refresh_token"],
+  response_types: ["code"],
+  token_endpoint_auth_method: "client_secret_post",
+  client_id_issued_at: 0,
+};
+
+function makeGetClient(map: Record<string, OAuthClientInformationFull>) {
+  return async (id: string) => map[id];
+}
 
 describe("safeReturnTo (CODE-M3)", () => {
   it("accepts an internal path", () => {
@@ -52,5 +70,35 @@ describe("safeReturnTo (CODE-M3)", () => {
 
   it("rejects oversize values", () => {
     expect(safeReturnTo("/" + "a".repeat(3000))).toBe("/authorize");
+  });
+});
+
+describe("validateMetaAuthReturn", () => {
+  it("rejects missing or direct /authorize returns", async () => {
+    const getClient = makeGetClient({});
+
+    await expect(validateMetaAuthReturn(undefined, getClient)).resolves.toBeNull();
+    await expect(validateMetaAuthReturn("/authorize", getClient)).resolves.toBeNull();
+  });
+
+  it("rejects returns with unknown clients", async () => {
+    const returnTo =
+      "/authorize?response_type=code&client_id=ghost-client&redirect_uri=https%3A%2F%2Fclaude.ai%2Fapi%2Fmcp%2Fauth_callback";
+
+    await expect(
+      validateMetaAuthReturn(returnTo, makeGetClient({})),
+    ).resolves.toBeNull();
+  });
+
+  it("accepts a valid /authorize return for a registered client", async () => {
+    const returnTo =
+      "/authorize?response_type=code&client_id=claude-client&redirect_uri=https%3A%2F%2Fclaude.ai%2Fapi%2Fmcp%2Fauth_callback";
+
+    await expect(
+      validateMetaAuthReturn(
+        returnTo,
+        makeGetClient({ "claude-client": claudeClient }),
+      ),
+    ).resolves.toBe(returnTo);
   });
 });

--- a/tests/transport/server-url.test.ts
+++ b/tests/transport/server-url.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { getServerUrl } from "../../src/transport/http.js";
+import { getServerUrl, healthPayload } from "../../src/transport/http.js";
 
 const KEYS = ["NODE_ENV", "SERVER_URL", "PORT"] as const;
 const originalEnv: Record<(typeof KEYS)[number], string | undefined> =
@@ -57,5 +57,11 @@ describe("getServerUrl", () => {
 
     process.env.SERVER_URL = "https://10.0.0.2";
     expect(() => getServerUrl()).toThrow(/private IP/);
+  });
+});
+
+describe("healthPayload", () => {
+  it("does not expose server name or version", () => {
+    expect(healthPayload()).toEqual({ status: "ok" });
   });
 });


### PR DESCRIPTION
<!--
Thanks for contributing to meta-ads-mcp.

Please complete the sections below. PRs that skip the security checklist or
the verification steps are likely to be sent back. See CONTRIBUTING.md for the
full contribution guide.
-->

## Summary

<!-- One or two sentences: what changes and why. -->

## Why

<!-- The motivation. Link an issue if there is one (Fixes #123). -->

## How to verify

<!-- Reproducible steps. Commands, URLs, logs, screenshots — whatever makes
the reviewer's life easier. -->

```bash
# example
npm test
```

## Tests

<!-- Which tests cover this change? If none, explain why. -->

- [ ] New tests added under `tests/` mirroring the source path
- [ ] Existing tests still pass (`npm test`)
- [ ] Manual verification against a real dev environment (describe below)

## Checklist

- [ ] `npm run lint`, `npm run typecheck`, `npm test`, `npm run build` all pass locally
- [ ] No secrets in the diff (env vars, tokens, keys). If unsure, run `gitleaks git --staged --config .gitleaks.toml`
- [ ] Updated relevant docs (`README.md`, `SECURITY.md`, `CONTRIBUTING.md`) if behavior changed
- [ ] Conventional commit prefix in title (`feat:`, `fix:`, `chore:`, `docs:`, `refactor:`, `test:`, `ci:`)

## Auth / security surface

Tick **all** that apply. If any box is ticked, expect extra review scrutiny and
explain the threat-model impact in the description.

- [ ] Touches `src/auth/`, `src/store/`, or `src/transport/security-config.ts`
- [ ] Modifies the OAuth flow, session cookie shape, or Firestore document layout
- [ ] Adds, removes, or rotates an environment variable referenced as a secret
- [ ] Changes a GitHub Actions workflow under `.github/workflows/`
- [ ] Adds a new third-party dependency (production or dev)
- [ ] Loosens an existing access check or allowlist

If none of the above apply, write *None* below and the bot will not block on
the security reviewer.

> _Threat-model notes:_
