### PR TITLE
Improve gitleaks regex and allowlist for historical commits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,15 +49,28 @@ jobs:
 
   secret-scan:
     name: gitleaks (secret scan)
+    # Required check: the job must always run so it can report a
+    # status. Skip only the inner steps for fork PRs, where GitHub
+    # withholds org secrets (GITLEAKS_LICENSE) and gitleaks-action
+    # aborts before scanning. Push to main and PRs from internal
+    # branches scan normally. Fork contributions are still covered
+    # by maintainers running pre-deploy-guard locally on the
+    # merged result.
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
+      - name: Skip notice (fork PR)
+        if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
+        run: echo "Skipping gitleaks scan — PR from fork (org secrets unavailable). Push to main will re-scan."
+
       - name: Checkout
+        if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
           fetch-depth: 0
 
       - name: Run gitleaks
+        if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
         uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7  # v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -47,7 +47,12 @@ tags = ["oauth", "secret"]
 [[rules]]
 id = "oauth-approval-pin"
 description = "MCP OAuth approval PIN (deprecated — should never appear)"
-regex = '''(?i)OAUTH_APPROVAL_PIN\s*[:=]\s*["']?[A-Za-z0-9]{6,}["']?'''
+# Quoted form OR unquoted value terminated by EOL/whitespace/punctuation.
+# The unquoted branch's trailing `[^.A-Za-z0-9_]` rejects identifier
+# references like `OAUTH_APPROVAL_PIN: process.env.X` that would otherwise
+# false-positive on the next identifier characters. RE2 (Go) does not
+# support lookahead, so we use alternation.
+regex = '''(?i)OAUTH_APPROVAL_PIN\s*[:=]\s*(?:["'][A-Za-z0-9]{6,}["']|[A-Za-z0-9]{6,}(?:$|[^.A-Za-z0-9_]))'''
 tags = ["oauth", "secret"]
 
 [[rules]]
@@ -109,6 +114,15 @@ tags = ["key", "pem"]
 
 [allowlist]
 description = "global allowlist for documented examples, lockfiles, and local env"
+# Historical commits with test-only fixture values that pre-date the
+# current fixture conventions (`test-*`, `placeholder`, `fixture`).
+# The current main versions of these test files use allowlisted patterns.
+# DO NOT extend this list to suppress findings in NEW commits — fix the
+# fixture instead.
+commits = [
+  "245fa2cf1aa2aa43f80044ca206888e61e73eaf0",
+  "79c5edcc82f8c5fa79b75d4bf16e6c14c785a0ad",
+]
 paths = [
   '''(^|/)\.env\.example$''',
   '''(^|/)\.env(\..*)?$''',


### PR DESCRIPTION
Enhance the regex for detecting OAUTH_APPROVAL_PIN and implement logic to skip scanning for pull requests from forks. Add an allowlist for historical commits to prevent false positives during secret scanning.

