### PR TITLE
fix(clone-bundle): audit fixes for v25 API compat + write safety

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,68 @@ All notable changes to this project are documented here.
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and
 this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.1.0] — 2026-05-13
+
+Audit-driven fixes for `ads_clone_ad_set_bundle` after Meta API error
+2500 surfaced a duplicate `destination_type` in the GET fields list.
+Verified against Marketing API v25 docs and an independent code review.
+
+### Fixed
+
+- **v22 compat**: `instagram_actor_id` removed from
+  `AdCreativeObjectStorySpec` (deprecated in v22.0 changelog). The bundle
+  now reads `instagram_user_id` with a fallback for legacy creatives and
+  always writes the new field. Also applied in `ads_create_ad_creative`.
+- **Write safety**: `MetaApiClient` no longer retries `POST` to
+  `/act_*/<collection>` paths on timeout/5xx/transient errors. Meta has no
+  native idempotency on creates, so the prior retry behavior could mint
+  duplicate ad sets/creatives/ads within a single tool invocation.
+  `POST /<id>` (updates) and `DELETE` are unaffected.
+- **Targeting roundtrip**: strip read-only fields
+  (`targeting_relaxation_types`, `is_whatsapp_destination_ad`,
+  `targeting_optimization`) returned by Meta on GET before sending the
+  targeting back on POST.
+- **Geo override**: `applyGeoOverride` now replaces `geo_locations`
+  instead of merging. Previously a Chile-source with city targeting cloned
+  to Colombia would inherit Chilean cities — Meta's docs recommend
+  redefining `geo_locations` on country swaps.
+- **Budget priority**: user-provided `target_ad_set.daily_budget` or
+  `lifetime_budget` now wins over the source budget regardless of source
+  shape. Previously a daily-budget override was silently dropped when the
+  source had a lifetime budget.
+- **Empty bundle**: throws before claiming idempotency when no source
+  creatives are clonable, instead of creating an empty ad set.
+- **`asset_feed_spec` order**: the unsupported-feed check now runs before
+  the video/link checks, so dynamic creatives that also expose a
+  `link_data` shape aren't silently cloned as static.
+- **Hard-coded `WEBSITE` fallback** removed for `destination_type` —
+  source value (or user override) is used, otherwise omitted.
+
+### Changed
+
+- **Idempotency cache**: moved from an in-process `Map` to a
+  Firestore-backed store (`clone_bundle_operations` collection). Survives
+  Cloud Run restarts and multi-instance deployments. Falls back to in-
+  memory when Firestore env vars are not set.
+- **Partial-failure tracking**: the store records created resources
+  incrementally; if a step fails, the error surfaces the partial state
+  (`ad_set=…, creatives=[…], ads=[…]`) and the run is marked `failed`.
+  Retries with the same `idempotency_key` are rejected with the orphan
+  list until the user cleans up.
+- **Stale lock reclaim**: `in_progress` records older than 15 minutes
+  (e.g. orphaned by a process crash between `claim` and `markFailed`) are
+  taken over on retry instead of blocking forever.
+- **CTA validation**: `creative_overrides.call_to_action_type` is now
+  validated against the shared `ctaEnum` — typos are rejected at schema
+  time instead of after creating the ad set.
+
+### Added
+
+- `target_ad_set.end_time` on `ads_clone_ad_set_bundle` (required when
+  the user provides `lifetime_budget`).
+- CBO support: bundle no longer requires source-level budget when the
+  parent campaign uses Campaign Budget Optimization.
+
 ## [3.0.0] — 2026-05-06
 
 ### Why this release

--- a/package-lock.json
+++ b/package-lock.json
@@ -809,9 +809,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/codegen": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
-      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/eventemitter": {
@@ -837,9 +837,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/inquire": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
-      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.1.tgz",
+      "integrity": "sha512-mnzgDV26ueAvk7rsbt9L7bE0SuAoqyuys/sMMrmVcN5x9VsxpcG3rqAUSgDyLp0UZlmNfIbQ4fHfCtreVBk8Ew==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/path": {
@@ -855,9 +855,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/utf8": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
-      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
+      "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -4017,22 +4017,22 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.5.5",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.5.tgz",
-      "integrity": "sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==",
+      "version": "7.5.8",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.8.tgz",
+      "integrity": "sha512-dvpCIeLPbXZS/Ete7yLaO7RenOdken2NHKykBXbsaGxZT0UTltcarBciw+A78SRQs9iMAAVpsYA+l8b1hTePIA==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/codegen": "^2.0.5",
         "@protobufjs/eventemitter": "^1.1.0",
         "@protobufjs/fetch": "^1.1.0",
         "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/inquire": "^1.1.1",
         "@protobufjs/path": "^1.1.2",
         "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
         "@types/node": ">=13.7.0",
         "long": "^5.0.0"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@byadsco/meta-ads-mcp",
-  "version": "3.0.1",
+  "version": "3.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@byadsco/meta-ads-mcp",
-      "version": "3.0.1",
+      "version": "3.1.0",
       "license": "MIT",
       "dependencies": {
         "@google-cloud/firestore": "^8.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@byadsco/meta-ads-mcp",
-  "version": "3.0.1",
+  "version": "3.1.0",
   "description": "MCP server for Meta Ads (Facebook/Instagram) management - agency multi-account",
   "author": {
     "name": "Santiago Bastidas",

--- a/src/meta/client.ts
+++ b/src/meta/client.ts
@@ -188,6 +188,14 @@ export class MetaApiClient {
 
     const reqUrl = skipTokenParam ? url : this.appendToken(url, token);
 
+    // POST to /act_<id>/<collection> creates new resources without native
+    // idempotency on Meta's side — retrying a timeout/5xx/network error can
+    // mint duplicates (e.g. two ad sets for one user intent). Other POSTs
+    // (updates on /<id>) and DELETEs are idempotent at the API level.
+    const isCreatingRequest =
+      method === "POST" && /^\/?act_[A-Za-z0-9]+\//.test(path);
+    const canRetryTransport = !isCreatingRequest;
+
     let lastError: Error | undefined;
 
     for (let attempt = 0; attempt <= this.maxRetries; attempt++) {
@@ -234,7 +242,7 @@ export class MetaApiClient {
             throw classification.mcpError;
           }
 
-          if (classification.retryable && attempt < this.maxRetries) {
+          if (classification.retryable && canRetryTransport && attempt < this.maxRetries) {
             lastError = classification.mcpError;
             await this.backoff(attempt);
             continue;
@@ -247,7 +255,7 @@ export class MetaApiClient {
           lastError = new Error(
             `HTTP ${response.status}: ${JSON.stringify(body)}`,
           );
-          if (response.status >= 500 && attempt < this.maxRetries) {
+          if (response.status >= 500 && canRetryTransport && attempt < this.maxRetries) {
             await this.backoff(attempt);
             continue;
           }
@@ -258,10 +266,11 @@ export class MetaApiClient {
       } catch (error) {
         if (error instanceof Error && error.name === "AbortError") {
           lastError = new Error(`Request timeout after ${this.timeout}ms`);
-          if (attempt < this.maxRetries) {
+          if (canRetryTransport && attempt < this.maxRetries) {
             await this.backoff(attempt);
             continue;
           }
+          throw lastError;
         }
 
         // Already-classified errors bubble up unchanged.
@@ -270,10 +279,11 @@ export class MetaApiClient {
         }
 
         lastError = error instanceof Error ? error : new Error(String(error));
-        if (attempt < this.maxRetries) {
+        if (canRetryTransport && attempt < this.maxRetries) {
           await this.backoff(attempt);
           continue;
         }
+        throw lastError;
       }
     }
 

--- a/src/store/clone-bundle-store.ts
+++ b/src/store/clone-bundle-store.ts
@@ -1,0 +1,117 @@
+import { Firestore } from "@google-cloud/firestore";
+import { getFirestore, isFirestoreEnabled } from "./firestore.js";
+import { logger } from "../utils/logger.js";
+
+export interface CloneBundleCreatedResources {
+  adSetId?: string;
+  creativeIds: string[];
+  adIds: string[];
+}
+
+export interface CloneBundleRecord {
+  cacheKey: string;
+  signature: string;
+  state: "in_progress" | "completed" | "failed";
+  startedAt: number;
+  completedAt?: number;
+  result?: unknown;
+  createdResources: CloneBundleCreatedResources;
+  lastError?: string;
+}
+
+const COLLECTION = "clone_bundle_operations";
+const STALE_IN_PROGRESS_MS = 15 * 60 * 1000;
+
+class InMemoryStore {
+  private readonly map = new Map<string, CloneBundleRecord>();
+
+  async getDoc(key: string): Promise<CloneBundleRecord | undefined> {
+    return this.map.get(key);
+  }
+
+  async claim(key: string, signature: string): Promise<{ status: "claimed" | "duplicate"; existing?: CloneBundleRecord }> {
+    const existing = this.map.get(key);
+    if (existing) {
+      if (existing.state === "in_progress" && Date.now() - existing.startedAt > STALE_IN_PROGRESS_MS) {
+        // Stale lock — allow re-claim.
+      } else {
+        return { status: "duplicate", existing };
+      }
+    }
+    this.map.set(key, {
+      cacheKey: key,
+      signature,
+      state: "in_progress",
+      startedAt: Date.now(),
+      createdResources: { creativeIds: [], adIds: [] },
+    });
+    return { status: "claimed" };
+  }
+
+  async update(key: string, partial: Partial<CloneBundleRecord>): Promise<void> {
+    const existing = this.map.get(key);
+    if (!existing) return;
+    this.map.set(key, { ...existing, ...partial });
+  }
+}
+
+class FirestoreStore {
+  constructor(private readonly db: Firestore) {}
+
+  private docRef(key: string) {
+    return this.db.collection(COLLECTION).doc(encodeURIComponent(key));
+  }
+
+  async getDoc(key: string): Promise<CloneBundleRecord | undefined> {
+    const snap = await this.docRef(key).get();
+    return snap.exists ? (snap.data() as CloneBundleRecord) : undefined;
+  }
+
+  async claim(key: string, signature: string): Promise<{ status: "claimed" | "duplicate"; existing?: CloneBundleRecord }> {
+    const ref = this.docRef(key);
+    return this.db.runTransaction(async (tx) => {
+      const snap = await tx.get(ref);
+      if (snap.exists) {
+        const existing = snap.data() as CloneBundleRecord;
+        const isStaleInFlight =
+          existing.state === "in_progress" &&
+          Date.now() - existing.startedAt > STALE_IN_PROGRESS_MS;
+        if (!isStaleInFlight) {
+          return { status: "duplicate", existing };
+        }
+        logger.warn({ cacheKey: key, startedAt: existing.startedAt }, "Reclaiming stale clone bundle lock");
+      }
+      const fresh: CloneBundleRecord = {
+        cacheKey: key,
+        signature,
+        state: "in_progress",
+        startedAt: Date.now(),
+        createdResources: { creativeIds: [], adIds: [] },
+      };
+      tx.set(ref, fresh);
+      return { status: "claimed" };
+    });
+  }
+
+  async update(key: string, partial: Partial<CloneBundleRecord>): Promise<void> {
+    await this.docRef(key).set(partial, { merge: true });
+  }
+}
+
+export interface CloneBundleStore {
+  getDoc(key: string): Promise<CloneBundleRecord | undefined>;
+  claim(key: string, signature: string): Promise<{ status: "claimed" | "duplicate"; existing?: CloneBundleRecord }>;
+  update(key: string, partial: Partial<CloneBundleRecord>): Promise<void>;
+}
+
+let cachedStore: CloneBundleStore | undefined;
+
+export function getCloneBundleStore(): CloneBundleStore {
+  if (cachedStore) return cachedStore;
+  cachedStore = isFirestoreEnabled() ? new FirestoreStore(getFirestore()) : new InMemoryStore();
+  return cachedStore;
+}
+
+export function resetCloneBundleStoreForTests(): void {
+  cachedStore = undefined;
+}

--- a/src/store/clone-bundle-store.ts
+++ b/src/store/clone-bundle-store.ts
@@ -20,7 +20,7 @@ export interface CloneBundleRecord {
 }
 
 const COLLECTION = "clone_bundle_operations";
-const STALE_IN_PROGRESS_MS = 15 * 60 * 1000;
+export const STALE_IN_PROGRESS_MS = 15 * 60 * 1000;
 
 class InMemoryStore {
   private readonly map = new Map<string, CloneBundleRecord>();

--- a/src/tools/adsets.ts
+++ b/src/tools/adsets.ts
@@ -8,6 +8,8 @@ import { AD_DEFAULT_FIELDS } from "../meta/types/ad.js";
 import { CREATIVE_DEFAULT_FIELDS } from "../meta/types/creative.js";
 import type { Ad, AdCreative, AdSet, GeoLocation, MetaApiResponse, TargetingSpec } from "../meta/types/index.js";
 import { READ, CREATE, UPDATE, DELETE, WRITE_WARNING } from "./_register.js";
+import { getCloneBundleStore } from "../store/clone-bundle-store.js";
+import { ctaEnum } from "./creatives.js";
 
 const statusEnum = z.enum(["ACTIVE", "PAUSED", "DELETED", "ARCHIVED"]);
 
@@ -122,10 +124,11 @@ const adSetIdentityFields = ["id", "name", "campaign_id", "status", "effective_s
 
 const cloneTargetAdSetSchema = z.object({
   name: z.string().min(1).describe("Name for the cloned ad set"),
-  geo_override: geoLocationSchema.describe("Geo override applied on top of the source targeting (for example, { countries: ['CL'] })"),
+  geo_override: geoLocationSchema.describe("Geo override that REPLACES the source geo_locations (for example, { countries: ['CL'] }). Cities/regions/zips from the source are NOT inherited."),
   status: z.enum(["ACTIVE", "PAUSED"]).default("PAUSED").describe("Status for the cloned ad set and ads. Defaults to PAUSED."),
-  daily_budget: z.number().optional().describe("Optional daily budget override in cents"),
-  lifetime_budget: z.number().optional().describe("Optional lifetime budget override in cents"),
+  daily_budget: z.number().optional().describe("Optional daily budget override in cents. Takes precedence over the source budget, regardless of source budget type."),
+  lifetime_budget: z.number().optional().describe("Optional lifetime budget override in cents. Requires end_time."),
+  end_time: z.string().optional().describe("ISO 8601 end time. Required when lifetime_budget is set."),
   destination_type: destinationTypeEnum.optional().describe("Optional destination_type override"),
   promoted_object: z.record(z.unknown()).optional().describe("Optional promoted_object override"),
 });
@@ -138,7 +141,7 @@ const creativeOverrideSchema = z.object({
   message: z.string().optional().describe("Primary text override"),
   description: z.string().optional().describe("Description override"),
   link_url: z.string().optional().describe("Optional destination URL override"),
-  call_to_action_type: z.string().optional().describe("Optional CTA override"),
+  call_to_action_type: ctaEnum.optional().describe("Optional CTA override"),
 }).refine(
   (value) => Boolean(value.source_ad_id || value.source_creative_id),
   "Each creative override must include source_ad_id or source_creative_id.",
@@ -184,15 +187,10 @@ interface CloneAdSetBundleResult {
   warnings: string[];
 }
 
-interface CachedCloneBundleOperation {
-  signature: string;
-  result: CloneAdSetBundleResult;
-}
-
 interface ResolvedCloneCreativeInput {
   name: string;
   page_id: string;
-  instagram_actor_id?: string;
+  instagram_user_id?: string;
   image_hash?: string;
   image_url?: string;
   video_id?: string;
@@ -202,8 +200,6 @@ interface ResolvedCloneCreativeInput {
   description?: string;
   call_to_action_type?: string;
 }
-
-const cloneAdSetBundleCache = new Map<string, CachedCloneBundleOperation>();
 
 function asRecord(value: unknown): Record<string, unknown> | undefined {
   return typeof value === "object" && value !== null ? value as Record<string, unknown> : undefined;
@@ -246,17 +242,27 @@ function buildAdSetDetailsFields(fields?: string[]): string {
   const requested =
     fields && fields.length > 0
       ? [...new Set([...adSetIdentityFields, ...fields])]
-      : [...ADSET_DEFAULT_FIELDS, "frequency_control_specs", "promoted_object", "destination_type"];
+      : [...new Set([...ADSET_DEFAULT_FIELDS, "frequency_control_specs", "promoted_object", "destination_type"])];
 
   return buildFieldsParam(requested, requested);
 }
 
+const TARGETING_READ_ONLY_FIELDS = [
+  "targeting_relaxation_types",
+  "is_whatsapp_destination_ad",
+  "targeting_optimization",
+] as const;
+
 function applyGeoOverride(targeting: TargetingSpec | undefined, geoOverride: GeoLocation): TargetingSpec {
   const nextTargeting = structuredClone(targeting ?? {}) as TargetingSpec;
-  nextTargeting.geo_locations = {
-    ...(nextTargeting.geo_locations ?? {}),
-    ...geoOverride,
-  };
+  // Replace, do NOT merge. Inheriting cities/regions/zips from the source
+  // when changing countries produces nonsensical targeting (e.g., "Colombia
+  // + Santiago, Chile"). Meta's own docs recommend redefining geo_locations
+  // when swapping country.
+  nextTargeting.geo_locations = { ...geoOverride };
+  for (const field of TARGETING_READ_ONLY_FIELDS) {
+    delete nextTargeting[field];
+  }
   return nextTargeting;
 }
 
@@ -291,11 +297,20 @@ function resolveCreativeCloneInput(
     return { reason: "reuse_source_media=false todavía no está soportado para clonado automático." };
   }
 
+  // Reject asset_feed_spec FIRST. A dynamic creative that also happens to have
+  // a video_data/link_data shape would otherwise silently be cloned as a
+  // static creative, losing the feed entirely.
+  if (sourceCreative.asset_feed_spec) {
+    return { reason: "El creative fuente usa asset_feed_spec y esa variante aún no está soportada por ads_clone_ad_set_bundle." };
+  }
+
   const objectStorySpec = asRecord(sourceCreative.object_story_spec);
   const videoData = asRecord(objectStorySpec?.["video_data"]);
   const linkData = asRecord(objectStorySpec?.["link_data"]);
   const pageId = getString(objectStorySpec, "page_id");
-  const instagramActorId = getString(objectStorySpec, "instagram_actor_id");
+  const instagramUserId =
+    getString(objectStorySpec, "instagram_user_id")
+    ?? getString(objectStorySpec, "instagram_actor_id");
   const effectiveLinkUrl = override?.link_url ?? extractEffectiveCreativeLinkUrl(sourceCreative);
   const defaultName =
     override?.name
@@ -322,7 +337,7 @@ function resolveCreativeCloneInput(
       input: {
         name: defaultName,
         page_id: pageId,
-        instagram_actor_id: instagramActorId,
+        instagram_user_id: instagramUserId,
         video_id: videoId,
         image_hash: imageHash,
         image_url: imageHash ? undefined : imageUrl,
@@ -343,7 +358,7 @@ function resolveCreativeCloneInput(
       input: {
         name: defaultName,
         page_id: pageId,
-        instagram_actor_id: instagramActorId,
+        instagram_user_id: instagramUserId,
         image_hash: getString(linkData, "image_hash") ?? sourceCreative.image_hash,
         image_url: getString(linkData, "picture") ?? sourceCreative.image_url,
         link_url: effectiveLinkUrl,
@@ -356,10 +371,6 @@ function resolveCreativeCloneInput(
           ?? sourceCreative.call_to_action_type,
       },
     };
-  }
-
-  if (sourceCreative.asset_feed_spec) {
-    return { reason: "El creative fuente usa asset_feed_spec y esa variante aún no está soportada por ads_clone_ad_set_bundle." };
   }
 
   return { reason: "No se pudo resolver una estructura clonable de object_story_spec en el creative fuente." };
@@ -482,20 +493,34 @@ export function registerAdSetTools(server: McpServer): void {
       const cacheKey = idempotency_key
         ? `${idempotency_key}:${accountPath}:${sourceAdSetIdValidated}:${target_ad_set.name}`
         : undefined;
+      const store = getCloneBundleStore();
 
-      if (cacheKey) {
-        const cached = cloneAdSetBundleCache.get(cacheKey);
-        if (cached) {
-          if (cached.signature !== requestSignature) {
+      if (cacheKey && !dry_run) {
+        const existing = await store.getDoc(cacheKey);
+        if (existing) {
+          if (existing.signature !== requestSignature) {
             throw new Error("idempotency_key already exists for a different ads_clone_ad_set_bundle payload.");
           }
-
-          return {
-            content: [
-              { type: "text", text: `ads_clone_ad_set_bundle reused cached result for key ${idempotency_key}.` },
-              { type: "text", text: JSON.stringify(cached.result, null, 2) },
-            ],
-          };
+          if (existing.state === "completed" && existing.result) {
+            return {
+              content: [
+                { type: "text", text: `ads_clone_ad_set_bundle reused cached result for key ${idempotency_key}.` },
+                { type: "text", text: JSON.stringify(existing.result, null, 2) },
+              ],
+            };
+          }
+          if (existing.state === "in_progress") {
+            throw new Error(`ads_clone_ad_set_bundle is already in progress for idempotency_key ${idempotency_key} (started ${new Date(existing.startedAt).toISOString()}). Wait for completion or use a different key.`);
+          }
+          if (existing.state === "failed") {
+            const created = existing.createdResources;
+            const orphans = [
+              created.adSetId ? `ad_set=${created.adSetId}` : undefined,
+              created.creativeIds.length ? `creatives=[${created.creativeIds.join(",")}]` : undefined,
+              created.adIds.length ? `ads=[${created.adIds.join(",")}]` : undefined,
+            ].filter(Boolean).join(", ");
+            throw new Error(`Previous ads_clone_ad_set_bundle run with idempotency_key ${idempotency_key} failed. Partial resources created: ${orphans || "none"}. Error: ${existing.lastError ?? "unknown"}. Clean up these resources manually (or with ads_delete_*) and retry with a new idempotency_key.`);
+          }
         }
       }
 
@@ -508,13 +533,11 @@ export function registerAdSetTools(server: McpServer): void {
         throw new Error("Source ad set is missing optimization_goal or billing_event and cannot be cloned safely.");
       }
 
-      if (
-        target_ad_set.daily_budget === undefined
-        && target_ad_set.lifetime_budget === undefined
-        && sourceAdSet.daily_budget === undefined
-        && sourceAdSet.lifetime_budget === undefined
-      ) {
-        throw new Error("Source ad set has no ad-set-level budget. Provide target_ad_set.daily_budget or target_ad_set.lifetime_budget.");
+      // Note: when both source and target have no budget, we assume the parent
+      // campaign uses CBO (Campaign Budget Optimization). Meta will reject the
+      // create call if that assumption is wrong, with a clear error.
+      if (target_ad_set.lifetime_budget !== undefined && !target_ad_set.end_time) {
+        throw new Error("target_ad_set.lifetime_budget requires target_ad_set.end_time.");
       }
 
       const adsFieldsParam = buildFieldsParam(undefined, [...AD_DEFAULT_FIELDS, "tracking_specs"]);
@@ -624,34 +647,92 @@ export function registerAdSetTools(server: McpServer): void {
         };
       }
 
-      const accountNodeId = normalizeAccountId(account_id);
+      if (resolvedCreativePlans.length === 0) {
+        throw new Error(`ads_clone_ad_set_bundle: no clonable creatives in source ad set ${sourceAdSetIdValidated}. Skipped: ${JSON.stringify(skipped)}`);
+      }
+
+      if (cacheKey) {
+        const claim = await store.claim(cacheKey, requestSignature);
+        if (claim.status === "duplicate") {
+          const existing = claim.existing!;
+          if (existing.signature !== requestSignature) {
+            throw new Error("idempotency_key already exists for a different ads_clone_ad_set_bundle payload.");
+          }
+          if (existing.state === "completed" && existing.result) {
+            return {
+              content: [
+                { type: "text", text: `ads_clone_ad_set_bundle reused cached result for key ${idempotency_key}.` },
+                { type: "text", text: JSON.stringify(existing.result, null, 2) },
+              ],
+            };
+          }
+          throw new Error(`ads_clone_ad_set_bundle: concurrent execution detected for idempotency_key ${idempotency_key}.`);
+        }
+      }
+
+      const createdResources = { adSetId: undefined as string | undefined, creativeIds: [] as string[], adIds: [] as string[] };
+      const markFailed = async (error: unknown): Promise<void> => {
+        if (!cacheKey) return;
+        try {
+          await store.update(cacheKey, {
+            state: "failed",
+            lastError: error instanceof Error ? error.message : String(error),
+            createdResources,
+          });
+        } catch (storeErr) {
+          // best-effort; do not mask the original error
+          void storeErr;
+        }
+      };
+
       const createAdSetBody: Record<string, string | number | boolean> = {
         campaign_id: sourceAdSet.campaign_id,
         name: target_ad_set.name,
-        destination_type: target_ad_set.destination_type ?? sourceAdSet.destination_type ?? "WEBSITE",
         status: targetStatus,
         optimization_goal: sourceAdSet.optimization_goal,
         billing_event: sourceAdSet.billing_event,
         targeting: JSON.stringify(clonedTargeting),
       };
+      const resolvedDestinationType = target_ad_set.destination_type ?? sourceAdSet.destination_type;
+      if (resolvedDestinationType) createAdSetBody.destination_type = resolvedDestinationType;
 
-      const resolvedLifetimeBudget = target_ad_set.lifetime_budget ?? (sourceAdSet.lifetime_budget ? Number(sourceAdSet.lifetime_budget) : undefined);
-      const resolvedDailyBudget =
-        resolvedLifetimeBudget === undefined
-          ? target_ad_set.daily_budget ?? (sourceAdSet.daily_budget ? Number(sourceAdSet.daily_budget) : undefined)
-          : undefined;
+      // Budget resolution: user-provided overrides win regardless of source
+      // budget shape. Only fall back to source when the user provides neither.
+      // If both source and user provide nothing, leave both unset (CBO case).
+      let resolvedDailyBudget: number | undefined;
+      let resolvedLifetimeBudget: number | undefined;
+      let resolvedEndTime: string | undefined;
+      if (target_ad_set.lifetime_budget !== undefined) {
+        resolvedLifetimeBudget = target_ad_set.lifetime_budget;
+        resolvedEndTime = target_ad_set.end_time;
+      } else if (target_ad_set.daily_budget !== undefined) {
+        resolvedDailyBudget = target_ad_set.daily_budget;
+      } else if (sourceAdSet.lifetime_budget) {
+        resolvedLifetimeBudget = Number(sourceAdSet.lifetime_budget);
+        resolvedEndTime = sourceAdSet.end_time;
+      } else if (sourceAdSet.daily_budget) {
+        resolvedDailyBudget = Number(sourceAdSet.daily_budget);
+      }
 
       if (resolvedLifetimeBudget !== undefined) createAdSetBody.lifetime_budget = String(resolvedLifetimeBudget);
       if (resolvedDailyBudget !== undefined) createAdSetBody.daily_budget = String(resolvedDailyBudget);
       if (sourceAdSet.bid_amount !== undefined) createAdSetBody.bid_amount = sourceAdSet.bid_amount;
       if (sourceAdSet.bid_strategy) createAdSetBody.bid_strategy = sourceAdSet.bid_strategy;
       if (sourceAdSet.start_time) createAdSetBody.start_time = sourceAdSet.start_time;
-      if (sourceAdSet.end_time && resolvedLifetimeBudget !== undefined) createAdSetBody.end_time = sourceAdSet.end_time;
+      if (resolvedEndTime && resolvedLifetimeBudget !== undefined) createAdSetBody.end_time = resolvedEndTime;
 
       const promotedObject = target_ad_set.promoted_object ?? sourceAdSet.promoted_object;
       if (promotedObject) createAdSetBody.promoted_object = JSON.stringify(promotedObject);
 
-      const newAdSet = await metaApiClient.postForm<{ id: string }>(`/${accountNodeId}/adsets`, createAdSetBody);
+      let newAdSet: { id: string };
+      try {
+        newAdSet = await metaApiClient.postForm<{ id: string }>(`/${accountPath}/adsets`, createAdSetBody);
+      } catch (err) {
+        await markFailed(err);
+        throw err;
+      }
+      createdResources.adSetId = newAdSet.id;
+      if (cacheKey) await store.update(cacheKey, { createdResources });
       result.new_ad_set = {
         id: newAdSet.id,
         name: target_ad_set.name,
@@ -664,7 +745,7 @@ export function registerAdSetTools(server: McpServer): void {
           name: plan.input.name,
           object_story_spec: JSON.stringify({
             page_id: plan.input.page_id,
-            ...(plan.input.instagram_actor_id ? { instagram_actor_id: plan.input.instagram_actor_id } : {}),
+            ...(plan.input.instagram_user_id ? { instagram_user_id: plan.input.instagram_user_id } : {}),
             ...(plan.input.video_id
               ? {
                   video_data: {
@@ -709,10 +790,18 @@ export function registerAdSetTools(server: McpServer): void {
           }),
         };
 
-        const createdCreative = await metaApiClient.postForm<{ id: string }>(
-          `/${accountNodeId}/adcreatives`,
-          creativeBody,
-        );
+        let createdCreative: { id: string };
+        try {
+          createdCreative = await metaApiClient.postForm<{ id: string }>(
+            `/${accountPath}/adcreatives`,
+            creativeBody,
+          );
+        } catch (err) {
+          await markFailed(err);
+          throw new Error(`${err instanceof Error ? err.message : String(err)} (partial state: ad_set=${createdResources.adSetId}, creatives=[${createdResources.creativeIds.join(",")}], ads=[${createdResources.adIds.join(",")}])`);
+        }
+        createdResources.creativeIds.push(createdCreative.id);
+        if (cacheKey) await store.update(cacheKey, { createdResources });
 
         result.created_creatives.push({
           id: createdCreative.id,
@@ -734,7 +823,15 @@ export function registerAdSetTools(server: McpServer): void {
           adBody.tracking_specs = JSON.stringify(plan.sourceAd.tracking_specs);
         }
 
-        const createdAd = await metaApiClient.postForm<{ id: string }>(`/${accountNodeId}/ads`, adBody);
+        let createdAd: { id: string };
+        try {
+          createdAd = await metaApiClient.postForm<{ id: string }>(`/${accountPath}/ads`, adBody);
+        } catch (err) {
+          await markFailed(err);
+          throw new Error(`${err instanceof Error ? err.message : String(err)} (partial state: ad_set=${createdResources.adSetId}, creatives=[${createdResources.creativeIds.join(",")}], ads=[${createdResources.adIds.join(",")}])`);
+        }
+        createdResources.adIds.push(createdAd.id);
+        if (cacheKey) await store.update(cacheKey, { createdResources });
         result.created_ads.push({
           id: createdAd.id,
           name: clonedAdName,
@@ -746,7 +843,11 @@ export function registerAdSetTools(server: McpServer): void {
       }
 
       if (cacheKey) {
-        cloneAdSetBundleCache.set(cacheKey, { signature: requestSignature, result });
+        await store.update(cacheKey, {
+          state: "completed",
+          completedAt: Date.now(),
+          result,
+        });
       }
 
       return {

--- a/src/tools/adsets.ts
+++ b/src/tools/adsets.ts
@@ -8,7 +8,7 @@ import { AD_DEFAULT_FIELDS } from "../meta/types/ad.js";
 import { CREATIVE_DEFAULT_FIELDS } from "../meta/types/creative.js";
 import type { Ad, AdCreative, AdSet, GeoLocation, MetaApiResponse, TargetingSpec } from "../meta/types/index.js";
 import { READ, CREATE, UPDATE, DELETE, WRITE_WARNING } from "./_register.js";
-import { getCloneBundleStore } from "../store/clone-bundle-store.js";
+import { getCloneBundleStore, STALE_IN_PROGRESS_MS } from "../store/clone-bundle-store.js";
 import { ctaEnum } from "./creatives.js";
 
 const statusEnum = z.enum(["ACTIVE", "PAUSED", "DELETED", "ARCHIVED"]);
@@ -510,7 +510,13 @@ export function registerAdSetTools(server: McpServer): void {
             };
           }
           if (existing.state === "in_progress") {
-            throw new Error(`ads_clone_ad_set_bundle is already in progress for idempotency_key ${idempotency_key} (started ${new Date(existing.startedAt).toISOString()}). Wait for completion or use a different key.`);
+            const lockAgeMs = Date.now() - existing.startedAt;
+            if (lockAgeMs <= STALE_IN_PROGRESS_MS) {
+              throw new Error(`ads_clone_ad_set_bundle is already in progress for idempotency_key ${idempotency_key} (started ${new Date(existing.startedAt).toISOString()}). Wait for completion or use a different key.`);
+            }
+            // Stale lock (>STALE_IN_PROGRESS_MS) — fall through to store.claim()
+            // which takes over the stale entry. This handles the crash-between-
+            // claim-and-markFailed case so users aren't blocked permanently.
           }
           if (existing.state === "failed") {
             const created = existing.createdResources;

--- a/src/tools/creatives.ts
+++ b/src/tools/creatives.ts
@@ -12,7 +12,7 @@ import { assertSafePublicUrl, UnsafeUrlError } from "../utils/url-guard.js";
 import { downloadSafePublicImage } from "../utils/safe-download.js";
 import { READ, CREATE, UPDATE, UPLOAD, WRITE_WARNING } from "./_register.js";
 
-const ctaEnum = z.enum([
+export const ctaEnum = z.enum([
   // Core actions
   "LEARN_MORE", "SIGN_UP", "DOWNLOAD", "SUBSCRIBE", "CONTACT_US",
   "APPLY_NOW", "GET_OFFER", "GET_QUOTE", "GET_STARTED", "OPEN_LINK",
@@ -274,7 +274,7 @@ export function registerCreativeTools(server: McpServer): void {
         }
 
         if (instagramActorIdValidated) {
-          objectStorySpec.instagram_actor_id = instagramActorIdValidated;
+          objectStorySpec.instagram_user_id = instagramActorIdValidated;
         }
 
         body.object_story_spec = JSON.stringify(objectStorySpec);

--- a/src/tools/instagram.ts
+++ b/src/tools/instagram.ts
@@ -52,7 +52,7 @@ export function registerInstagramTools(server: McpServer): void {
         content: [
           {
             type: "text",
-            text: `Instagram Business Account found!\nID: ${ig.id}\nUsername: ${ig.username ?? "N/A"}\nName: ${ig.name ?? "N/A"}\nFollowers: ${ig.followers_count ?? "N/A"}\nMedia count: ${ig.media_count ?? "N/A"}\n\nUse this ID (${ig.id}) as the instagram_actor_id parameter when creating creatives. The MCP maps it to the correct API field automatically (instagram_actor_id inside object_story_spec, instagram_user_id at top-level for source_instagram_media_id / object_story_id modes).`,
+            text: `Instagram Business Account found!\nID: ${ig.id}\nUsername: ${ig.username ?? "N/A"}\nName: ${ig.name ?? "N/A"}\nFollowers: ${ig.followers_count ?? "N/A"}\nMedia count: ${ig.media_count ?? "N/A"}\n\nUse this ID (${ig.id}) as the instagram_actor_id parameter when creating creatives. The MCP maps it to instagram_user_id internally (Meta deprecated instagram_actor_id in Marketing API v22.0).`,
           },
           { type: "text", text: JSON.stringify(ig, null, 2) },
         ],

--- a/tests/meta/client.test.ts
+++ b/tests/meta/client.test.ts
@@ -278,6 +278,61 @@ describe("MetaApiClient", () => {
       expect(vi.mocked(fetch)).toHaveBeenCalledTimes(2);
     });
 
+    it("does NOT retry POST to account-scoped collection paths on 5xx (idempotency safety)", async () => {
+      const retryClient = new MetaApiClient({
+        maxRetries: 3,
+        timeout: 5000,
+      });
+
+      const serverErrorResponse = mockFetchResponse(
+        {
+          error: {
+            message: "Server error",
+            type: "API_ERROR",
+            code: 1,
+          },
+        },
+      );
+
+      vi.stubGlobal("fetch", vi.fn().mockResolvedValue(serverErrorResponse));
+
+      await expect(retryClient.postForm("/act_123/adsets", { name: "x" })).rejects.toThrow();
+      // POST to /act_*/adsets is a CREATE — must not retry, even on retryable
+      // errors, because Meta has no native idempotency and a successful create
+      // followed by a response-side failure would mint a duplicate on retry.
+      expect(vi.mocked(fetch)).toHaveBeenCalledTimes(1);
+    });
+
+    it("still retries POST to non-account-scoped paths (updates are idempotent)", async () => {
+      const retryClient = new MetaApiClient({
+        maxRetries: 1,
+        timeout: 5000,
+      });
+
+      const serverErrorResponse = mockFetchResponse(
+        {
+          error: {
+            message: "Server error",
+            type: "API_ERROR",
+            code: 1,
+          },
+        },
+      );
+      const successResponse = mockFetchResponse({ success: true });
+
+      vi.stubGlobal(
+        "fetch",
+        vi.fn()
+          .mockResolvedValueOnce(serverErrorResponse)
+          .mockResolvedValueOnce(successResponse),
+      );
+
+      // POST /<adset_id> is an UPDATE — idempotent, safe to retry.
+      const result = await retryClient.postForm("/1234567890", { name: "x" });
+      expect(result).toEqual({ success: true });
+      expect(vi.mocked(fetch)).toHaveBeenCalledTimes(2);
+    });
+
     it("does not retry auth errors", async () => {
       const retryClient = new MetaApiClient({
         maxRetries: 2,

--- a/tests/tools/adsets.test.ts
+++ b/tests/tools/adsets.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { registerAdSetTools } from "../../src/tools/adsets.js";
+import { resetCloneBundleStoreForTests } from "../../src/store/clone-bundle-store.js";
 import {
   cleanupTestToken,
   createMockMcpServer,
@@ -10,10 +11,12 @@ import {
 describe("registerAdSetTools", () => {
   beforeEach(() => {
     setupTestToken();
+    resetCloneBundleStoreForTests();
   });
 
   afterEach(() => {
     cleanupTestToken();
+    resetCloneBundleStoreForTests();
     vi.restoreAllMocks();
   });
 
@@ -289,6 +292,353 @@ describe("registerAdSetTools", () => {
       const second = await handler(input) as { content: Array<{ type: string; text: string }> };
       expect(second.content[0].text).toContain("reused cached result");
       expect(vi.mocked(fetch)).toHaveBeenCalledTimes(6);
+    });
+
+    it("never duplicates destination_type in the source GET fields list", async () => {
+      const server = createMockMcpServer();
+      registerAdSetTools(server as never);
+
+      vi.stubGlobal("fetch", vi.fn().mockResolvedValue(mockFetchResponse({
+        id: "2099", name: "X", campaign_id: "1001",
+        status: "ACTIVE", effective_status: "ACTIVE",
+        daily_budget: "500",
+        optimization_goal: "OFFSITE_CONVERSIONS",
+        billing_event: "IMPRESSIONS",
+        targeting: { geo_locations: { countries: ["HN"] } },
+        destination_type: "WEBSITE",
+      })));
+
+      const handler = server._registeredTools[2].handler;
+      // dry_run=true short-circuits after the GET; we just want to assert the fields list shape.
+      await handler({
+        account_id: "act_123",
+        source_ad_set_id: "2099",
+        target_ad_set: { name: "Y", geo_override: { countries: ["CL"] }, status: "PAUSED" },
+        creative_overrides: [],
+        reuse_source_media: true,
+        dry_run: true,
+      }).catch(() => undefined);
+
+      const firstUrl = new URL(vi.mocked(fetch).mock.calls[0][0] as string);
+      const fields = firstUrl.searchParams.get("fields")?.split(",") ?? [];
+      const dups = fields.filter((f) => f === "destination_type");
+      expect(dups).toHaveLength(1);
+    });
+
+    it("dry-run: geo_override REPLACES source geo_locations (no city/region inheritance)", async () => {
+      const server = createMockMcpServer();
+      registerAdSetTools(server as never);
+
+      vi.stubGlobal("fetch", vi.fn()
+        .mockResolvedValueOnce(mockFetchResponse({
+          id: "2099", name: "Source", campaign_id: "1001",
+          status: "ACTIVE", effective_status: "ACTIVE",
+          daily_budget: "500",
+          optimization_goal: "OFFSITE_CONVERSIONS",
+          billing_event: "IMPRESSIONS",
+          targeting: {
+            geo_locations: {
+              countries: ["CL"],
+              cities: [{ key: "santiago" }],
+              regions: [{ key: "RM" }],
+            },
+            // Read-only fields Meta returns on GET — must be stripped on POST.
+            targeting_relaxation_types: { lookalike: 1 },
+            targeting_optimization: "expansion_all",
+            is_whatsapp_destination_ad: false,
+          },
+          destination_type: "WEBSITE",
+        }))
+        .mockResolvedValueOnce(mockFetchResponse({ data: [] }))); // no ads — bundle throws
+
+      const handler = server._registeredTools[2].handler;
+      // dry_run=true to avoid needing to simulate the create chain;
+      // we want to assert geo_override behavior on the cloned targeting.
+      // But applyGeoOverride is only tested via the create body, so we
+      // inspect the dry-run plan's behavior indirectly: the test simply
+      // ensures no crash and that the bundle doesn't try to inherit cities.
+      // (Detailed POST-body assertions live in the partial-failure test below.)
+      await handler({
+        account_id: "act_123",
+        source_ad_set_id: "2099",
+        target_ad_set: { name: "Target", geo_override: { countries: ["CO"] }, status: "PAUSED" },
+        creative_overrides: [],
+        reuse_source_media: true,
+        dry_run: true,
+      }).catch((err: Error) => {
+        // dry-run may still succeed with 0 planned creatives; that's fine.
+        expect(err).toBeUndefined();
+      });
+    });
+
+    it("create: strips read-only targeting fields and replaces geo_locations", async () => {
+      const server = createMockMcpServer();
+      registerAdSetTools(server as never);
+
+      vi.stubGlobal("fetch", vi.fn()
+        .mockResolvedValueOnce(mockFetchResponse({
+          id: "2099", name: "Source", campaign_id: "1001",
+          status: "ACTIVE", effective_status: "ACTIVE",
+          daily_budget: "500",
+          optimization_goal: "OFFSITE_CONVERSIONS",
+          billing_event: "IMPRESSIONS",
+          targeting: {
+            geo_locations: { countries: ["CL"], cities: [{ key: "santiago" }] },
+            targeting_relaxation_types: { lookalike: 1 },
+            targeting_optimization: "expansion_all",
+            is_whatsapp_destination_ad: false,
+            genders: [2],
+          },
+          promoted_object: { pixel_id: "px_1" },
+          destination_type: "WEBSITE",
+        }))
+        .mockResolvedValueOnce(mockFetchResponse({
+          data: [{
+            id: "3001", name: "Source__a1", adset_id: "2099", campaign_id: "1001",
+            status: "ACTIVE", effective_status: "ACTIVE", creative: { id: "4001" },
+            created_time: "2026-01-01T00:00:00-0000", updated_time: "2026-01-01T00:00:00-0000",
+          }],
+        }))
+        .mockResolvedValueOnce(mockFetchResponse({
+          id: "4001", name: "C1",
+          object_story_spec: {
+            page_id: "6001",
+            instagram_user_id: "ig_7777",
+            link_data: { link: "https://x.com/", message: "m", name: "h", image_hash: "h1" },
+          },
+        }))
+        .mockResolvedValueOnce(mockFetchResponse({ id: "20001" })) // POST ad set
+        .mockResolvedValueOnce(mockFetchResponse({ id: "40001" })) // POST creative
+        .mockResolvedValueOnce(mockFetchResponse({ id: "30001" }))); // POST ad
+
+      const handler = server._registeredTools[2].handler;
+      await handler({
+        account_id: "act_123",
+        source_ad_set_id: "2099",
+        target_ad_set: { name: "Target", geo_override: { countries: ["CO"] }, status: "PAUSED" },
+        creative_overrides: [],
+        reuse_source_media: true,
+        dry_run: false,
+        idempotency_key: "k-strip-1",
+      });
+
+      // 4th fetch call = POST /act_123/adsets
+      const adsetPost = vi.mocked(fetch).mock.calls[3];
+      expect(adsetPost[1]?.method).toBe("POST");
+      const body = adsetPost[1]?.body as string;
+      const params = new URLSearchParams(body);
+      const sentTargeting = JSON.parse(params.get("targeting") ?? "{}") as Record<string, unknown>;
+
+      // geo_locations REPLACED — no cities inherited.
+      expect(sentTargeting.geo_locations).toEqual({ countries: ["CO"] });
+      // Other targeting fields preserved.
+      expect(sentTargeting.genders).toEqual([2]);
+      // Read-only fields stripped.
+      expect(sentTargeting.targeting_relaxation_types).toBeUndefined();
+      expect(sentTargeting.targeting_optimization).toBeUndefined();
+      expect(sentTargeting.is_whatsapp_destination_ad).toBeUndefined();
+
+      // 5th fetch call = POST /act_123/adcreatives — uses instagram_user_id, not instagram_actor_id.
+      const creativePost = vi.mocked(fetch).mock.calls[4];
+      const creativeBody = creativePost[1]?.body as string;
+      const creativeParams = new URLSearchParams(creativeBody);
+      const oss = JSON.parse(creativeParams.get("object_story_spec") ?? "{}") as Record<string, unknown>;
+      expect(oss.instagram_user_id).toBe("ig_7777");
+      expect(oss.instagram_actor_id).toBeUndefined();
+    });
+
+    it("falls back to legacy instagram_actor_id on read but writes instagram_user_id", async () => {
+      const server = createMockMcpServer();
+      registerAdSetTools(server as never);
+
+      vi.stubGlobal("fetch", vi.fn()
+        .mockResolvedValueOnce(mockFetchResponse({
+          id: "2099", name: "Source", campaign_id: "1001",
+          status: "ACTIVE", effective_status: "ACTIVE",
+          daily_budget: "500",
+          optimization_goal: "OFFSITE_CONVERSIONS",
+          billing_event: "IMPRESSIONS",
+          targeting: { geo_locations: { countries: ["CL"] } },
+          destination_type: "WEBSITE",
+        }))
+        .mockResolvedValueOnce(mockFetchResponse({
+          data: [{
+            id: "3001", name: "Source__a1", adset_id: "2099", campaign_id: "1001",
+            status: "ACTIVE", effective_status: "ACTIVE", creative: { id: "4001" },
+            created_time: "2026-01-01T00:00:00-0000", updated_time: "2026-01-01T00:00:00-0000",
+          }],
+        }))
+        .mockResolvedValueOnce(mockFetchResponse({
+          id: "4001", name: "C1",
+          object_story_spec: {
+            page_id: "6001",
+            // Legacy field name — old creatives still return this.
+            instagram_actor_id: "ig_legacy_5555",
+            link_data: { link: "https://x.com/", image_hash: "h1" },
+          },
+        }))
+        .mockResolvedValueOnce(mockFetchResponse({ id: "20001" }))
+        .mockResolvedValueOnce(mockFetchResponse({ id: "40001" }))
+        .mockResolvedValueOnce(mockFetchResponse({ id: "30001" })));
+
+      const handler = server._registeredTools[2].handler;
+      await handler({
+        account_id: "act_123",
+        source_ad_set_id: "2099",
+        target_ad_set: { name: "Target", geo_override: { countries: ["CO"] }, status: "PAUSED" },
+        creative_overrides: [],
+        reuse_source_media: true,
+        dry_run: false,
+        idempotency_key: "k-legacy-1",
+      });
+
+      const creativePost = vi.mocked(fetch).mock.calls[4];
+      const oss = JSON.parse(
+        new URLSearchParams(creativePost[1]?.body as string).get("object_story_spec") ?? "{}",
+      ) as Record<string, unknown>;
+      expect(oss.instagram_user_id).toBe("ig_legacy_5555");
+      expect(oss.instagram_actor_id).toBeUndefined();
+    });
+
+    it("user-provided daily_budget wins over source lifetime_budget", async () => {
+      const server = createMockMcpServer();
+      registerAdSetTools(server as never);
+
+      vi.stubGlobal("fetch", vi.fn()
+        .mockResolvedValueOnce(mockFetchResponse({
+          id: "2099", name: "Source", campaign_id: "1001",
+          status: "ACTIVE", effective_status: "ACTIVE",
+          lifetime_budget: "100000",
+          end_time: "2026-12-31T23:59:59-0000",
+          optimization_goal: "OFFSITE_CONVERSIONS",
+          billing_event: "IMPRESSIONS",
+          targeting: { geo_locations: { countries: ["CL"] } },
+          destination_type: "WEBSITE",
+        }))
+        .mockResolvedValueOnce(mockFetchResponse({
+          data: [{
+            id: "3001", name: "Source__a1", adset_id: "2099", campaign_id: "1001",
+            status: "ACTIVE", effective_status: "ACTIVE", creative: { id: "4001" },
+            created_time: "2026-01-01T00:00:00-0000", updated_time: "2026-01-01T00:00:00-0000",
+          }],
+        }))
+        .mockResolvedValueOnce(mockFetchResponse({
+          id: "4001", name: "C1",
+          object_story_spec: {
+            page_id: "6001",
+            link_data: { link: "https://x.com/", image_hash: "h1" },
+          },
+        }))
+        .mockResolvedValueOnce(mockFetchResponse({ id: "20001" }))
+        .mockResolvedValueOnce(mockFetchResponse({ id: "40001" }))
+        .mockResolvedValueOnce(mockFetchResponse({ id: "30001" })));
+
+      const handler = server._registeredTools[2].handler;
+      await handler({
+        account_id: "act_123",
+        source_ad_set_id: "2099",
+        target_ad_set: {
+          name: "Target", geo_override: { countries: ["CO"] }, status: "PAUSED",
+          daily_budget: 500,
+        },
+        creative_overrides: [],
+        reuse_source_media: true,
+        dry_run: false,
+        idempotency_key: "k-budget-1",
+      });
+
+      const adsetPost = vi.mocked(fetch).mock.calls[3];
+      const params = new URLSearchParams(adsetPost[1]?.body as string);
+      expect(params.get("daily_budget")).toBe("500");
+      expect(params.get("lifetime_budget")).toBeNull();
+      expect(params.get("end_time")).toBeNull();
+    });
+
+    it("throws when no creatives can be cloned (does not create an empty ad set)", async () => {
+      const server = createMockMcpServer();
+      registerAdSetTools(server as never);
+
+      vi.stubGlobal("fetch", vi.fn()
+        .mockResolvedValueOnce(mockFetchResponse({
+          id: "2099", name: "Source", campaign_id: "1001",
+          status: "ACTIVE", effective_status: "ACTIVE",
+          daily_budget: "500",
+          optimization_goal: "OFFSITE_CONVERSIONS",
+          billing_event: "IMPRESSIONS",
+          targeting: { geo_locations: { countries: ["CL"] } },
+          destination_type: "WEBSITE",
+        }))
+        .mockResolvedValueOnce(mockFetchResponse({
+          data: [{
+            id: "3001", name: "Source__a1", adset_id: "2099", campaign_id: "1001",
+            status: "ACTIVE", effective_status: "ACTIVE", creative: { id: "4001" },
+            created_time: "2026-01-01T00:00:00-0000", updated_time: "2026-01-01T00:00:00-0000",
+          }],
+        }))
+        .mockResolvedValueOnce(mockFetchResponse({
+          id: "4001", name: "C1",
+          // asset_feed_spec — not supported, will be skipped.
+          asset_feed_spec: { bodies: [{ text: "x" }] },
+          object_story_spec: { page_id: "6001", link_data: { link: "https://x.com/" } },
+        })));
+
+      const handler = server._registeredTools[2].handler;
+      await expect(handler({
+        account_id: "act_123",
+        source_ad_set_id: "2099",
+        target_ad_set: { name: "Target", geo_override: { countries: ["CO"] }, status: "PAUSED" },
+        creative_overrides: [],
+        reuse_source_media: true,
+        dry_run: false,
+        idempotency_key: "k-empty-1",
+      })).rejects.toThrow(/no clonable creatives/);
+
+      // No POSTs at all — we threw before claiming or creating anything.
+      const posts = vi.mocked(fetch).mock.calls.filter((c) => c[1]?.method === "POST");
+      expect(posts).toHaveLength(0);
+    });
+
+    it("surfaces partial state in the error when ad creation fails after ad set + creative succeed", async () => {
+      const server = createMockMcpServer();
+      registerAdSetTools(server as never);
+
+      vi.stubGlobal("fetch", vi.fn()
+        .mockResolvedValueOnce(mockFetchResponse({
+          id: "2099", name: "Source", campaign_id: "1001",
+          status: "ACTIVE", effective_status: "ACTIVE",
+          daily_budget: "500",
+          optimization_goal: "OFFSITE_CONVERSIONS",
+          billing_event: "IMPRESSIONS",
+          targeting: { geo_locations: { countries: ["CL"] } },
+          destination_type: "WEBSITE",
+        }))
+        .mockResolvedValueOnce(mockFetchResponse({
+          data: [{
+            id: "3001", name: "Source__a1", adset_id: "2099", campaign_id: "1001",
+            status: "ACTIVE", effective_status: "ACTIVE", creative: { id: "4001" },
+            created_time: "2026-01-01T00:00:00-0000", updated_time: "2026-01-01T00:00:00-0000",
+          }],
+        }))
+        .mockResolvedValueOnce(mockFetchResponse({
+          id: "4001", name: "C1",
+          object_story_spec: { page_id: "6001", link_data: { link: "https://x.com/", image_hash: "h1" } },
+        }))
+        .mockResolvedValueOnce(mockFetchResponse({ id: "20001" })) // POST ad set OK
+        .mockResolvedValueOnce(mockFetchResponse({ id: "40001" })) // POST creative OK
+        .mockResolvedValueOnce(mockFetchResponse({  // POST ad FAILS
+          error: { message: "Bad ad payload", type: "OAuthException", code: 100 },
+        })));
+
+      const handler = server._registeredTools[2].handler;
+      await expect(handler({
+        account_id: "act_123",
+        source_ad_set_id: "2099",
+        target_ad_set: { name: "Target", geo_override: { countries: ["CO"] }, status: "PAUSED" },
+        creative_overrides: [],
+        reuse_source_media: true,
+        dry_run: false,
+        idempotency_key: "k-partial-1",
+      })).rejects.toThrow(/partial state.*ad_set=20001.*creatives=\[40001\]/);
     });
   });
 

--- a/tests/tools/adsets.test.ts
+++ b/tests/tools/adsets.test.ts
@@ -598,6 +598,70 @@ describe("registerAdSetTools", () => {
       expect(posts).toHaveLength(0);
     });
 
+    it("reclaims a stale in_progress lock instead of blocking retries forever", async () => {
+      // Simulate a previous crash: the store has an in_progress doc older than
+      // STALE_IN_PROGRESS_MS for the same key. The retry must take over the
+      // stale lock and proceed, not throw "already in progress".
+      const { getCloneBundleStore, STALE_IN_PROGRESS_MS } = await import("../../src/store/clone-bundle-store.js");
+      const store = getCloneBundleStore();
+      const staleKey = "k-stale-1:act_123:2099:Target";
+      await store.claim(staleKey, JSON.stringify({
+        account_id: "act_123",
+        source_ad_set_id: "2099",
+        target_ad_set: {
+          name: "Target",
+          geo_override: { countries: ["CO"] },
+          status: "PAUSED",
+        },
+        creative_overrides: [],
+        reuse_source_media: true,
+      }));
+      // Backdate startedAt so the lock is stale.
+      await store.update(staleKey, { startedAt: Date.now() - STALE_IN_PROGRESS_MS - 1000 });
+
+      const server = createMockMcpServer();
+      registerAdSetTools(server as never);
+
+      vi.stubGlobal("fetch", vi.fn()
+        .mockResolvedValueOnce(mockFetchResponse({
+          id: "2099", name: "Source", campaign_id: "1001",
+          status: "ACTIVE", effective_status: "ACTIVE",
+          daily_budget: "500",
+          optimization_goal: "OFFSITE_CONVERSIONS",
+          billing_event: "IMPRESSIONS",
+          targeting: { geo_locations: { countries: ["CL"] } },
+          destination_type: "WEBSITE",
+        }))
+        .mockResolvedValueOnce(mockFetchResponse({
+          data: [{
+            id: "3001", name: "Source__a1", adset_id: "2099", campaign_id: "1001",
+            status: "ACTIVE", effective_status: "ACTIVE", creative: { id: "4001" },
+            created_time: "2026-01-01T00:00:00-0000", updated_time: "2026-01-01T00:00:00-0000",
+          }],
+        }))
+        .mockResolvedValueOnce(mockFetchResponse({
+          id: "4001", name: "C1",
+          object_story_spec: { page_id: "6001", link_data: { link: "https://x.com/", image_hash: "h1" } },
+        }))
+        .mockResolvedValueOnce(mockFetchResponse({ id: "20002" }))
+        .mockResolvedValueOnce(mockFetchResponse({ id: "40002" }))
+        .mockResolvedValueOnce(mockFetchResponse({ id: "30002" })));
+
+      const handler = server._registeredTools[2].handler;
+      const result = await handler({
+        account_id: "act_123",
+        source_ad_set_id: "2099",
+        target_ad_set: { name: "Target", geo_override: { countries: ["CO"] }, status: "PAUSED" },
+        creative_overrides: [],
+        reuse_source_media: true,
+        dry_run: false,
+        idempotency_key: "k-stale-1",
+      }) as { content: Array<{ type: string; text: string }> };
+
+      const payload = JSON.parse(result.content[1].text) as { new_ad_set: { id?: string } };
+      expect(payload.new_ad_set.id).toBe("20002");
+    });
+
     it("surfaces partial state in the error when ad creation fails after ad set + creative succeed", async () => {
       const server = createMockMcpServer();
       registerAdSetTools(server as never);


### PR DESCRIPTION
Audit-driven fixes after Meta API error 2500 (duplicate destination_type in GET fields). Verified against Marketing API v25 docs + independent code review.

- instagram_actor_id → instagram_user_id (deprecated in v22.0 changelog). Read fallback preserves legacy creatives.
- MetaApiClient no longer retries POST to /act_*/<collection> paths on timeout/5xx — prevented silent duplicates of created resources.
- ads_clone_ad_set_bundle: strip read-only targeting fields (targeting_relaxation_types, is_whatsapp_destination_ad, targeting_optimization) before POST.
- ads_clone_ad_set_bundle: geo_override now replaces geo_locations instead of merging (was inheriting cities/regions on country swap).
- ads_clone_ad_set_bundle: user-provided budget overrides win regardless of source budget shape. Adds target_ad_set.end_time.
- ads_clone_ad_set_bundle: idempotency moved from in-process Map to Firestore-backed store with partial-failure tracking. Errors surface partial state (created ad_set/creative/ad IDs).
- ads_clone_ad_set_bundle: CBO ad sets are clonable (no budget required).
- ads_clone_ad_set_bundle: asset_feed_spec rejected before video/link check; throws on empty bundle instead of creating empty ad set.
- creative_overrides.call_to_action_type validated against ctaEnum.
- Removed hard-coded "WEBSITE" destination_type fallback.

Adds 9 tests covering critical/high paths.

<!--
Thanks for contributing to meta-ads-mcp.

Please complete the sections below. PRs that skip the security checklist or
the verification steps are likely to be sent back. See CONTRIBUTING.md for the
full contribution guide.
-->

## Summary

<!-- One or two sentences: what changes and why. -->

## Why

<!-- The motivation. Link an issue if there is one (Fixes #123). -->

## How to verify

<!-- Reproducible steps. Commands, URLs, logs, screenshots — whatever makes
the reviewer's life easier. -->

```bash
# example
npm test
```

## Tests

<!-- Which tests cover this change? If none, explain why. -->

- [ ] New tests added under `tests/` mirroring the source path
- [ ] Existing tests still pass (`npm test`)
- [ ] Manual verification against a real dev environment (describe below)

## Checklist

- [ ] `npm run lint`, `npm run typecheck`, `npm test`, `npm run build` all pass locally
- [ ] No secrets in the diff (env vars, tokens, keys). If unsure, run `gitleaks git --staged --config .gitleaks.toml`
- [ ] Updated relevant docs (`README.md`, `SECURITY.md`, `CONTRIBUTING.md`) if behavior changed
- [ ] Conventional commit prefix in title (`feat:`, `fix:`, `chore:`, `docs:`, `refactor:`, `test:`, `ci:`)

## Auth / security surface

Tick **all** that apply. If any box is ticked, expect extra review scrutiny and
explain the threat-model impact in the description.

- [ ] Touches `src/auth/`, `src/store/`, or `src/transport/security-config.ts`
- [ ] Modifies the OAuth flow, session cookie shape, or Firestore document layout
- [ ] Adds, removes, or rotates an environment variable referenced as a secret
- [ ] Changes a GitHub Actions workflow under `.github/workflows/`
- [ ] Adds a new third-party dependency (production or dev)
- [ ] Loosens an existing access check or allowlist

If none of the above apply, write *None* below and the bot will not block on
the security reviewer.

> _Threat-model notes:_
