### PR TITLE
release: v3.1.1 — fix ads_create_custom_audience for pixel-based WEBSITE audiences

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,15 +49,28 @@ jobs:
 
   secret-scan:
     name: gitleaks (secret scan)
+    # Required check: the job must always run so it can report a
+    # status. Skip only the inner steps for fork PRs, where GitHub
+    # withholds org secrets (GITLEAKS_LICENSE) and gitleaks-action
+    # aborts before scanning. Push to main and PRs from internal
+    # branches scan normally. Fork contributions are still covered
+    # by maintainers running pre-deploy-guard locally on the
+    # merged result.
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
+      - name: Skip notice (fork PR)
+        if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
+        run: echo "Skipping gitleaks scan — PR from fork (org secrets unavailable). Push to main will re-scan."
+
       - name: Checkout
+        if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
           fetch-depth: 0
 
       - name: Run gitleaks
+        if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
         uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7  # v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -47,7 +47,12 @@ tags = ["oauth", "secret"]
 [[rules]]
 id = "oauth-approval-pin"
 description = "MCP OAuth approval PIN (deprecated — should never appear)"
-regex = '''(?i)OAUTH_APPROVAL_PIN\s*[:=]\s*["']?[A-Za-z0-9]{6,}["']?'''
+# Quoted form OR unquoted value terminated by EOL/whitespace/punctuation.
+# The unquoted branch's trailing `[^.A-Za-z0-9_]` rejects identifier
+# references like `OAUTH_APPROVAL_PIN: process.env.X` that would otherwise
+# false-positive on the next identifier characters. RE2 (Go) does not
+# support lookahead, so we use alternation.
+regex = '''(?i)OAUTH_APPROVAL_PIN\s*[:=]\s*(?:["'][A-Za-z0-9]{6,}["']|[A-Za-z0-9]{6,}(?:$|[^.A-Za-z0-9_]))'''
 tags = ["oauth", "secret"]
 
 [[rules]]
@@ -109,6 +114,15 @@ tags = ["key", "pem"]
 
 [allowlist]
 description = "global allowlist for documented examples, lockfiles, and local env"
+# Historical commits with test-only fixture values that pre-date the
+# current fixture conventions (`test-*`, `placeholder`, `fixture`).
+# The current main versions of these test files use allowlisted patterns.
+# DO NOT extend this list to suppress findings in NEW commits — fix the
+# fixture instead.
+commits = [
+  "245fa2cf1aa2aa43f80044ca206888e61e73eaf0",
+  "79c5edcc82f8c5fa79b75d4bf16e6c14c785a0ad",
+]
 paths = [
   '''(^|/)\.env\.example$''',
   '''(^|/)\.env(\..*)?$''',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1899,9 +1899,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4074,9 +4074,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.14.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
-      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@byadsco/meta-ads-mcp",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@byadsco/meta-ads-mcp",
-      "version": "3.1.0",
+      "version": "3.1.1",
       "license": "MIT",
       "dependencies": {
         "@google-cloud/firestore": "^8.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@byadsco/meta-ads-mcp",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "MCP server for Meta Ads (Facebook/Instagram) management - agency multi-account",
   "author": {
     "name": "Santiago Bastidas",

--- a/src/tools/audiences.ts
+++ b/src/tools/audiences.ts
@@ -87,15 +87,17 @@ export function registerAudienceTools(server: McpServer): void {
   server.registerTool(
     "ads_create_custom_audience",
     {
-      description: `${WRITE_WARNING}Create a new custom audience on an ad account (CUSTOM customer-list, WEBSITE pixel-based, APP, OFFLINE_CONVERSION or ENGAGEMENT). For CUSTOM/customer-list audiences, PII (email, phone) must be SHA-256 hashed before upload. After creation: (1) optionally feed users via the customer-list endpoint, (2) build a lookalike with ads_create_lookalike_audience, and (3) apply the audience id to an ad set with ads_update_ad_set (targeting.custom_audiences=[{id}]).`,
+      description: `${WRITE_WARNING}Create a custom audience on an ad account. Two main flows: (a) WEBSITE pixel-based — pass 'rule' (event_sources of type 'pixel') and OMIT 'subtype' (Meta v18+ infers it; passing subtype: WEBSITE returns error 2654). (b) CUSTOM customer-list — pass subtype: 'CUSTOM' + customer_file_source; PII must be SHA-256 hashed before uploading users. After creation: build a lookalike with ads_create_lookalike_audience and apply the id to an ad set with ads_update_ad_set (targeting.custom_audiences=[{id}]).`,
       inputSchema: {
         account_id: z.string().describe("Ad account ID"),
         name: z.string().min(1).describe("Audience name"),
         description: z.string().optional().describe("Audience description"),
         subtype: z
           .enum(["CUSTOM", "WEBSITE", "APP", "OFFLINE_CONVERSION", "ENGAGEMENT"])
-          .default("CUSTOM")
-          .describe("Audience subtype"),
+          .optional()
+          .describe(
+            "Audience subtype. OMIT (or pass 'WEBSITE') when 'rule' is set — for pixel-based audiences Meta infers the subtype and rejects an explicit one (error 2654); the tool drops it automatically. For non-rule flows: when omitted, defaults to 'CUSTOM' (customer-list), which also requires customer_file_source.",
+          ),
         customer_file_source: z
           .enum([
             "USER_PROVIDED_ONLY",
@@ -103,9 +105,14 @@ export function registerAudienceTools(server: McpServer): void {
             "BOTH_USER_AND_PARTNER_PROVIDED",
           ])
           .optional()
-          .describe("Source of customer data (required for CUSTOM subtype)"),
+          .describe("Required only when subtype = 'CUSTOM' (customer-list)."),
         retention_days: z.number().optional().describe("Retention period in days"),
-        rule: z.string().optional().describe("Rule definition for WEBSITE audiences (JSON string)"),
+        rule: z
+          .string()
+          .optional()
+          .describe(
+            "JSON rule for pixel/event-based audiences (WEBSITE). Shape: {inclusions:{operator:'or',rules:[{event_sources:[{id:'<pixel_id>',type:'pixel'}],retention_seconds:<n>,filter:{operator:'and',filters:[{field:'event',operator:'=',value:'<event_name>'}]}}]}}. When 'rule' is set, omit 'subtype'.",
+          ),
         prefill: z.boolean().optional().describe("Whether to prefill with existing data (for WEBSITE)"),
       },
       annotations: { ...CREATE },
@@ -113,11 +120,17 @@ export function registerAudienceTools(server: McpServer): void {
     async ({ account_id, name, description, subtype, customer_file_source, retention_days, rule, prefill }) => {
       const id = normalizeAccountId(account_id);
 
-      const body: Record<string, string | number | boolean> = {
-        name,
-        subtype,
-      };
+      const effectiveSubtype = rule ? undefined : (subtype ?? "CUSTOM");
 
+      if (effectiveSubtype === "CUSTOM" && !customer_file_source) {
+        throw new Error(
+          "subtype 'CUSTOM' requires customer_file_source. Use one of: USER_PROVIDED_ONLY, PARTNER_PROVIDED_ONLY, BOTH_USER_AND_PARTNER_PROVIDED.",
+        );
+      }
+
+      const body: Record<string, string | number | boolean> = { name };
+
+      if (effectiveSubtype) body.subtype = effectiveSubtype;
       if (description) body.description = description;
       if (customer_file_source) body.customer_file_source = customer_file_source;
       if (retention_days !== undefined) body.retention_days = retention_days;
@@ -129,11 +142,12 @@ export function registerAudienceTools(server: McpServer): void {
         body,
       );
 
+      const reportedType = effectiveSubtype ?? "WEBSITE (inferred from rule)";
       return {
         content: [
           {
             type: "text",
-            text: `Custom audience created!\nID: ${result.id}\nName: ${name}\nType: ${subtype}`,
+            text: `Custom audience created!\nID: ${result.id}\nName: ${name}\nType: ${reportedType}`,
           },
         ],
       };

--- a/tests/tools/audiences.test.ts
+++ b/tests/tools/audiences.test.ts
@@ -1,0 +1,195 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { registerAudienceTools } from "../../src/tools/audiences.js";
+import {
+  createMockMcpServer,
+  setupTestToken,
+  cleanupTestToken,
+  mockFetchResponse,
+} from "../setup.js";
+
+const CREATE_AUDIENCE_INDEX = 2;
+
+const PIXEL_RULE = JSON.stringify({
+  inclusions: {
+    operator: "or",
+    rules: [
+      {
+        event_sources: [{ id: "319119567739392", type: "pixel" }],
+        retention_seconds: 15552000,
+        filter: {
+          operator: "and",
+          filters: [{ field: "event", operator: "=", value: "FTD" }],
+        },
+      },
+    ],
+  },
+});
+
+describe("registerAudienceTools", () => {
+  beforeEach(() => {
+    setupTestToken();
+  });
+
+  afterEach(() => {
+    cleanupTestToken();
+    vi.restoreAllMocks();
+  });
+
+  it("registers exactly 5 tools", () => {
+    const server = createMockMcpServer();
+    registerAudienceTools(server as never);
+    expect(server.registerTool).toHaveBeenCalledTimes(5);
+  });
+
+  it("registers tools with expected names", () => {
+    const server = createMockMcpServer();
+    registerAudienceTools(server as never);
+
+    const names = server._registeredTools.map((t) => t.name);
+    expect(names).toEqual([
+      "ads_get_custom_audiences",
+      "ads_get_audience_details",
+      "ads_create_custom_audience",
+      "ads_create_lookalike_audience",
+      "ads_delete_custom_audience",
+    ]);
+  });
+
+  describe("ads_create_custom_audience handler", () => {
+    it("omits subtype and forwards rule when creating a pixel-based WEBSITE audience", async () => {
+      const server = createMockMcpServer();
+      registerAudienceTools(server as never);
+
+      vi.stubGlobal("fetch", vi.fn().mockResolvedValue(mockFetchResponse({ id: "9000123" })));
+
+      const handler = server._registeredTools[CREATE_AUDIENCE_INDEX].handler;
+      const result = await handler({
+        account_id: "1564852554415330",
+        name: "Doradobet - FTD - 180D",
+        description: undefined,
+        subtype: undefined,
+        customer_file_source: undefined,
+        retention_days: 180,
+        rule: PIXEL_RULE,
+        prefill: true,
+      }) as { content: Array<{ type: string; text: string }> };
+
+      expect(result.content[0].text).toContain("Custom audience created!");
+      expect(result.content[0].text).toContain("9000123");
+
+      const call = vi.mocked(fetch).mock.calls[0];
+      const body = String(call[1]?.body ?? "");
+      const params = new URLSearchParams(body);
+
+      expect(params.get("name")).toBe("Doradobet - FTD - 180D");
+      expect(params.get("rule")).toBe(PIXEL_RULE);
+      expect(params.get("retention_days")).toBe("180");
+      expect(params.get("prefill")).toBe("true");
+      expect(params.has("subtype")).toBe(false);
+      expect(params.has("customer_file_source")).toBe(false);
+    });
+
+    it("silences subtype when caller passes both subtype WEBSITE and rule (Meta v25 rejects it)", async () => {
+      const server = createMockMcpServer();
+      registerAudienceTools(server as never);
+
+      vi.stubGlobal("fetch", vi.fn().mockResolvedValue(mockFetchResponse({ id: "9000124" })));
+
+      const handler = server._registeredTools[CREATE_AUDIENCE_INDEX].handler;
+      await handler({
+        account_id: "1564852554415330",
+        name: "Doradobet - FTD - 180D",
+        description: undefined,
+        subtype: "WEBSITE",
+        customer_file_source: undefined,
+        retention_days: 180,
+        rule: PIXEL_RULE,
+        prefill: undefined,
+      });
+
+      const call = vi.mocked(fetch).mock.calls[0];
+      const params = new URLSearchParams(String(call[1]?.body ?? ""));
+
+      expect(params.get("rule")).toBe(PIXEL_RULE);
+      expect(params.has("subtype")).toBe(false);
+    });
+
+    it("throws early when subtype=CUSTOM is missing customer_file_source", async () => {
+      const server = createMockMcpServer();
+      registerAudienceTools(server as never);
+
+      const fetchSpy = vi.fn();
+      vi.stubGlobal("fetch", fetchSpy);
+
+      const handler = server._registeredTools[CREATE_AUDIENCE_INDEX].handler;
+
+      await expect(
+        handler({
+          account_id: "1564852554415330",
+          name: "Test customer list",
+          description: undefined,
+          subtype: "CUSTOM",
+          customer_file_source: undefined,
+          retention_days: undefined,
+          rule: undefined,
+          prefill: undefined,
+        }),
+      ).rejects.toThrow(/customer_file_source/);
+
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
+
+    it("defaults to subtype=CUSTOM when caller passes customer_file_source without subtype (no rule)", async () => {
+      const server = createMockMcpServer();
+      registerAudienceTools(server as never);
+
+      vi.stubGlobal("fetch", vi.fn().mockResolvedValue(mockFetchResponse({ id: "9000126" })));
+
+      const handler = server._registeredTools[CREATE_AUDIENCE_INDEX].handler;
+      await handler({
+        account_id: "1564852554415330",
+        name: "Customer list (no explicit subtype)",
+        description: undefined,
+        subtype: undefined,
+        customer_file_source: "USER_PROVIDED_ONLY",
+        retention_days: undefined,
+        rule: undefined,
+        prefill: undefined,
+      });
+
+      const call = vi.mocked(fetch).mock.calls[0];
+      const params = new URLSearchParams(String(call[1]?.body ?? ""));
+
+      expect(params.get("subtype")).toBe("CUSTOM");
+      expect(params.get("customer_file_source")).toBe("USER_PROVIDED_ONLY");
+    });
+
+    it("forwards subtype and customer_file_source for a customer-list audience", async () => {
+      const server = createMockMcpServer();
+      registerAudienceTools(server as never);
+
+      vi.stubGlobal("fetch", vi.fn().mockResolvedValue(mockFetchResponse({ id: "9000125" })));
+
+      const handler = server._registeredTools[CREATE_AUDIENCE_INDEX].handler;
+      await handler({
+        account_id: "1564852554415330",
+        name: "Customer list test",
+        description: "seed list",
+        subtype: "CUSTOM",
+        customer_file_source: "USER_PROVIDED_ONLY",
+        retention_days: 365,
+        rule: undefined,
+        prefill: undefined,
+      });
+
+      const call = vi.mocked(fetch).mock.calls[0];
+      const params = new URLSearchParams(String(call[1]?.body ?? ""));
+
+      expect(params.get("subtype")).toBe("CUSTOM");
+      expect(params.get("customer_file_source")).toBe("USER_PROVIDED_ONLY");
+      expect(params.get("description")).toBe("seed list");
+      expect(params.get("retention_days")).toBe("365");
+      expect(params.has("rule")).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- **fix(audiences)**: `ads_create_custom_audience` now correctly creates pixel-based WEBSITE audiences. Meta Graph API v25 rejects an explicit `subtype` when a `rule` is provided (error 2654); the handler now derives `effectiveSubtype = rule ? undefined : (subtype ?? "CUSTOM")` so WCAs work and customer-list audiences keep their backward-compatible default.
- **chore(release)**: bump version to **3.1.1** (patch — bug fix, no breaking changes).
- Bundles previously-staged fixes on this branch: gitleaks regex/allowlist refinements and fork-PR scan-skip logic.

## Why

The MCP tool was unusable for the common case of building a WCA from pixel events (e.g. "FTD - 180d" on the Doradobet pixel). Two failure modes:

1. With `subtype: "WEBSITE"` → Meta error 2654: *"El parámetro 'subtipo' no se admite en la versión actual de la API."*
2. Without `subtype` → schema default `"CUSTOM"` kicked in → Meta error #100: *"Missing parameter(s): customer_file_source."*

Validated against the [official Meta Marketing API v25 docs](https://developers.facebook.com/documentation/ads-commerce/marketing-api/audiences/guides/website-custom-audiences) (updated Apr 30, 2026): the WCA create endpoint only accepts `name`, `rule`, `retention_days`, `prefill`, `audience_labels` — no `subtype`, no `customer_file_source`. The fixed handler matches the official curl example exactly.

## Test plan

- [x] `npm run lint` clean
- [x] `npm run typecheck` clean
- [x] `npm test` — 367/367 pass
- [x] `npm run build` clean
- [x] `pre-deploy-guard` quick + full both green
- [x] New `tests/tools/audiences.test.ts` covers 7 scenarios:
  - WCA without `subtype`: body has `rule`, no `subtype`
  - WCA with `subtype: "WEBSITE"` + `rule`: `subtype` silently dropped
  - `subtype: "CUSTOM"` without `customer_file_source`: throws early, no Meta call
  - `customer_file_source` only (no `subtype`, no `rule`): defaults to `CUSTOM` (regression caught by Codex review)
  - `subtype: "CUSTOM"` + `customer_file_source`: forwards both
  - Tool registration count and names
- [ ] Manual end-to-end against Doradobet Perú (`act_1564852554415330`) — owner to run after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)