### PR TITLE
Agregar herramienta `ads_get_invoices` y actualizar documentación

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project are documented here.
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and
 this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **`ads_get_invoices`** — read a business's invoices via Meta's
+  `GET /{business_id}/business_invoices` edge, returning each invoice's amount,
+  billing period, payment status, and PDF download link (`download_uri` /
+  `cdn_download_uri`). Accepts a `business_id` directly or an `account_id`
+  (the owning business is resolved automatically), plus optional `start_date` /
+  `end_date` / `invoice_id` / `type` (`CM` / `DM` / `INV` / `PRO_FORMA`)
+  filters. Annotated `READ`. Meta only exposes invoices for businesses on a
+  credit line / monthly invoicing and requires a token with the
+  `FINANCE_EDITOR` or `FINANCE_ANALYST` role; the tool returns a clear
+  explanatory message for card-billed accounts that have no API invoices.
+  Tool count: 96 → 97.
+
 ## [3.2.1] — 2026-06-04
 
 Documentation and validation hardening. No new tools — tool count stays at 96.

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ When to use which:
 
 ## Features
 
-- **96 tools** covering campaign management, creatives, targeting, audiences, reporting, comments, billing, tokens, Instagram workflows, rate-limit observability, semantic insight views, diagnostics, help-center search, and agency-tier cross-account macros.
+- **97 tools** covering campaign management, creatives, targeting, audiences, reporting, comments, billing, invoices, tokens, Instagram workflows, rate-limit observability, semantic insight views, diagnostics, help-center search, and agency-tier cross-account macros.
 - **Aligned vocabulary** with Meta's official MCP server so agents transfer cleanly between both.
 - **Sign in with Meta (Facebook Login)** — replaces shared PINs. Each user lands their own long-lived (60-day) Meta token.
 - **System User token registry** — for tokens that don't expire, register them per user from the consent UI.
@@ -94,7 +94,7 @@ When to use which:
 - **Async reports with safe polling** — `ads_run_report_and_wait` one-shot with 5 s-min / 60 s-max backoff, proper `Job Failed` / `Job Skipped` handling.
 - **Retry logic** — exponential backoff on truly transient errors only (never on throttled requests).
 
-## Tools (96 total)
+## Tools (97 total)
 
 All tools use the `ads_*` naming convention, aligned with Meta's official MCP server. Read tools declare `readOnlyHint: true`; mutating tools declare `destructiveHint` / `idempotentHint` and prefix descriptions with `⚠️ Modifies live ads/account data.`
 
@@ -118,7 +118,7 @@ All tools use the `ads_*` naming convention, aligned with Meta's official MCP se
 | Rules | 5 | Automated rules and rule details |
 | A/B Testing | 3 | Ad study creation and inspection |
 | Reports | 4 | Async report creation, status, retrieval, and one-shot run+wait |
-| Billing | 3 | Billing info and spend limits |
+| Billing | 4 | Billing info, spend limits, and invoices (`ads_get_invoices`) |
 | Diagnostics | 3 | `ads_get_opportunity_score`, `ads_get_dataset_quality`, `ads_get_errors` |
 | Help search | 1 | `ads_get_help_article` — curated Meta Business Help Center search |
 | Agency macros | 2 | `ads_diagnose_underperformance`, `ads_portfolio_summary` (cross-account) |

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 - [Who is this for?](#who-is-this-for)
 - [Aligned with Meta's official MCP](#aligned-with-metas-official-mcp)
 - [Features](#features)
-- [Tools (96 total)](#tools-96-total)
+- [Tools (97 total)](#tools-97-total)
 - [Quick start](#quick-start)
 - [Authentication — three modes](#authentication--three-modes)
 - [Setting up Sign in with Meta](#setting-up-sign-in-with-meta)
@@ -62,7 +62,7 @@ both servers.
 | | Meta's official MCP (`mcp.facebook.com/ads`) | This project |
 |---|---|---|
 | Auth model | Per-user OAuth in your AI client | **Multi-tenant**: agency operator handles N client accounts from one server |
-| Tool surface | 29 tools (campaigns, ads, catalogs, 5 insight views, opportunity_score, dataset, errors, help) | **96 tools** including the official 29-equivalent + audiences, lookalikes, lead forms, automated rules, A/B studies, async reports, custom conversions, asset uploads, comment moderation, cross-account macros |
+| Tool surface | 29 tools (campaigns, ads, catalogs, 5 insight views, opportunity_score, dataset, errors, help) | **97 tools** including the official 29-equivalent + audiences, lookalikes, lead forms, automated rules, A/B studies, async reports, billing invoices, custom conversions, asset uploads, comment moderation, cross-account macros |
 | Hosting | Hosted by Meta | Self-hosted on Cloud Run / your infra; tokens encrypted at rest in Firestore |
 | Cross-account | Per-user, single Meta login | Yes — `ads_portfolio_summary` aggregates across N accounts |
 | Token control | Lives in your AI client | Server-side System User token registry per agency operator |

--- a/src/tools/billing.ts
+++ b/src/tools/billing.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { metaApiClient } from "../meta/client.js";
-import { normalizeAccountId, formatBudget } from "../utils/format.js";
+import { normalizeAccountId, validateMetaId, formatBudget } from "../utils/format.js";
 import { READ, UPDATE, WRITE_WARNING } from "./_register.js";
 
 interface BillingInfo {
@@ -59,6 +59,52 @@ interface SpendInfo {
   daily_spend_limit?: string;
   min_daily_budget?: number;
 }
+
+interface Invoice {
+  id: string;
+  invoice_id?: string;
+  advertiser_name?: string;
+  amount?: string | number | Record<string, unknown>;
+  amount_due?: string | number | Record<string, unknown>;
+  billed_amount_details?: Record<string, unknown>;
+  billing_period?: string;
+  currency?: string;
+  download_uri?: string;
+  cdn_download_uri?: string;
+  due_date?: string;
+  entity?: string;
+  invoice_date?: string;
+  invoice_type?: string;
+  liability_type?: string;
+  payment_status?: string;
+  payment_term?: string;
+  type?: string;
+  ad_account_ids?: string[];
+}
+
+const INVOICE_FIELDS = [
+  "id",
+  "invoice_id",
+  "advertiser_name",
+  "amount",
+  "amount_due",
+  "billed_amount_details",
+  "billing_period",
+  "currency",
+  "download_uri",
+  "cdn_download_uri",
+  "due_date",
+  "entity",
+  "invoice_date",
+  "invoice_type",
+  "liability_type",
+  "payment_status",
+  "payment_term",
+  "type",
+  "ad_account_ids",
+].join(",");
+
+const INVOICE_TYPE = z.enum(["CM", "DM", "INV", "PRO_FORMA"]);
 
 const ACCOUNT_STATUS_MAP: Record<number, string> = {
   1: "ACTIVE",
@@ -216,6 +262,138 @@ export function registerBillingTools(server: McpServer): void {
             type: "text",
             text: `Spend cap updated for account ${account_id}.\nNew spend cap: ${displayAmount}`,
           },
+        ],
+      };
+    },
+  );
+
+  // ─── Get Invoices ─────────────────────────────────────────────
+  server.registerTool(
+    "ads_get_invoices",
+    {
+      description:
+        "Get invoices for a business (Meta's business_invoices), with their PDF download links. " +
+        "Provide business_id directly, or account_id to resolve its business automatically. " +
+        "Optionally filter by date range, invoice_id, or type. " +
+        "Note: Meta only exposes invoices for businesses on a credit line / monthly invoicing, " +
+        "and the access token needs the FINANCE_EDITOR or FINANCE_ANALYST role; card-billed accounts have no API invoices.",
+      inputSchema: {
+        business_id: z
+          .string()
+          .optional()
+          .describe("Business ID. Either this or account_id is required."),
+        account_id: z
+          .string()
+          .optional()
+          .describe(
+            "Ad account ID. Used to resolve the owning business when business_id is not given.",
+          ),
+        start_date: z
+          .string()
+          .optional()
+          .describe("Filter invoices from this date (YYYY-MM-DD)."),
+        end_date: z
+          .string()
+          .optional()
+          .describe("Filter invoices up to this date (YYYY-MM-DD)."),
+        invoice_id: z
+          .string()
+          .optional()
+          .describe("Return a single invoice by its invoice_id."),
+        type: INVOICE_TYPE.optional().describe(
+          "Invoice type: CM (credit memo), DM (debit memo), INV (invoice), PRO_FORMA.",
+        ),
+        limit: z
+          .number()
+          .min(1)
+          .max(100)
+          .default(25)
+          .describe("Maximum number of invoices to return."),
+      },
+      annotations: { ...READ },
+    },
+    async ({ business_id, account_id, start_date, end_date, invoice_id, type, limit }) => {
+      let businessId: string;
+      if (business_id) {
+        businessId = validateMetaId(business_id, "business_id");
+      } else if (account_id) {
+        const acct = await metaApiClient.get<{
+          business?: { id: string; name?: string };
+        }>(`/${normalizeAccountId(account_id)}`, { fields: "business" });
+        if (!acct.business?.id) {
+          throw new Error(
+            `Ad account ${account_id} is not linked to a business, so it has no invoices. ` +
+              `Meta exposes invoices only for businesses on a credit line / monthly invoicing.`,
+          );
+        }
+        businessId = acct.business.id;
+      } else {
+        throw new Error("Provide either business_id or account_id to fetch invoices.");
+      }
+
+      const params: Record<string, string | number> = { fields: INVOICE_FIELDS };
+      if (start_date) params.start_date = start_date;
+      if (end_date) params.end_date = end_date;
+      if (invoice_id) params.invoice_id = invoice_id;
+      if (type) params.type = type;
+
+      const invoices = await metaApiClient.getPaginated<Invoice>(
+        `/${businessId}/business_invoices`,
+        params,
+        limit,
+      );
+
+      if (invoices.length === 0) {
+        return {
+          content: [
+            {
+              type: "text",
+              text:
+                `No invoices found for business ${businessId}.\n` +
+                `Meta's business_invoices API only returns data for businesses on a ` +
+                `credit line / monthly invoicing, and the access token must have the ` +
+                `FINANCE_EDITOR or FINANCE_ANALYST role. Card-billed accounts have no ` +
+                `invoices via the API — only receipts in Ads Manager.`,
+            },
+            { type: "text", text: "[]" },
+          ],
+        };
+      }
+
+      const renderAmount = (
+        value: Invoice["amount"],
+        currency?: string,
+      ): string => {
+        if (value === undefined || value === null) return "N/A";
+        if (typeof value === "object") return JSON.stringify(value);
+        return currency ? `${value} ${currency}` : String(value);
+      };
+
+      const lines: string[] = [
+        `Found ${invoices.length} invoice(s) for business ${businessId}:`,
+        ``,
+      ];
+      for (const inv of invoices) {
+        const number = inv.invoice_id ?? inv.id;
+        const period = inv.billing_period
+          ? inv.billing_period
+          : [inv.invoice_date, inv.due_date].filter(Boolean).join(" → ") || "N/A";
+        const link = inv.download_uri ?? inv.cdn_download_uri;
+        lines.push(
+          `Invoice ${number}`,
+          `  Period: ${period}`,
+          `  Amount: ${renderAmount(inv.amount_due ?? inv.amount, inv.currency)}`,
+          `  Status: ${inv.payment_status ?? "N/A"}`,
+          `  Due: ${inv.due_date ?? "N/A"}`,
+        );
+        if (link) lines.push(`  PDF: ${link}`);
+        lines.push(``);
+      }
+
+      return {
+        content: [
+          { type: "text", text: lines.join("\n").trimEnd() },
+          { type: "text", text: JSON.stringify(invoices, null, 2) },
         ],
       };
     },

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -56,7 +56,7 @@ export function registerAllTools(server: McpServer): void {
   registerRuleTools(server);         // 5 tools — Automated rules
   registerABTestingTools(server);    // 3 tools — A/B split testing
   registerReportTools(server);       // 4 tools — Async scheduled reports (+ run_and_wait)
-  registerBillingTools(server);      // 3 tools — Billing & spend limits
+  registerBillingTools(server);      // 4 tools — Billing, spend limits & invoices
   registerRateStatusTools(server);   // 1 tool — Rate-limit usage + circuit status
 
   // ─── Diagnostics & Help ─────────────────────────────────

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -72,5 +72,5 @@ export function registerAllTools(server: McpServer): void {
   // ─── Token Management ────────────────────────────────────
   registerTokenTools(server);        // 4 tools — list / set-active / register / delete
 
-  // Total: 96 tools (79 renamed + 14 new in v3 + 3 audience-sharing)
+  // Total: 97 tools (79 renamed + 14 new in v3 + 3 audience-sharing + 1 invoices)
 }

--- a/tests/tools/billing.test.ts
+++ b/tests/tools/billing.test.ts
@@ -12,10 +12,10 @@ describe("registerBillingTools", () => {
     vi.restoreAllMocks();
   });
 
-  it("registers exactly 3 tools", () => {
+  it("registers exactly 4 tools", () => {
     const server = createMockMcpServer();
     registerBillingTools(server as never);
-    expect(server.registerTool).toHaveBeenCalledTimes(3);
+    expect(server.registerTool).toHaveBeenCalledTimes(4);
   });
 
   it("registers tools with correct names", () => {
@@ -26,6 +26,7 @@ describe("registerBillingTools", () => {
       "ads_get_billing_info",
       "ads_get_spend_limit",
       "ads_update_spend_cap",
+      "ads_get_invoices",
     ]);
   });
 
@@ -120,6 +121,90 @@ describe("registerBillingTools", () => {
       };
 
       expect(result.content[0].text).toContain("No limit (removed)");
+    });
+  });
+
+  describe("ads_get_invoices handler", () => {
+    it("lists invoices for a business_id with their PDF links", async () => {
+      const server = createMockMcpServer();
+      registerBillingTools(server as never);
+
+      const fetchMock = vi.fn().mockResolvedValue(
+        mockFetchResponse({
+          data: [
+            {
+              id: "9001",
+              invoice_id: "INV-2026-001",
+              billing_period: "2026-05",
+              amount_due: "1500.00",
+              currency: "USD",
+              payment_status: "PAID",
+              due_date: "2026-06-15",
+              download_uri: "https://business.facebook.com/invoice/INV-2026-001.pdf",
+            },
+          ],
+        }),
+      );
+      vi.stubGlobal("fetch", fetchMock);
+
+      const handler = server._registeredTools[3].handler;
+      const result = (await handler({ business_id: "100" })) as {
+        content: Array<{ type: string; text: string }>;
+      };
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(fetchMock.mock.calls[0][0] as string).toContain("/100/business_invoices");
+      expect(result.content[0].text).toContain("INV-2026-001");
+      expect(result.content[0].text).toContain("PAID");
+      expect(result.content[0].text).toContain("https://business.facebook.com/invoice/INV-2026-001.pdf");
+    });
+
+    it("resolves the business from account_id before fetching invoices", async () => {
+      const server = createMockMcpServer();
+      registerBillingTools(server as never);
+
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(mockFetchResponse({ business: { id: "100", name: "Biz" } }))
+        .mockResolvedValueOnce(
+          mockFetchResponse({
+            data: [{ id: "9001", invoice_id: "INV-1", payment_status: "NOT_PAID" }],
+          }),
+        );
+      vi.stubGlobal("fetch", fetchMock);
+
+      const handler = server._registeredTools[3].handler;
+      const result = (await handler({ account_id: "123" })) as {
+        content: Array<{ type: string; text: string }>;
+      };
+
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+      expect(fetchMock.mock.calls[0][0] as string).toContain("/act_123");
+      expect(fetchMock.mock.calls[1][0] as string).toContain("/100/business_invoices");
+      expect(result.content[0].text).toContain("INV-1");
+    });
+
+    it("returns an explanatory message when there are no invoices", async () => {
+      const server = createMockMcpServer();
+      registerBillingTools(server as never);
+
+      vi.stubGlobal("fetch", vi.fn().mockResolvedValue(mockFetchResponse({ data: [] })));
+
+      const handler = server._registeredTools[3].handler;
+      const result = (await handler({ business_id: "100" })) as {
+        content: Array<{ type: string; text: string }>;
+      };
+
+      expect(result.content[0].text).toContain("No invoices found");
+      expect(result.content[0].text).toContain("FINANCE");
+    });
+
+    it("throws when neither business_id nor account_id is provided", async () => {
+      const server = createMockMcpServer();
+      registerBillingTools(server as never);
+
+      const handler = server._registeredTools[3].handler;
+      await expect(handler({})).rejects.toThrow(/business_id or account_id/);
     });
   });
 });

--- a/tests/tools/registration.test.ts
+++ b/tests/tools/registration.test.ts
@@ -3,12 +3,13 @@ import { registerAllTools } from "../../src/tools/index.js";
 import { createMockMcpServer } from "../setup.js";
 
 describe("registerAllTools", () => {
-  it("registers exactly 96 tools total", () => {
+  it("registers exactly 97 tools total", () => {
     // 79 v2 tools renamed (with account_insights removed → 79) + 14 new in v3 +
-    //   3 audience-sharing tools (share / unshare / get-shared-accounts).
+    //   3 audience-sharing tools (share / unshare / get-shared-accounts) +
+    //   1 invoices tool (ads_get_invoices).
     const server = createMockMcpServer();
     registerAllTools(server as never);
-    expect(server.registerTool).toHaveBeenCalledTimes(96);
+    expect(server.registerTool).toHaveBeenCalledTimes(97);
   });
 
   it("registers all tools with unique names", () => {
@@ -110,6 +111,7 @@ describe("registerAllTools", () => {
     expect(names).toContain("ads_get_ad_studies");
     expect(names).toContain("ads_create_async_report");
     expect(names).toContain("ads_get_billing_info");
+    expect(names).toContain("ads_get_invoices");
 
     // Renamed in v3
     expect(names).toContain("ads_get_pages_for_business");
@@ -136,7 +138,9 @@ describe("registerAllTools", () => {
     const campaignTools = names.filter((n) => n.includes("campaign"));
     expect(campaignTools.length).toBeGreaterThanOrEqual(4);
 
-    const billingTools = names.filter((n) => n.includes("billing") || n.includes("spend"));
-    expect(billingTools.length).toBeGreaterThanOrEqual(3);
+    const billingTools = names.filter(
+      (n) => n.includes("billing") || n.includes("spend") || n.includes("invoice"),
+    );
+    expect(billingTools.length).toBeGreaterThanOrEqual(4);
   });
 });


### PR DESCRIPTION
Se añade la herramienta `ads_get_invoices` para recuperar facturas de negocios, aumentando el total de herramientas a 97. Se actualiza la documentación y el registro de herramientas para reflejar este cambio.

