### PR TITLE
release: v3.2.1 — doc count fix + delete-audience validation hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,25 @@ All notable changes to this project are documented here.
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and
 this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [3.2.0] — 2026-05-26
+## [3.2.1] — 2026-06-04
+
+Documentation and validation hardening. No new tools — tool count stays at 96.
+
+### Fixed
+
+- **`ads_delete_custom_audience`** now validates Meta's response and throws
+  when the API does not confirm `success: true`, instead of reporting a
+  false positive on any 2xx body. Brings it in line with the
+  `ads_share_custom_audience` / `ads_unshare_custom_audience` write tools
+  added in 3.2.0.
+- **Docs**: README tool count corrected from `93` to `96` (TOC, comparison
+  table, features list, and the `Tools` section heading) to match the actual
+  registered tool count and the 3.2.0 CHANGELOG.
+
+### Changed
+
+- **Dev dependencies**: lockfile refreshed (vitest/vite toolchain moved from
+  `rollup` to `rolldown` bindings). No runtime/production dependency changes.
 
 Cross-account custom-audience sharing. Meta exposes audience sharing via
 `POST /{audience_id}/adaccounts` but the MCP had no tool for it — agencies

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 - [Who is this for?](#who-is-this-for)
 - [Aligned with Meta's official MCP](#aligned-with-metas-official-mcp)
 - [Features](#features)
-- [Tools (93 total)](#tools-93-total)
+- [Tools (96 total)](#tools-96-total)
 - [Quick start](#quick-start)
 - [Authentication — three modes](#authentication--three-modes)
 - [Setting up Sign in with Meta](#setting-up-sign-in-with-meta)
@@ -62,7 +62,7 @@ both servers.
 | | Meta's official MCP (`mcp.facebook.com/ads`) | This project |
 |---|---|---|
 | Auth model | Per-user OAuth in your AI client | **Multi-tenant**: agency operator handles N client accounts from one server |
-| Tool surface | 29 tools (campaigns, ads, catalogs, 5 insight views, opportunity_score, dataset, errors, help) | **93 tools** including the official 29-equivalent + audiences, lookalikes, lead forms, automated rules, A/B studies, async reports, custom conversions, asset uploads, comment moderation, cross-account macros |
+| Tool surface | 29 tools (campaigns, ads, catalogs, 5 insight views, opportunity_score, dataset, errors, help) | **96 tools** including the official 29-equivalent + audiences, lookalikes, lead forms, automated rules, A/B studies, async reports, custom conversions, asset uploads, comment moderation, cross-account macros |
 | Hosting | Hosted by Meta | Self-hosted on Cloud Run / your infra; tokens encrypted at rest in Firestore |
 | Cross-account | Per-user, single Meta login | Yes — `ads_portfolio_summary` aggregates across N accounts |
 | Token control | Lives in your AI client | Server-side System User token registry per agency operator |
@@ -78,7 +78,7 @@ When to use which:
 
 ## Features
 
-- **93 tools** covering campaign management, creatives, targeting, audiences, reporting, comments, billing, tokens, Instagram workflows, rate-limit observability, semantic insight views, diagnostics, help-center search, and agency-tier cross-account macros.
+- **96 tools** covering campaign management, creatives, targeting, audiences, reporting, comments, billing, tokens, Instagram workflows, rate-limit observability, semantic insight views, diagnostics, help-center search, and agency-tier cross-account macros.
 - **Aligned vocabulary** with Meta's official MCP server so agents transfer cleanly between both.
 - **Sign in with Meta (Facebook Login)** — replaces shared PINs. Each user lands their own long-lived (60-day) Meta token.
 - **System User token registry** — for tokens that don't expire, register them per user from the consent UI.
@@ -94,7 +94,7 @@ When to use which:
 - **Async reports with safe polling** — `ads_run_report_and_wait` one-shot with 5 s-min / 60 s-max backoff, proper `Job Failed` / `Job Skipped` handling.
 - **Retry logic** — exponential backoff on truly transient errors only (never on throttled requests).
 
-## Tools (93 total)
+## Tools (96 total)
 
 All tools use the `ads_*` naming convention, aligned with Meta's official MCP server. Read tools declare `readOnlyHint: true`; mutating tools declare `destructiveHint` / `idempotentHint` and prefix descriptions with `⚠️ Modifies live ads/account data.`
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@byadsco/meta-ads-mcp",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@byadsco/meta-ads-mcp",
-      "version": "3.2.0",
+      "version": "3.2.1",
       "license": "MIT",
       "dependencies": {
         "@google-cloud/firestore": "^8.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@byadsco/meta-ads-mcp",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "MCP server for Meta Ads (Facebook/Instagram) management - agency multi-account",
   "author": {
     "name": "Santiago Bastidas",

--- a/src/tools/audiences.ts
+++ b/src/tools/audiences.ts
@@ -358,7 +358,13 @@ export function registerAudienceTools(server: McpServer): void {
     },
     async ({ audience_id }) => {
       const id = validateMetaId(audience_id, "audience");
-      await metaApiClient.delete<{ success: boolean }>(`/${id}`);
+      const response = await metaApiClient.delete<{ success?: boolean }>(`/${id}`);
+
+      if (response?.success !== true) {
+        throw new Error(
+          `Meta did not confirm the deletion for audience ${id}. Response: ${JSON.stringify(response)}`,
+        );
+      }
 
       return {
         content: [

--- a/tests/tools/audiences.test.ts
+++ b/tests/tools/audiences.test.ts
@@ -11,6 +11,7 @@ const CREATE_AUDIENCE_INDEX = 2;
 const SHARE_AUDIENCE_INDEX = 4;
 const UNSHARE_AUDIENCE_INDEX = 5;
 const GET_SHARED_ACCOUNTS_INDEX = 6;
+const DELETE_AUDIENCE_INDEX = 7;
 
 const PIXEL_RULE = JSON.stringify({
   inclusions: {
@@ -379,6 +380,61 @@ describe("registerAudienceTools", () => {
 
       expect(result.content[0].text).toContain("shared with 2 account(s)");
       expect(result.content[0].text).toContain("act_1564852554415330");
+    });
+  });
+
+  describe("ads_delete_custom_audience handler", () => {
+    it("sends DELETE to /{audience_id} and confirms success", async () => {
+      const server = createMockMcpServer();
+      registerAudienceTools(server as never);
+
+      vi.stubGlobal("fetch", vi.fn().mockResolvedValue(mockFetchResponse({ success: true })));
+
+      const handler = server._registeredTools[DELETE_AUDIENCE_INDEX].handler;
+      const result = (await handler({
+        audience_id: "9000123",
+      })) as { content: Array<{ type: string; text: string }> };
+
+      const call = vi.mocked(fetch).mock.calls[0];
+      expect(call[1]?.method).toBe("DELETE");
+
+      const url = new URL(call[0] as string);
+      expect(url.pathname).toContain("/9000123");
+      expect(result.content[0].text).toContain("Audience 9000123 deleted successfully");
+    });
+
+    it("throws when Meta returns success=false", async () => {
+      const server = createMockMcpServer();
+      registerAudienceTools(server as never);
+
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue(mockFetchResponse({ success: false })),
+      );
+
+      const handler = server._registeredTools[DELETE_AUDIENCE_INDEX].handler;
+      await expect(
+        handler({
+          audience_id: "9000123",
+        }),
+      ).rejects.toThrow(/did not confirm the deletion/);
+    });
+
+    it("throws when Meta returns a body without success", async () => {
+      const server = createMockMcpServer();
+      registerAudienceTools(server as never);
+
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue(mockFetchResponse({})),
+      );
+
+      const handler = server._registeredTools[DELETE_AUDIENCE_INDEX].handler;
+      await expect(
+        handler({
+          audience_id: "9000123",
+        }),
+      ).rejects.toThrow(/did not confirm the deletion/);
     });
   });
 });


### PR DESCRIPTION
## Resumen

Release de mantenimiento **v3.2.1** (patch). No agrega herramientas — el conteo se mantiene en **96**.

### Fixed
- **`ads_delete_custom_audience`** ahora valida que Meta confirme `success: true` y lanza error si no, en lugar de reportar un falso positivo ante cualquier 2xx. Lo alinea con las tools `ads_share_custom_audience` / `ads_unshare_custom_audience` de 3.2.0. Incluye 3 tests nuevos.
- **Docs**: conteo de tools del README corregido `93` → `96` (TOC, tabla comparativa, lista de features y heading de la sección `Tools`), para que coincida con el conteo real registrado y con el CHANGELOG de 3.2.0.

### Changed
- **Dev dependencies**: lockfile refrescado (toolchain de vitest/vite migró de `rollup` a bindings de `rolldown`). Sin cambios en dependencias de producción/runtime.

## Verificación
- `npm run lint` ✅
- `npm run typecheck` ✅
- `npm test` ✅ (376 tests)
- `npm run build` ✅
- pre-deploy-guard (gitleaks + secret scan) ✅ 8/8 PASS

## Deploy / release
Al hacer **merge a `main`**: el workflow `deploy.yml` corre preflight → build/push de imagen → deploy a Cloud Run → smoke test, y luego auto-publica el GitHub Release `v3.2.1` (leyendo `package.json`) + publish de artefactos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)