### PR TITLE
ci: auto-publish GitHub Release after successful Cloud Run deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -370,19 +370,28 @@ jobs:
   release:
     # Auto-publish a GitHub Release when package.json version is bumped on main.
     # Idempotent: skips silently if a release for the current version already
-    # exists. The created release fires publish.yml which ships to npm.pkg.github.com
-    # and ghcr.io. Prereleases (versions containing "-") get --prerelease.
+    # exists, so non-version-bumping pushes are no-ops.
+    #
+    # Note: this job only CREATES the release. It does not trigger publish.yml
+    # by itself, because GitHub blocks recursive workflow triggers from
+    # GITHUB_TOKEN-created releases. The follow-up `publish` job below calls
+    # publish.yml explicitly via workflow_call, which is permitted.
     name: Auto-publish GitHub Release
     needs: deploy
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
       contents: write
+    outputs:
+      created: ${{ steps.create.outputs.created }}
+      tag: ${{ steps.version.outputs.tag }}
+      prerelease: ${{ steps.version.outputs.prerelease }}
     steps:
-      - name: Checkout
+      - name: Checkout deployed SHA
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
-          fetch-depth: 0   # full history needed for --generate-notes
+          ref: ${{ github.sha }}    # match the commit the deploy job validated
+          fetch-depth: 0            # full history needed for --generate-notes
 
       - name: Read package.json version
         id: version
@@ -416,16 +425,40 @@ jobs:
           fi
 
       - name: Create GitHub Release
+        id: create
         if: steps.check.outputs.skip == 'false'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ steps.version.outputs.tag }}
+          DEPLOYED_SHA: ${{ github.sha }}
           IS_PRERELEASE: ${{ steps.version.outputs.prerelease }}
         run: |
           set -eu
-          ARGS=("$TAG" --target main --generate-notes)
+          # Target the exact SHA the deploy job validated, not "main". Otherwise
+          # a second commit landing while this workflow runs could move main's
+          # HEAD and the tag would point at code that hasn't been deployed yet.
+          ARGS=("$TAG" --target "$DEPLOYED_SHA" --generate-notes)
           if [ "$IS_PRERELEASE" = "true" ]; then
             ARGS+=(--prerelease)
           fi
           gh release create "${ARGS[@]}"
-          echo "Released $TAG. publish.yml is now queued to ship npm + ghcr artifacts."
+          echo "created=true" >> "$GITHUB_OUTPUT"
+          echo "Released $TAG at $DEPLOYED_SHA. The follow-up publish job will ship npm + ghcr artifacts."
+
+  publish:
+    # Trigger publish.yml explicitly via workflow_call. We can't rely on the
+    # `release: published` event because GitHub blocks recursive triggers from
+    # GITHUB_TOKEN-created releases (workflow_dispatch and workflow_call are
+    # the only permitted exceptions).
+    needs: release
+    if: needs.release.outputs.created == 'true'
+    uses: ./.github/workflows/publish.yml
+    with:
+      tag: ${{ needs.release.outputs.tag }}
+      prerelease: ${{ needs.release.outputs.prerelease == 'true' }}
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+      attestations: write
+    secrets: inherit

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -366,3 +366,66 @@ jobs:
             echo "OAuth metadata check FAILED (HTTP ${OAUTH_STATUS})"
             exit 1
           fi
+
+  release:
+    # Auto-publish a GitHub Release when package.json version is bumped on main.
+    # Idempotent: skips silently if a release for the current version already
+    # exists. The created release fires publish.yml which ships to npm.pkg.github.com
+    # and ghcr.io. Prereleases (versions containing "-") get --prerelease.
+    name: Auto-publish GitHub Release
+    needs: deploy
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          fetch-depth: 0   # full history needed for --generate-notes
+
+      - name: Read package.json version
+        id: version
+        run: |
+          set -eu
+          VERSION=$(node -p "require('./package.json').version")
+          if ! printf '%s' "$VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$'; then
+            echo "Invalid version in package.json: '$VERSION'"
+            exit 1
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "tag=v$VERSION" >> "$GITHUB_OUTPUT"
+          if [[ "$VERSION" == *-* ]]; then
+            echo "prerelease=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "prerelease=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Skip if release already exists
+        id: check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.version.outputs.tag }}
+        run: |
+          if gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            echo "Release $TAG already exists — skipping."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "No release for $TAG yet — will create."
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create GitHub Release
+        if: steps.check.outputs.skip == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.version.outputs.tag }}
+          IS_PRERELEASE: ${{ steps.version.outputs.prerelease }}
+        run: |
+          set -eu
+          ARGS=("$TAG" --target main --generate-notes)
+          if [ "$IS_PRERELEASE" = "true" ]; then
+            ARGS+=(--prerelease)
+          fi
+          gh release create "${ARGS[@]}"
+          echo "Released $TAG. publish.yml is now queued to ship npm + ghcr artifacts."

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,6 +3,21 @@ name: Publish to GitHub Packages
 on:
   release:
     types: [published]
+  workflow_call:
+    # Allow deploy.yml to invoke this workflow after creating a release with
+    # GITHUB_TOKEN. Releases created by GITHUB_TOKEN do not fire the `release`
+    # event by design (GitHub blocks recursive workflow triggers), so we have
+    # to call publish.yml explicitly from the workflow that creates the tag.
+    inputs:
+      tag:
+        description: Release tag to publish (e.g. v3.0.0)
+        required: true
+        type: string
+      prerelease:
+        description: Whether to publish as a prerelease (next dist-tag, no :latest)
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -11,7 +26,7 @@ permissions:
   attestations: write
 
 concurrency:
-  group: publish-${{ github.ref }}
+  group: publish-${{ inputs.tag || github.ref }}
   cancel-in-progress: false
 
 jobs:
@@ -22,6 +37,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          # When triggered by `release` event, github.ref already points to the
+          # tag; when called via workflow_call, github.ref is the caller's ref
+          # so we must explicitly check out the tag we were asked to publish.
+          ref: ${{ inputs.tag || github.ref }}
 
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
@@ -57,6 +77,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          ref: ${{ inputs.tag || github.ref }}
 
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
@@ -75,7 +97,10 @@ jobs:
       - name: Determine npm dist-tag
         id: disttag
         env:
-          IS_PRERELEASE: ${{ github.event.release.prerelease }}
+          # When triggered by release event, github.event.release.prerelease is
+          # the source of truth; when called via workflow_call, inputs.prerelease
+          # is what the caller passed.
+          IS_PRERELEASE: ${{ github.event.release.prerelease || inputs.prerelease }}
         run: |
           if [ "$IS_PRERELEASE" = "true" ]; then
             echo "tag=next" >> "$GITHUB_OUTPUT"
@@ -97,6 +122,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          ref: ${{ inputs.tag || github.ref }}
 
       - name: Log in to GHCR
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9  # v3
@@ -110,11 +137,15 @@ jobs:
         uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051  # v5
         with:
           images: ghcr.io/byadsco/meta-ads-mcp
+          # type=semver normally derives the version from github.ref. When this
+          # workflow is invoked via workflow_call, github.ref is the caller's
+          # branch (not the tag), so we override `value=` with the tag we were
+          # asked to publish. github.ref_name on a release event is the tag name.
           tags: |
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
-            type=raw,value=latest,enable=${{ !github.event.release.prerelease }}
+            type=semver,pattern={{version}},value=${{ inputs.tag || github.ref_name }}
+            type=semver,pattern={{major}}.{{minor}},value=${{ inputs.tag || github.ref_name }}
+            type=semver,pattern={{major}},value=${{ inputs.tag || github.ref_name }}
+            type=raw,value=latest,enable=${{ !(github.event.release.prerelease || inputs.prerelease) }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f  # v3


### PR DESCRIPTION
## Summary

Eliminates the manual `gh release create` step for cutting non-prerelease versions. After this lands, the flow per [CONTRIBUTING.md:111-121](https://github.com/byadsco/meta-ads-mcp/blob/main/CONTRIBUTING.md#L111-L121) becomes a single PR:

1. Open a PR that bumps `version` in `package.json`.
2. Merge the PR.

That's it. The new `release` job in [deploy.yml](.github/workflows/deploy.yml) handles steps 3 and 4 — creating the tag and triggering `publish.yml`.

## What it does

After the existing `deploy` job succeeds:

- Reads `version` from `package.json`.
- Checks if a release for `vX.Y.Z` already exists. If yes, skips silently — most pushes don't bump the version.
- If no, calls `gh release create vX.Y.Z --target main --generate-notes`, which fires the existing `publish.yml` workflow → ships to `npm.pkg.github.com` + `ghcr.io`.
- Prereleases (versions containing `-`, e.g. `3.1.0-rc.1`) get `--prerelease` so npm publishes under the `next` dist-tag and ghcr skips the `:latest` Docker tag — matches [publish.yml:75-90](.github/workflows/publish.yml#L75-L90) behavior.

## Why this design

- **Idempotent**: regular pushes to `main` (docs, fixes, refactors) don't bump the version → release already exists → no-op. Costs ~10s per push.
- **Sequence is `deploy → release`**, not the other way around. If the deploy fails or smoke tests fail, no release is published pointing at broken code.
- **Single source of truth**: `package.json` version drives everything. No separate file to keep in sync.
- **Doesn't replace manual control for prereleases**: the team can still run `gh release create v3.0.0-rc.1 --prerelease` by hand if they want richer notes than `--generate-notes` gives. The auto-job will skip because the release already exists.

## Why now

We just shipped v3.0.0 (commit `6066595`, PR #64). The deploy ran but the release wasn't created — `package.json` said `3.0.0` but the latest release tag was still `v2.0.2`. Manual `gh release create v3.0.0` was needed. This PR makes that step go away for future versions.

## Test plan

- [ ] Merge this PR. The first run on `main` should detect that `v3.0.0` already exists (just created manually) and skip silently — verify in the deploy.yml run logs.
- [ ] On the next version bump (`3.0.1` patch or `3.1.0` feat), verify the auto-release job creates the tag, generates notes from PRs since `v3.0.0`, and triggers `publish.yml`.
- [ ] For a prerelease test: bump to `3.0.1-rc.1`, push, verify `--prerelease` is set on the created release and `publish.yml` ships under the `next` npm tag.

## Notes

- The `release` job needs `permissions: contents: write` to create releases — scoped to that one job, the rest of the workflow keeps `contents: read`.
- `fetch-depth: 0` is required so `gh release create --generate-notes` can walk back to the previous tag.
- Uses `${{ secrets.GITHUB_TOKEN }}` — no new secrets to provision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)