### PR TITLE
Clarify campaign vs ad set budget ownership

### DIFF
--- a/src/tools/adsets.ts
+++ b/src/tools/adsets.ts
@@ -797,15 +797,15 @@ export function registerAdSetTools(server: McpServer): void {
   server.registerTool(
     "ads_create_ad_set",
     {
-      description: `${WRITE_WARNING}Create a new ad set within a campaign. Requires targeting specification, optimization goal, budget, and destination_type (required for ODAX campaigns). Common destination_type values: WEBSITE (traffic/sales to website), APP (app installs), MESSENGER/WHATSAPP/INSTAGRAM_DIRECT (messaging), ON_AD (lead forms, instant experiences). Ad sets are created in PAUSED status by default.`,
+      description: `${WRITE_WARNING}Create a new ad set within a campaign. Requires targeting specification, optimization goal, and destination_type (required for ODAX campaigns). Budget belongs at exactly one level: when the parent campaign has either daily_budget or lifetime_budget (campaign budget / CBO), omit both ad-set budget fields. Only pass daily_budget or lifetime_budget here for ad-set budget / ABO campaigns. Common destination_type values: WEBSITE (traffic/sales to website), APP (app installs), MESSENGER/WHATSAPP/INSTAGRAM_DIRECT (messaging), ON_AD (lead forms, instant experiences). Ad sets are created in PAUSED status by default.`,
       inputSchema: {
         account_id: z.string().describe("Ad account ID"),
         campaign_id: z.string().describe("Parent campaign ID"),
         name: z.string().min(1).describe("Ad set name"),
         destination_type: destinationTypeEnum.describe("Where the ad traffic is directed. Required for ODAX campaigns. Common values: WEBSITE (website traffic/conversions), APP (app installs), MESSENGER (Messenger conversations), WHATSAPP (WhatsApp conversations), INSTAGRAM_DIRECT (Instagram DMs), ON_AD (lead forms, instant experiences, post engagement), ON_VIDEO (video views), ON_PAGE (page engagement), SHOP_AUTOMATIC (shop)"),
         status: z.enum(["ACTIVE", "PAUSED"]).default("PAUSED"),
-        daily_budget: z.number().optional().describe("Daily budget in cents (e.g., 2000 = $20.00)"),
-        lifetime_budget: z.number().optional().describe("Lifetime budget in cents"),
+        daily_budget: z.number().optional().describe("Ad-set daily budget in cents (e.g., 2000 = $20.00). Omit when the parent campaign has a daily or lifetime budget."),
+        lifetime_budget: z.number().optional().describe("Ad-set lifetime budget in cents. Omit when the parent campaign has a daily or lifetime budget."),
         optimization_goal: optimizationGoalEnum.describe("Optimization goal"),
         billing_event: billingEventEnum.default("IMPRESSIONS"),
         bid_amount: z.number().optional().describe("Bid cap in cents"),

--- a/tests/tools/adsets.test.ts
+++ b/tests/tools/adsets.test.ts
@@ -625,6 +625,34 @@ describe("registerAdSetTools", () => {
     });
   });
 
+  describe("ads_create_ad_set handler", () => {
+    it("does not send an ad-set budget when both optional budget fields are omitted", async () => {
+      const server = createMockMcpServer();
+      registerAdSetTools(server as never);
+
+      vi.stubGlobal("fetch", vi.fn().mockResolvedValue(mockFetchResponse({ id: "2001" })));
+
+      const tool = server._registeredTools.find((t) => t.name === "ads_create_ad_set");
+      expect(tool).toBeDefined();
+
+      await tool!.handler({
+        account_id: "act_123",
+        campaign_id: "1001",
+        name: "Campaign-budget ad set",
+        destination_type: "WEBSITE",
+        status: "PAUSED",
+        optimization_goal: "LINK_CLICKS",
+        billing_event: "IMPRESSIONS",
+        targeting: { geo_locations: { countries: ["MX"] } },
+      });
+
+      const call = vi.mocked(fetch).mock.calls[0];
+      const params = new URLSearchParams(call[1]?.body as string);
+      expect(params.has("daily_budget")).toBe(false);
+      expect(params.has("lifetime_budget")).toBe(false);
+    });
+  });
+
   describe("ads_update_ad_set handler", () => {
     it("issues POST /<ad_set_id> with only the budget field and confirms success", async () => {
       const server = createMockMcpServer();


### PR DESCRIPTION
## Summary
- clarify that `ads_create_ad_set` does not always require an ad-set budget
- tell agents to omit both ad-set budget fields when the parent campaign owns either a daily or lifetime budget
- add a regression test proving omitted budget fields are not sent to Meta

## Why
The current tool description says an ad set requires a budget, while both budget fields are optional and Meta rejects budgets at both campaign and ad-set level (subcode 1885621). This contradiction can lead tool-using models to supply an ad-set budget for campaign-budget campaigns.

## Verification
- `npm test -- --run tests/tools/adsets.test.ts` (19 passed)
- `npm run build`