### PR TITLE
fix(auth): return 401 for invalid Bearer tokens (was 500)

### DIFF
--- a/src/auth/oauth-provider.ts
+++ b/src/auth/oauth-provider.ts
@@ -12,6 +12,10 @@ import type {
   OAuthTokens,
   OAuthTokenRevocationRequest,
 } from "@modelcontextprotocol/sdk/shared/auth.js";
+import {
+  InvalidGrantError,
+  InvalidTokenError,
+} from "@modelcontextprotocol/sdk/server/auth/errors.js";
 import { logger } from "../utils/logger.js";
 import {
   InMemoryAuthCodesStore,
@@ -115,14 +119,16 @@ export class MetaAdsOAuthProvider implements OAuthServerProvider {
   ): Promise<string> {
     const entry = await this.authCodesImpl.get(authorizationCode);
     if (!entry) {
-      throw new Error("Invalid authorization code");
+      throw new InvalidGrantError("Invalid authorization code");
     }
     if (entry.clientId !== client.client_id) {
-      throw new Error("Authorization code was issued to a different client");
+      throw new InvalidGrantError(
+        "Authorization code was issued to a different client",
+      );
     }
     if (entry.expiresAt < Math.floor(Date.now() / 1000)) {
       await this.authCodesImpl.delete(authorizationCode);
-      throw new Error("Authorization code has expired");
+      throw new InvalidGrantError("Authorization code has expired");
     }
     return entry.codeChallenge;
   }
@@ -138,14 +144,16 @@ export class MetaAdsOAuthProvider implements OAuthServerProvider {
     // first caller sees the entry. RFC 6749 §10.5: codes must be single-use.
     const entry = await this.authCodesImpl.consume(authorizationCode);
     if (!entry) {
-      throw new Error("Invalid authorization code");
+      throw new InvalidGrantError("Invalid authorization code");
     }
 
     if (entry.clientId !== client.client_id) {
-      throw new Error("Authorization code was issued to a different client");
+      throw new InvalidGrantError(
+        "Authorization code was issued to a different client",
+      );
     }
     if (entry.expiresAt < Math.floor(Date.now() / 1000)) {
-      throw new Error("Authorization code has expired");
+      throw new InvalidGrantError("Authorization code has expired");
     }
 
     // Defense-in-depth PKCE check. mcp-sdk's primary verification happens
@@ -161,7 +169,7 @@ export class MetaAdsOAuthProvider implements OAuthServerProvider {
         .update(codeVerifier)
         .digest("base64url");
       if (computed !== entry.codeChallenge) {
-        throw new Error("PKCE verification failed");
+        throw new InvalidGrantError("PKCE verification failed");
       }
     }
 
@@ -185,14 +193,16 @@ export class MetaAdsOAuthProvider implements OAuthServerProvider {
       algorithms: ["HS256"],
       audience: REFRESH_AUDIENCE,
     }).catch(() => {
-      throw new Error("Invalid refresh token");
+      throw new InvalidGrantError("Invalid refresh token");
     });
 
     if (payload.type !== "refresh") {
-      throw new Error("Token is not a refresh token");
+      throw new InvalidGrantError("Token is not a refresh token");
     }
     if (payload.sub !== client.client_id) {
-      throw new Error("Refresh token was issued to a different client");
+      throw new InvalidGrantError(
+        "Refresh token was issued to a different client",
+      );
     }
     // jti must be present in the allow-list — i.e. issued by us, not yet
     // revoked, and not yet rotated. Old tokens issued before this code
@@ -200,7 +210,7 @@ export class MetaAdsOAuthProvider implements OAuthServerProvider {
     // intended behaviour after rolling out the change.
     const jti = typeof payload.jti === "string" ? payload.jti : null;
     if (!jti) {
-      throw new Error("Refresh token missing jti");
+      throw new InvalidGrantError("Refresh token missing jti");
     }
     // Atomic consume: under concurrent refresh requests with the same
     // token, only one wins. Without this, has()+delete() were two
@@ -209,7 +219,9 @@ export class MetaAdsOAuthProvider implements OAuthServerProvider {
     // sufficient async interleaving). Even if generateTokens fails after
     // this, the worst case is the user has to re-authorize.
     if (!(await this.refreshJtiStoreImpl.consume(jti))) {
-      throw new Error("Refresh token has been revoked or already used");
+      throw new InvalidGrantError(
+        "Refresh token has been revoked or already used",
+      );
     }
 
     return this.generateTokens({
@@ -223,15 +235,20 @@ export class MetaAdsOAuthProvider implements OAuthServerProvider {
   async verifyAccessToken(token: string): Promise<AuthInfo> {
     const secret = getJwtSecret();
 
+    // Throw the SDK's typed error so requireBearerAuth responds with
+    // 401 + WWW-Authenticate (triggering the client's refresh flow).
+    // A plain Error here falls through to the SDK's generic 500 path,
+    // which leaves clients stuck pretending the server is down once
+    // their 1h access token expires.
     const { payload } = await jwtVerify(token, secret, {
       algorithms: ["HS256"],
       audience: ACCESS_AUDIENCE,
     }).catch(() => {
-      throw new Error("Invalid access token");
+      throw new InvalidTokenError("Invalid access token");
     });
 
     if (payload.type !== "access") {
-      throw new Error("Token is not an access token");
+      throw new InvalidTokenError("Token is not an access token");
     }
 
     const extra: Record<string, unknown> = {};

--- a/tests/auth/oauth-provider.test.ts
+++ b/tests/auth/oauth-provider.test.ts
@@ -1,10 +1,15 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { Response } from "express";
+import { SignJWT } from "jose";
 import {
   oauthProvider,
   resetOAuthProviderForTests,
 } from "../../src/auth/oauth-provider.js";
 import type { OAuthClientInformationFull } from "@modelcontextprotocol/sdk/shared/auth.js";
+import {
+  InvalidGrantError,
+  InvalidTokenError,
+} from "@modelcontextprotocol/sdk/server/auth/errors.js";
 
 const original = process.env.OAUTH_SECRET;
 
@@ -349,6 +354,59 @@ describe("MetaAdsOAuthProvider", () => {
     await expect(
       oauthProvider.verifyAccessToken(tokens.refresh_token!),
     ).rejects.toThrow(/Invalid access token/);
+  });
+
+  it("verifyAccessToken rejects malformed tokens with InvalidTokenError (SDK maps to 401)", async () => {
+    await expect(
+      oauthProvider.verifyAccessToken("not-a-jwt"),
+    ).rejects.toBeInstanceOf(InvalidTokenError);
+  });
+
+  it("verifyAccessToken rejects expired tokens with InvalidTokenError (SDK maps to 401)", async () => {
+    const secret = new TextEncoder().encode("x".repeat(64));
+    const expired = await new SignJWT({
+      sub: "test-client",
+      type: "access",
+    })
+      .setProtectedHeader({ alg: "HS256" })
+      .setIssuedAt(0)
+      .setExpirationTime(1)
+      .setAudience("mcp-oauth-access")
+      .sign(secret);
+
+    await expect(oauthProvider.verifyAccessToken(expired)).rejects.toBeInstanceOf(
+      InvalidTokenError,
+    );
+  });
+
+  it("verifyAccessToken rejects wrong-audience tokens with InvalidTokenError", async () => {
+    const secret = new TextEncoder().encode("x".repeat(64));
+    const now = Math.floor(Date.now() / 1000);
+    const wrongAudience = await new SignJWT({
+      sub: "test-client",
+      type: "access",
+    })
+      .setProtectedHeader({ alg: "HS256" })
+      .setIssuedAt(now)
+      .setExpirationTime(now + 60)
+      .setAudience("some-other-audience")
+      .sign(secret);
+
+    await expect(
+      oauthProvider.verifyAccessToken(wrongAudience),
+    ).rejects.toBeInstanceOf(InvalidTokenError);
+  });
+
+  it("exchangeRefreshToken rejects invalid tokens with InvalidGrantError", async () => {
+    await expect(
+      oauthProvider.exchangeRefreshToken(fakeClient, "not-a-jwt"),
+    ).rejects.toBeInstanceOf(InvalidGrantError);
+  });
+
+  it("exchangeAuthorizationCode rejects unknown codes with InvalidGrantError", async () => {
+    await expect(
+      oauthProvider.exchangeAuthorizationCode(fakeClient, "does-not-exist"),
+    ).rejects.toBeInstanceOf(InvalidGrantError);
   });
 
   it("preserves fb_user_id across refresh-token exchange (token name is never in the JWT)", async () => {


### PR DESCRIPTION
## Summary

- `verifyAccessToken` and the OAuth grant exchanges threw plain `Error` objects when a token was invalid/expired/wrong-shape. The MCP SDK's `requireBearerAuth` middleware only treats `InvalidTokenError | InsufficientScopeError | OAuthError | ServerError` as auth failures; anything else falls through to a generic **500** with body `{"error":"server_error","error_description":"Internal Server Error"}` (OAuth format).
- As a result, every time the 1h MCP access token expired, the client received 500 instead of 401, never saw `WWW-Authenticate`, and never refreshed. The user had to re-authenticate every hour, even with valid Meta tokens stored in Firestore. Reproduced in production and locally.
- This PR throws `InvalidTokenError` from `verifyAccessToken` and `InvalidGrantError` from `exchangeRefreshToken` / `exchangeAuthorizationCode` / `challengeForAuthorizationCode`. The SDK now correctly responds **401 + `WWW-Authenticate: Bearer error="invalid_token"`**, which triggers the client's automatic refresh flow (refresh token is valid 30 days).

## Reproduction

Before:
```
$ curl -i -X POST https://meta-ads-mcp.../mcp -H 'Authorization: Bearer eyJ...bad...sig'
HTTP/2 500
content-type: application/json
{"error":"server_error","error_description":"Internal Server Error"}
```

After (verified locally with `npm run dev`):
```
$ curl -i -X POST http://localhost:3007/mcp -H 'Authorization: Bearer eyJ...bad...sig'
HTTP/1.1 401 Unauthorized
WWW-Authenticate: Bearer error="invalid_token", error_description="Invalid access token"
{"error":"invalid_token","error_description":"Invalid access token"}
```

## Test plan

- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm test` — 336 / 336 (16 in oauth-provider.test.ts; 5 new asserting `InvalidTokenError` / `InvalidGrantError` instanceof on each error path)
- [x] `npm run build`
- [x] curl reproduction local: invalid Bearer → 401 + WWW-Authenticate (was 500)
- [ ] post-deploy: confirm 500s for `/mcp` drop in Cloud Logging within 1h
- [ ] post-deploy: confirm at least one affected user reconnects without re-auth