### PR TITLE
feat: agregar gestión completa de WhatsApp Business API (27 herramien…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,30 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 
+- **WhatsApp Business management (27 new `whatsapp_*` tools)** — full
+  management surface for the WhatsApp Business Platform via the Graph API,
+  in four new modules:
+  - `src/tools/whatsapp.ts` (8): WABA discovery
+    (`whatsapp_get_business_accounts`, with automatic `/me/businesses`
+    scanning), phone number list/details, register/deregister,
+    request/verify ownership code, and business profile get/update.
+  - `src/tools/whatsapp-templates.ts` (6): message template CRUD
+    (`whatsapp_get_templates`, `whatsapp_create_template`,
+    `whatsapp_update_template`, `whatsapp_delete_template`) plus WABA
+    analytics (`whatsapp_get_analytics` — MESSAGING / CONVERSATION /
+    PRICING families) and `whatsapp_get_template_analytics`.
+  - `src/tools/whatsapp-flows.ts` (6): WhatsApp Flows lifecycle — list,
+    create (inline Flow JSON), update (metadata + Flow JSON asset upload),
+    publish, deprecate (irreversible), delete (drafts only).
+  - `src/tools/whatsapp-config.ts` (7): QR code deep links
+    (`message_qrdls` CRUD) and webhook subscription management
+    (`subscribed_apps` get/subscribe/unsubscribe). No webhook receiver
+    endpoint is included — events go to the Meta App's configured webhook.
+  Message sending and media upload are intentionally out of scope.
+  The OAuth flow now requests the `whatsapp_business_management` scope;
+  previously issued tokens must re-authorize before `whatsapp_*` tools work.
+  `MetaApiClient.delete()` now accepts optional query params (needed for
+  template deletion by name). Tool count: 97 → 124.
 - **`ads_get_invoices`** — read a business's invoices via Meta's
   `GET /{business_id}/business_invoices` edge, returning each invoice's amount,
   billing period, payment status, and PDF download link (`download_uri` /

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 - [Who is this for?](#who-is-this-for)
 - [Aligned with Meta's official MCP](#aligned-with-metas-official-mcp)
 - [Features](#features)
-- [Tools (97 total)](#tools-97-total)
+- [Tools (124 total)](#tools-124-total)
 - [Quick start](#quick-start)
 - [Authentication — three modes](#authentication--three-modes)
 - [Setting up Sign in with Meta](#setting-up-sign-in-with-meta)
@@ -62,7 +62,7 @@ both servers.
 | | Meta's official MCP (`mcp.facebook.com/ads`) | This project |
 |---|---|---|
 | Auth model | Per-user OAuth in your AI client | **Multi-tenant**: agency operator handles N client accounts from one server |
-| Tool surface | 29 tools (campaigns, ads, catalogs, 5 insight views, opportunity_score, dataset, errors, help) | **97 tools** including the official 29-equivalent + audiences, lookalikes, lead forms, automated rules, A/B studies, async reports, billing invoices, custom conversions, asset uploads, comment moderation, cross-account macros |
+| Tool surface | 29 tools (campaigns, ads, catalogs, 5 insight views, opportunity_score, dataset, errors, help) | **124 tools** including the official 29-equivalent + audiences, lookalikes, lead forms, automated rules, A/B studies, async reports, billing invoices, custom conversions, asset uploads, comment moderation, cross-account macros, and full WhatsApp Business management (templates, phone numbers, flows, QR codes) |
 | Hosting | Hosted by Meta | Self-hosted on Cloud Run / your infra; tokens encrypted at rest in Firestore |
 | Cross-account | Per-user, single Meta login | Yes — `ads_portfolio_summary` aggregates across N accounts |
 | Token control | Lives in your AI client | Server-side System User token registry per agency operator |
@@ -78,7 +78,7 @@ When to use which:
 
 ## Features
 
-- **97 tools** covering campaign management, creatives, targeting, audiences, reporting, comments, billing, invoices, tokens, Instagram workflows, rate-limit observability, semantic insight views, diagnostics, help-center search, and agency-tier cross-account macros.
+- **124 tools** covering campaign management, creatives, targeting, audiences, reporting, comments, billing, invoices, tokens, Instagram workflows, WhatsApp Business management, rate-limit observability, semantic insight views, diagnostics, help-center search, and agency-tier cross-account macros.
 - **Aligned vocabulary** with Meta's official MCP server so agents transfer cleanly between both.
 - **Sign in with Meta (Facebook Login)** — replaces shared PINs. Each user lands their own long-lived (60-day) Meta token.
 - **System User token registry** — for tokens that don't expire, register them per user from the consent UI.
@@ -94,9 +94,9 @@ When to use which:
 - **Async reports with safe polling** — `ads_run_report_and_wait` one-shot with 5 s-min / 60 s-max backoff, proper `Job Failed` / `Job Skipped` handling.
 - **Retry logic** — exponential backoff on truly transient errors only (never on throttled requests).
 
-## Tools (97 total)
+## Tools (124 total)
 
-All tools use the `ads_*` naming convention, aligned with Meta's official MCP server. Read tools declare `readOnlyHint: true`; mutating tools declare `destructiveHint` / `idempotentHint` and prefix descriptions with `⚠️ Modifies live ads/account data.`
+Ads tools use the `ads_*` naming convention, aligned with Meta's official MCP server; WhatsApp Business tools use `whatsapp_*`. Read tools declare `readOnlyHint: true`; mutating tools declare `destructiveHint` / `idempotentHint` and prefix descriptions with a `⚠️` warning.
 
 | Category | Tools | Description |
 |---|---|---|
@@ -125,6 +125,12 @@ All tools use the `ads_*` naming convention, aligned with Meta's official MCP se
 | Instagram | 2 | IG account and media lookup |
 | Tokens | 4 | List / set-active / register / delete |
 | Rate Status | 1 | Live view of quota usage, open circuits and write-pacer state |
+| WhatsApp — WABAs & phones | 8 | `whatsapp_get_business_accounts`, phone number list/register/deregister/verify, business profile get/update |
+| WhatsApp — Templates & analytics | 6 | Message template CRUD (`whatsapp_create_template`, edit, delete), WABA analytics (messaging/conversation/pricing), per-template analytics |
+| WhatsApp — Flows | 6 | Flow list/create/update (incl. Flow JSON upload), publish, deprecate, delete |
+| WhatsApp — QR & webhooks | 7 | QR deep-link CRUD (`message_qrdls`), webhook subscription get/subscribe/unsubscribe |
+
+WhatsApp tools require the `whatsapp_business_management` permission. Tokens issued before this scope was added must be re-authorized (sign in again through the OAuth flow) before the `whatsapp_*` tools will work, and the Meta App must have the **WhatsApp product** added in the developer dashboard.
 
 Tool definitions live under [src/tools/](src/tools/), wired together in [src/tools/index.ts](src/tools/index.ts).
 
@@ -204,7 +210,7 @@ The repo is public but the deployment is private: nothing sensitive lives in the
 1. **Create a Meta App** at <https://developers.facebook.com>:
    - Add the *Facebook Login* product.
    - In *Facebook Login → Settings*, set the Valid OAuth Redirect URI to `<SERVER_URL>/auth/meta/callback`.
-   - In *App Review → Permissions and Features*, request `ads_management`, `ads_read`, `pages_show_list`, `pages_read_engagement`, `business_management`, `email`. While the app is in *Development* mode, only people listed under *Roles* can sign in.
+   - In *App Review → Permissions and Features*, request `ads_management`, `ads_read`, `pages_show_list`, `pages_read_engagement`, `business_management`, `whatsapp_business_management`, `email`. While the app is in *Development* mode, only people listed under *Roles* can sign in. For the `whatsapp_*` tools, also add the **WhatsApp product** to the app.
 
 2. **Provision Firestore** in your GCP project:
    - In the Cloud Console: Firestore → Create database → Native mode → pick a region.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1858,20 +1858,20 @@
       }
     },
     "node_modules/body-parser": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
-      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
       "license": "MIT",
       "dependencies": {
         "bytes": "^3.1.2",
-        "content-type": "^1.0.5",
+        "content-type": "^2.0.0",
         "debug": "^4.4.3",
-        "http-errors": "^2.0.0",
-        "iconv-lite": "^0.7.0",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
         "on-finished": "^2.4.1",
-        "qs": "^6.14.1",
-        "raw-body": "^3.0.1",
-        "type-is": "^2.0.1"
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
       },
       "engines": {
         "node": ">=18"
@@ -1881,10 +1881,23 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2721,9 +2734,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "funding": [
         {
           "type": "github",
@@ -3053,9 +3066,9 @@
       "license": "MIT"
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
-      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -4278,9 +4291,9 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.6.4",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.4.tgz",
-      "integrity": "sha512-RJJPTTpvFfHcWLkIa2JFWK4XvtSzS0yEWDmunqHXli1h3JlkbcQZXDZdcWxv+JK3Xsl5/UFDPZ0iGm7DAengYw==",
+      "version": "7.6.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
+      "integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -5043,17 +5056,34 @@
       }
     },
     "node_modules/type-is": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
-      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
       "license": "MIT",
       "dependencies": {
-        "content-type": "^1.0.5",
+        "content-type": "^2.0.0",
         "media-typer": "^1.1.0",
         "mime-types": "^3.0.0"
       },
       "engines": {
-        "node": ">= 0.6"
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/typescript": {

--- a/src/auth/meta-oauth.ts
+++ b/src/auth/meta-oauth.ts
@@ -10,6 +10,7 @@ const DEFAULT_SCOPES = [
   "pages_show_list",
   "pages_read_engagement",
   "business_management",
+  "whatsapp_business_management",
   "email",
   "public_profile",
 ];

--- a/src/meta/client.ts
+++ b/src/meta/client.ts
@@ -109,8 +109,11 @@ export class MetaApiClient {
     return this.execute<T>("POST", url, path, { body: formData }, true);
   }
 
-  async delete<T>(path: string): Promise<T> {
-    const url = this.buildUrl(path);
+  async delete<T>(
+    path: string,
+    params?: Record<string, string | number | boolean | undefined>,
+  ): Promise<T> {
+    const url = this.buildUrl(path, params);
     return this.execute<T>("DELETE", url, path);
   }
 
@@ -206,11 +209,16 @@ export class MetaApiClient {
     // mint duplicates (e.g. two ad sets for one user intent). The /<id>/copies
     // edge (ad/ad set/campaign duplication) creates a resource on a non-act_
     // path, so it must be classed as creating too — otherwise a retried copy
-    // mints a duplicate ad. Other POSTs (updates on /<id>) and DELETEs are
+    // mints a duplicate ad. The WhatsApp creating edges live on plain-numeric
+    // WABA/phone paths: /message_templates, /flows, /message_qrdls create
+    // resources, and /request_code sends a real SMS/voice call — all mint
+    // duplicates on retry. Other POSTs (updates on /<id>) and DELETEs are
     // idempotent at the API level.
     const isCreatingRequest =
       method === "POST" &&
-      (/^\/?act_[A-Za-z0-9]+\//.test(path) || /\/copies$/.test(path));
+      (/^\/?act_[A-Za-z0-9]+\//.test(path) ||
+        /\/copies$/.test(path) ||
+        /\/(message_templates|flows|message_qrdls|request_code)$/.test(path));
     const canRetryTransport = !isCreatingRequest;
 
     let lastError: Error | undefined;

--- a/src/meta/types/index.ts
+++ b/src/meta/types/index.ts
@@ -14,3 +14,4 @@ export * from "./pixel.js";
 export * from "./rule.js";
 export * from "./study.js";
 export * from "./instagram.js";
+export * from "./whatsapp.js";

--- a/src/meta/types/whatsapp.ts
+++ b/src/meta/types/whatsapp.ts
@@ -1,0 +1,132 @@
+export interface WhatsAppBusinessAccount {
+  id: string;
+  name?: string;
+  currency?: string;
+  timezone_id?: string;
+  message_template_namespace?: string;
+  account_review_status?: string;
+  business_verification_status?: string;
+  country?: string;
+  ownership_type?: string;
+  health_status?: Record<string, unknown>;
+}
+
+export interface WhatsAppPhoneNumber {
+  id: string;
+  display_phone_number?: string;
+  verified_name?: string;
+  code_verification_status?: string;
+  quality_rating?: string;
+  platform_type?: string;
+  throughput?: { level?: string };
+  status?: string;
+  name_status?: string;
+  messaging_limit_tier?: string;
+}
+
+export interface WhatsAppBusinessProfile {
+  about?: string;
+  address?: string;
+  description?: string;
+  email?: string;
+  profile_picture_url?: string;
+  websites?: string[];
+  vertical?: string;
+  messaging_product?: string;
+}
+
+export interface TemplateComponent {
+  type: string;
+  format?: string;
+  text?: string;
+  buttons?: Record<string, unknown>[];
+  example?: Record<string, unknown>;
+  [key: string]: unknown;
+}
+
+export interface MessageTemplate {
+  id: string;
+  name?: string;
+  status?: string;
+  category?: string;
+  language?: string;
+  quality_score?: { score?: string; date?: number };
+  components?: TemplateComponent[];
+  rejected_reason?: string;
+  parameter_format?: string;
+}
+
+export interface WhatsAppFlow {
+  id: string;
+  name?: string;
+  status?: string;
+  categories?: string[];
+  validation_errors?: Record<string, unknown>[];
+  json_version?: string;
+  data_api_version?: string;
+  endpoint_uri?: string;
+  preview?: { preview_url?: string; expires_at?: string };
+}
+
+export interface WhatsAppQrCode {
+  code: string;
+  prefilled_message?: string;
+  deep_link_url?: string;
+  qr_image_url?: string;
+}
+
+export interface WebhookSubscription {
+  whatsapp_business_api_data?: { id: string; name?: string; link?: string };
+  override_callback_uri?: string;
+}
+
+export const WABA_DEFAULT_FIELDS = [
+  "id",
+  "name",
+  "currency",
+  "timezone_id",
+  "message_template_namespace",
+  "account_review_status",
+  "business_verification_status",
+  "country",
+  "ownership_type",
+] as const;
+
+export const WA_PHONE_DEFAULT_FIELDS = [
+  "id",
+  "display_phone_number",
+  "verified_name",
+  "code_verification_status",
+  "quality_rating",
+  "platform_type",
+  "throughput",
+  "status",
+  "name_status",
+] as const;
+
+export const WA_TEMPLATE_DEFAULT_FIELDS = [
+  "id",
+  "name",
+  "status",
+  "category",
+  "language",
+  "quality_score",
+] as const;
+
+export const WA_FLOW_DEFAULT_FIELDS = [
+  "id",
+  "name",
+  "status",
+  "categories",
+  "validation_errors",
+] as const;
+
+export const WA_PROFILE_FIELDS = [
+  "about",
+  "address",
+  "description",
+  "email",
+  "profile_picture_url",
+  "websites",
+  "vertical",
+] as const;

--- a/src/tools/_register.ts
+++ b/src/tools/_register.ts
@@ -47,3 +47,6 @@ export const TOKEN: ToolAnnotations = {
 
 /** Prefix every write-tool description so clients that ignore annotations still see the warning. */
 export const WRITE_WARNING = "⚠️ Modifies live ads/account data. ";
+
+/** Same, for WhatsApp Business tools. */
+export const WHATSAPP_WRITE_WARNING = "⚠️ Modifies live WhatsApp Business data. ";

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -24,6 +24,10 @@ import { registerEntityTools } from "./entities.js";
 import { registerDiagnosticTools } from "./diagnostics.js";
 import { registerHelpTools } from "./help.js";
 import { registerMacroTools } from "./macros.js";
+import { registerWhatsAppTools } from "./whatsapp.js";
+import { registerWhatsAppTemplateTools } from "./whatsapp-templates.js";
+import { registerWhatsAppFlowTools } from "./whatsapp-flows.js";
+import { registerWhatsAppConfigTools } from "./whatsapp-config.js";
 
 /**
  * Register all Meta Ads tools on the MCP server.
@@ -69,8 +73,14 @@ export function registerAllTools(server: McpServer): void {
   // ─── Instagram ──────────────────────────────────────────
   registerInstagramTools(server);    // 2 tools — IG account & media lookup
 
+  // ─── WhatsApp Business ──────────────────────────────────
+  registerWhatsAppTools(server);         // 8 tools — WABAs, phone numbers, business profile
+  registerWhatsAppTemplateTools(server); // 6 tools — message templates + analytics
+  registerWhatsAppFlowTools(server);     // 6 tools — WhatsApp Flows lifecycle
+  registerWhatsAppConfigTools(server);   // 7 tools — QR deep links + webhook subscriptions
+
   // ─── Token Management ────────────────────────────────────
   registerTokenTools(server);        // 4 tools — list / set-active / register / delete
 
-  // Total: 97 tools (79 renamed + 14 new in v3 + 3 audience-sharing + 1 invoices)
+  // Total: 124 tools (79 renamed + 14 new in v3 + 3 audience-sharing + 1 invoices + 27 WhatsApp)
 }

--- a/src/tools/whatsapp-config.ts
+++ b/src/tools/whatsapp-config.ts
@@ -1,0 +1,322 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { metaApiClient } from "../meta/client.js";
+import { validateMetaId } from "../utils/format.js";
+import type { WhatsAppQrCode, WebhookSubscription } from "../meta/types/whatsapp.js";
+import { READ, CREATE, UPDATE, DELETE, TOGGLE, WHATSAPP_WRITE_WARNING } from "./_register.js";
+
+function validateQrCodeId(code: string): string {
+  if (!/^[A-Za-z0-9]{1,64}$/.test(code)) {
+    throw new Error(
+      `Invalid QR code id: must be alphanumeric. Got: ${JSON.stringify(code).slice(0, 80)}`,
+    );
+  }
+  return code;
+}
+
+function describeQr(qr: WhatsAppQrCode): string {
+  return (
+    `- Code: ${qr.code}\n` +
+    `  Message: ${qr.prefilled_message ?? "N/A"}\n` +
+    `  Link: ${qr.deep_link_url ?? "N/A"}` +
+    (qr.qr_image_url ? `\n  QR image: ${qr.qr_image_url}` : "")
+  );
+}
+
+export function registerWhatsAppConfigTools(server: McpServer): void {
+  // ─── Get QR Codes ─────────────────────────────────────────────
+  server.registerTool(
+    "whatsapp_get_qr_codes",
+    {
+      description:
+        "List QR code deep links for a WhatsApp phone number, or get one by its code. Each QR code " +
+        "opens a chat with a prefilled message when scanned.",
+      inputSchema: {
+        phone_number_id: z.string().describe("Phone number ID."),
+        code: z.string().optional().describe("Specific QR code id to fetch."),
+      },
+      annotations: { ...READ },
+    },
+    async ({ phone_number_id, code }) => {
+      const id = validateMetaId(phone_number_id, "phone_number_id");
+
+      const path = code
+        ? `/${id}/message_qrdls/${validateQrCodeId(code)}`
+        : `/${id}/message_qrdls`;
+      // Meta documents the single-code GET as {data:[...]} like the list edge,
+      // but tolerate a bare-object response so a shape change can't produce a
+      // false "no QR codes found".
+      const response = await metaApiClient.get<{ data?: WhatsAppQrCode[]; code?: string }>(path);
+      const codes: WhatsAppQrCode[] =
+        response.data ?? (response.code ? [response as WhatsAppQrCode] : []);
+
+      if (codes.length === 0) {
+        return {
+          content: [
+            { type: "text", text: `No QR codes found for phone ${phone_number_id}.` },
+            { type: "text", text: "[]" },
+          ],
+        };
+      }
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Found ${codes.length} QR code(s) for phone ${phone_number_id}:\n\n${codes.map(describeQr).join("\n")}`,
+          },
+          { type: "text", text: JSON.stringify(codes, null, 2) },
+        ],
+      };
+    },
+  );
+
+  // ─── Create QR Code ───────────────────────────────────────────
+  server.registerTool(
+    "whatsapp_create_qr_code",
+    {
+      description:
+        `${WHATSAPP_WRITE_WARNING}Create a QR code deep link for a WhatsApp phone number. Scanning it ` +
+        "opens a chat with the prefilled message. Returns the code, wa.me deep link, and optionally " +
+        "a QR image URL.",
+      inputSchema: {
+        phone_number_id: z.string().describe("Phone number ID."),
+        prefilled_message: z
+          .string()
+          .min(1)
+          .max(140)
+          .describe("Message prefilled in the user's chat when they scan the code."),
+        generate_qr_image: z
+          .enum(["SVG", "PNG"])
+          .optional()
+          .describe("Also return a rendered QR image in this format."),
+      },
+      annotations: { ...CREATE },
+    },
+    async ({ phone_number_id, prefilled_message, generate_qr_image }) => {
+      const id = validateMetaId(phone_number_id, "phone_number_id");
+
+      const body: Record<string, unknown> = { prefilled_message };
+      if (generate_qr_image) body.generate_qr_image = generate_qr_image;
+
+      const qr = await metaApiClient.post<WhatsAppQrCode>(`/${id}/message_qrdls`, body);
+
+      return {
+        content: [
+          { type: "text", text: `QR code created for phone ${phone_number_id}:\n${describeQr(qr)}` },
+          { type: "text", text: JSON.stringify(qr, null, 2) },
+        ],
+      };
+    },
+  );
+
+  // ─── Update QR Code ───────────────────────────────────────────
+  server.registerTool(
+    "whatsapp_update_qr_code",
+    {
+      description:
+        `${WHATSAPP_WRITE_WARNING}Update the prefilled message of an existing QR code deep link. ` +
+        "The code and deep link URL stay the same.",
+      inputSchema: {
+        phone_number_id: z.string().describe("Phone number ID."),
+        code: z.string().describe("QR code id to update."),
+        prefilled_message: z.string().min(1).max(140).describe("New prefilled message."),
+      },
+      annotations: { ...UPDATE },
+    },
+    async ({ phone_number_id, code, prefilled_message }) => {
+      const id = validateMetaId(phone_number_id, "phone_number_id");
+
+      const qr = await metaApiClient.post<WhatsAppQrCode>(`/${id}/message_qrdls`, {
+        code: validateQrCodeId(code),
+        prefilled_message,
+      });
+
+      return {
+        content: [
+          { type: "text", text: `QR code ${code} updated:\n${describeQr(qr)}` },
+          { type: "text", text: JSON.stringify(qr, null, 2) },
+        ],
+      };
+    },
+  );
+
+  // ─── Delete QR Code ───────────────────────────────────────────
+  server.registerTool(
+    "whatsapp_delete_qr_code",
+    {
+      description:
+        `${WHATSAPP_WRITE_WARNING}Delete a QR code deep link. Scans of the printed code stop working. ` +
+        "Cannot be undone.",
+      inputSchema: {
+        phone_number_id: z.string().describe("Phone number ID."),
+        code: z.string().describe("QR code id to delete."),
+      },
+      annotations: { ...DELETE },
+    },
+    async ({ phone_number_id, code }) => {
+      const id = validateMetaId(phone_number_id, "phone_number_id");
+      const result = await metaApiClient.delete<{ success?: boolean }>(
+        `/${id}/message_qrdls/${validateQrCodeId(code)}`,
+      );
+      if (result?.success !== true) {
+        throw new Error(
+          `Meta did not confirm the deletion of QR code ${code}. Response: ${JSON.stringify(result)}`,
+        );
+      }
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: `QR code ${code} deleted from phone ${phone_number_id}.\n${JSON.stringify(result)}`,
+          },
+        ],
+      };
+    },
+  );
+
+  // ─── Get Webhook Subscriptions ────────────────────────────────
+  server.registerTool(
+    "whatsapp_get_webhook_subscriptions",
+    {
+      description:
+        "List the apps subscribed to webhook events on a WhatsApp Business Account, including any " +
+        "callback URI override.",
+      inputSchema: {
+        waba_id: z.string().describe("WhatsApp Business Account ID."),
+      },
+      annotations: { ...READ },
+    },
+    async ({ waba_id }) => {
+      const id = validateMetaId(waba_id, "waba_id");
+      const response = await metaApiClient.get<{ data: WebhookSubscription[] }>(
+        `/${id}/subscribed_apps`,
+      );
+      const subs = response.data ?? [];
+
+      if (subs.length === 0) {
+        return {
+          content: [
+            {
+              type: "text",
+              text:
+                `No apps subscribed to webhooks on WABA ${waba_id}. ` +
+                `Use whatsapp_subscribe_webhook to subscribe this server's Meta app.`,
+            },
+            { type: "text", text: "[]" },
+          ],
+        };
+      }
+
+      const lines = [
+        `${subs.length} app(s) subscribed to WABA ${waba_id} webhooks:`,
+        ``,
+        ...subs.map(
+          (s) =>
+            `- ${s.whatsapp_business_api_data?.name ?? "Unknown app"} (ID: ${s.whatsapp_business_api_data?.id ?? "?"})` +
+            (s.override_callback_uri ? `\n  Callback override: ${s.override_callback_uri}` : ""),
+        ),
+      ];
+
+      return {
+        content: [
+          { type: "text", text: lines.join("\n") },
+          { type: "text", text: JSON.stringify(subs, null, 2) },
+        ],
+      };
+    },
+  );
+
+  // ─── Subscribe Webhook ────────────────────────────────────────
+  server.registerTool(
+    "whatsapp_subscribe_webhook",
+    {
+      description:
+        `${WHATSAPP_WRITE_WARNING}Subscribe the Meta app that owns this access token to webhook events ` +
+        "on a WABA (messages, template status updates, etc.). Events are delivered to the app's " +
+        "configured webhook endpoint — this server does not receive them. Optionally override the " +
+        "callback URL for this WABA (override_callback_uri and verify_token must be provided together).",
+      inputSchema: {
+        waba_id: z.string().describe("WhatsApp Business Account ID."),
+        override_callback_uri: z
+          .string()
+          .url()
+          .optional()
+          .describe("Alternate callback URL for this WABA only (requires verify_token)."),
+        verify_token: z
+          .string()
+          .optional()
+          .describe("Verify token Meta will send to the override callback (required with override_callback_uri)."),
+      },
+      annotations: { ...TOGGLE },
+    },
+    async ({ waba_id, override_callback_uri, verify_token }) => {
+      const id = validateMetaId(waba_id, "waba_id");
+
+      if (Boolean(override_callback_uri) !== Boolean(verify_token)) {
+        throw new Error("override_callback_uri and verify_token must be provided together.");
+      }
+
+      const body: Record<string, unknown> = {};
+      if (override_callback_uri) {
+        body.override_callback_uri = override_callback_uri;
+        body.verify_token = verify_token;
+      }
+
+      const result = await metaApiClient.post<{ success?: boolean }>(
+        `/${id}/subscribed_apps`,
+        body,
+      );
+      if (result?.success !== true) {
+        throw new Error(
+          `Meta did not confirm the webhook subscription for WABA ${id}. Response: ${JSON.stringify(result)}`,
+        );
+      }
+
+      return {
+        content: [
+          {
+            type: "text",
+            text:
+              `App subscribed to webhooks on WABA ${waba_id}` +
+              `${override_callback_uri ? ` with callback override ${override_callback_uri}` : ""}.\n` +
+              `${JSON.stringify(result)}`,
+          },
+        ],
+      };
+    },
+  );
+
+  // ─── Unsubscribe Webhook ──────────────────────────────────────
+  server.registerTool(
+    "whatsapp_unsubscribe_webhook",
+    {
+      description:
+        `${WHATSAPP_WRITE_WARNING}Unsubscribe the Meta app that owns this access token from webhook ` +
+        "events on a WABA. The app stops receiving message and template events for this account.",
+      inputSchema: {
+        waba_id: z.string().describe("WhatsApp Business Account ID."),
+      },
+      annotations: { ...TOGGLE },
+    },
+    async ({ waba_id }) => {
+      const id = validateMetaId(waba_id, "waba_id");
+      const result = await metaApiClient.delete<{ success?: boolean }>(`/${id}/subscribed_apps`);
+      if (result?.success !== true) {
+        throw new Error(
+          `Meta did not confirm the webhook unsubscription for WABA ${id}. Response: ${JSON.stringify(result)}`,
+        );
+      }
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: `App unsubscribed from webhooks on WABA ${waba_id}.\n${JSON.stringify(result)}`,
+          },
+        ],
+      };
+    },
+  );
+}

--- a/src/tools/whatsapp-flows.ts
+++ b/src/tools/whatsapp-flows.ts
@@ -1,0 +1,342 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { metaApiClient } from "../meta/client.js";
+import { validateMetaId } from "../utils/format.js";
+import { buildFieldsParam, requireOneOf } from "../utils/validation.js";
+import {
+  WA_FLOW_DEFAULT_FIELDS,
+  type WhatsAppFlow,
+} from "../meta/types/whatsapp.js";
+import { READ, CREATE, UPDATE, TOGGLE, DELETE, WHATSAPP_WRITE_WARNING } from "./_register.js";
+
+const FLOW_CATEGORY = z.enum([
+  "SIGN_UP", "SIGN_IN", "APPOINTMENT_BOOKING", "LEAD_GENERATION",
+  "CONTACT_US", "CUSTOMER_SUPPORT", "SURVEY", "OTHER",
+]);
+
+const FLOW_DETAIL_FIELDS = [
+  "id",
+  "name",
+  "status",
+  "categories",
+  "validation_errors",
+  "json_version",
+  "data_api_version",
+  "endpoint_uri",
+  "preview.invalidate(false)",
+  "whatsapp_business_account",
+  "application",
+].join(",");
+
+function formatValidationErrors(errors: WhatsAppFlow["validation_errors"]): string {
+  if (!errors || errors.length === 0) return "";
+  return `\n  Validation errors:\n${JSON.stringify(errors, null, 2)}`;
+}
+
+async function uploadFlowJson(
+  flowId: string,
+  flowJson: string,
+): Promise<{ success?: boolean; validation_errors?: Record<string, unknown>[] }> {
+  const formData = new FormData();
+  formData.set("file", new Blob([flowJson], { type: "application/json" }), "flow.json");
+  formData.set("name", "flow.json");
+  formData.set("asset_type", "FLOW_JSON");
+  return metaApiClient.postMultipart(`/${flowId}/assets`, formData);
+}
+
+export function registerWhatsAppFlowTools(server: McpServer): void {
+  // ─── Get Flows ────────────────────────────────────────────────
+  server.registerTool(
+    "whatsapp_get_flows",
+    {
+      description:
+        "List WhatsApp Flows on a WhatsApp Business Account, or get full details for one flow " +
+        "(including validation errors and a web preview URL).",
+      inputSchema: {
+        waba_id: z.string().optional().describe("WhatsApp Business Account ID to list flows for."),
+        flow_id: z.string().optional().describe("Flow ID for single-flow details."),
+        fields: z.array(z.string()).optional().describe("Fields to return per flow."),
+        limit: z.number().min(1).max(100).default(25).describe("Maximum flows to return."),
+      },
+      annotations: { ...READ },
+    },
+    async ({ waba_id, flow_id, fields, limit }) => {
+      requireOneOf({ waba_id, flow_id }, ["waba_id", "flow_id"]);
+
+      if (flow_id) {
+        const flow = await metaApiClient.get<WhatsAppFlow>(
+          `/${validateMetaId(flow_id, "flow_id")}`,
+          { fields: fields && fields.length > 0 ? fields.join(",") : FLOW_DETAIL_FIELDS },
+        );
+        return {
+          content: [
+            {
+              type: "text",
+              text:
+                `Flow: ${flow.name ?? flow.id}\n` +
+                `  Status: ${flow.status ?? "N/A"}\n` +
+                `  Categories: ${flow.categories?.join(", ") ?? "N/A"}\n` +
+                `  Preview: ${flow.preview?.preview_url ?? "N/A"}` +
+                formatValidationErrors(flow.validation_errors),
+            },
+            { type: "text", text: JSON.stringify(flow, null, 2) },
+          ],
+        };
+      }
+
+      const flows = await metaApiClient.getPaginated<WhatsAppFlow>(
+        `/${validateMetaId(waba_id!, "waba_id")}/flows`,
+        { fields: buildFieldsParam(fields, [...WA_FLOW_DEFAULT_FIELDS]) },
+        limit,
+      );
+
+      if (flows.length === 0) {
+        return {
+          content: [
+            { type: "text", text: `No flows found on WABA ${waba_id}.` },
+            { type: "text", text: "[]" },
+          ],
+        };
+      }
+
+      const lines = [
+        `Found ${flows.length} flow(s) on WABA ${waba_id}:`,
+        ``,
+        ...flows.map(
+          (f) =>
+            `- ${f.name ?? f.id} — ${f.status ?? "?"} (ID: ${f.id})` +
+            `${f.validation_errors && f.validation_errors.length > 0 ? " ⚠ has validation errors" : ""}`,
+        ),
+      ];
+
+      return {
+        content: [
+          { type: "text", text: lines.join("\n") },
+          { type: "text", text: JSON.stringify(flows, null, 2) },
+        ],
+      };
+    },
+  );
+
+  // ─── Create Flow ──────────────────────────────────────────────
+  server.registerTool(
+    "whatsapp_create_flow",
+    {
+      description:
+        `${WHATSAPP_WRITE_WARNING}Create a WhatsApp Flow (draft). Optionally provide flow_json to set ` +
+        "the flow content in the same call, clone_flow_id to copy an existing flow, or publish=true " +
+        "to publish immediately (only works if the flow has no validation errors).",
+      inputSchema: {
+        waba_id: z.string().describe("WhatsApp Business Account ID."),
+        name: z.string().min(1).max(200).describe("Flow name."),
+        categories: z
+          .array(FLOW_CATEGORY)
+          .min(1)
+          .describe("Flow categories (at least one)."),
+        flow_json: z
+          .string()
+          .optional()
+          .describe("Stringified Flow JSON defining the screens and logic."),
+        clone_flow_id: z.string().optional().describe("Existing flow ID to clone content from."),
+        endpoint_uri: z
+          .string()
+          .url()
+          .optional()
+          .describe("Data endpoint URL for dynamic flows (Flow JSON 3.0+)."),
+        publish: z
+          .boolean()
+          .optional()
+          .describe("Publish immediately after creation (requires valid flow_json)."),
+      },
+      annotations: { ...CREATE },
+    },
+    async ({ waba_id, name, categories, flow_json, clone_flow_id, endpoint_uri, publish }) => {
+      const id = validateMetaId(waba_id, "waba_id");
+
+      const body: Record<string, unknown> = { name, categories };
+      if (flow_json !== undefined) body.flow_json = flow_json;
+      if (clone_flow_id !== undefined) body.clone_flow_id = validateMetaId(clone_flow_id, "flow_id");
+      if (endpoint_uri !== undefined) body.endpoint_uri = endpoint_uri;
+      if (publish !== undefined) body.publish = publish;
+
+      const result = await metaApiClient.post<{
+        id: string;
+        success?: boolean;
+        validation_errors?: Record<string, unknown>[];
+      }>(`/${id}/flows`, body);
+
+      return {
+        content: [
+          {
+            type: "text",
+            text:
+              `Flow "${name}" created on WABA ${waba_id}.\n  ID: ${result.id}` +
+              formatValidationErrors(result.validation_errors),
+          },
+          { type: "text", text: JSON.stringify(result, null, 2) },
+        ],
+      };
+    },
+  );
+
+  // ─── Update Flow ──────────────────────────────────────────────
+  server.registerTool(
+    "whatsapp_update_flow",
+    {
+      description:
+        `${WHATSAPP_WRITE_WARNING}Update a flow's metadata (name, categories, endpoint) and/or replace ` +
+        "its Flow JSON content. Content updates only apply to DRAFT flows — published flows must be " +
+        "cloned first. Always check validation_errors in the response before publishing.",
+      inputSchema: {
+        flow_id: z.string().describe("Flow ID to update."),
+        name: z.string().min(1).max(200).optional().describe("New flow name."),
+        categories: z.array(FLOW_CATEGORY).min(1).optional().describe("New categories."),
+        endpoint_uri: z.string().url().optional().describe("New data endpoint URL."),
+        flow_json: z
+          .string()
+          .optional()
+          .describe("Stringified Flow JSON to replace the flow content."),
+      },
+      annotations: { ...UPDATE },
+    },
+    async ({ flow_id, name, categories, endpoint_uri, flow_json }) => {
+      const id = validateMetaId(flow_id, "flow_id");
+
+      const metadata: Record<string, unknown> = {};
+      if (name !== undefined) metadata.name = name;
+      if (categories !== undefined) metadata.categories = categories;
+      if (endpoint_uri !== undefined) metadata.endpoint_uri = endpoint_uri;
+
+      if (Object.keys(metadata).length === 0 && flow_json === undefined) {
+        throw new Error("Provide at least one of name, categories, endpoint_uri, or flow_json.");
+      }
+
+      const results: Record<string, unknown> = {};
+      if (Object.keys(metadata).length > 0) {
+        const metadataResult = await metaApiClient.post<{ success?: boolean }>(`/${id}`, metadata);
+        if (metadataResult?.success !== true) {
+          throw new Error(
+            `Meta did not confirm the metadata update for flow ${id}. Response: ${JSON.stringify(metadataResult)}`,
+          );
+        }
+        results.metadata = metadataResult;
+      }
+      let validationErrors: Record<string, unknown>[] | undefined;
+      if (flow_json !== undefined) {
+        const assetResult = await uploadFlowJson(id, flow_json);
+        if (assetResult?.success !== true) {
+          throw new Error(
+            `Meta did not confirm the Flow JSON upload for flow ${id}. Response: ${JSON.stringify(assetResult)}`,
+          );
+        }
+        results.flow_json = assetResult;
+        validationErrors = assetResult.validation_errors;
+      }
+
+      return {
+        content: [
+          {
+            type: "text",
+            text:
+              `Flow ${flow_id} updated` +
+              `${Object.keys(metadata).length > 0 ? ` (metadata: ${Object.keys(metadata).join(", ")})` : ""}` +
+              `${flow_json !== undefined ? " (flow content replaced)" : ""}.` +
+              formatValidationErrors(validationErrors),
+          },
+          { type: "text", text: JSON.stringify(results, null, 2) },
+        ],
+      };
+    },
+  );
+
+  // ─── Publish Flow ─────────────────────────────────────────────
+  server.registerTool(
+    "whatsapp_publish_flow",
+    {
+      description:
+        `${WHATSAPP_WRITE_WARNING}Publish a DRAFT flow so it can be sent to users. Fails if the flow ` +
+        "has validation errors (check with whatsapp_get_flows first). Published flows cannot be " +
+        "edited — only cloned or deprecated.",
+      inputSchema: {
+        flow_id: z.string().describe("Flow ID to publish."),
+      },
+      annotations: { ...TOGGLE },
+    },
+    async ({ flow_id }) => {
+      const id = validateMetaId(flow_id, "flow_id");
+      const result = await metaApiClient.post<{ success?: boolean }>(`/${id}/publish`, {});
+      if (result?.success !== true) {
+        throw new Error(
+          `Meta did not confirm the publish for flow ${id}. Response: ${JSON.stringify(result)}`,
+        );
+      }
+
+      return {
+        content: [
+          { type: "text", text: `Flow ${flow_id} published.\n${JSON.stringify(result)}` },
+        ],
+      };
+    },
+  );
+
+  // ─── Deprecate Flow ───────────────────────────────────────────
+  server.registerTool(
+    "whatsapp_deprecate_flow",
+    {
+      description:
+        `${WHATSAPP_WRITE_WARNING}Deprecate a PUBLISHED flow. IRREVERSIBLE — a deprecated flow can ` +
+        "never be reactivated; users who open it see an error. Only use when the flow is retired for good.",
+      inputSchema: {
+        flow_id: z.string().describe("Flow ID to deprecate."),
+      },
+      annotations: { ...DELETE },
+    },
+    async ({ flow_id }) => {
+      const id = validateMetaId(flow_id, "flow_id");
+      const result = await metaApiClient.post<{ success?: boolean }>(`/${id}/deprecate`, {});
+      if (result?.success !== true) {
+        throw new Error(
+          `Meta did not confirm the deprecation for flow ${id}. Response: ${JSON.stringify(result)}`,
+        );
+      }
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Flow ${flow_id} deprecated (irreversible).\n${JSON.stringify(result)}`,
+          },
+        ],
+      };
+    },
+  );
+
+  // ─── Delete Flow ──────────────────────────────────────────────
+  server.registerTool(
+    "whatsapp_delete_flow",
+    {
+      description:
+        `${WHATSAPP_WRITE_WARNING}Delete a flow. Only DRAFT flows can be deleted — published flows ` +
+        "must be deprecated instead. Cannot be undone.",
+      inputSchema: {
+        flow_id: z.string().describe("Flow ID to delete (must be in DRAFT status)."),
+      },
+      annotations: { ...DELETE },
+    },
+    async ({ flow_id }) => {
+      const id = validateMetaId(flow_id, "flow_id");
+      const result = await metaApiClient.delete<{ success?: boolean }>(`/${id}`);
+      if (result?.success !== true) {
+        throw new Error(
+          `Meta did not confirm the deletion for flow ${id}. Response: ${JSON.stringify(result)}`,
+        );
+      }
+
+      return {
+        content: [
+          { type: "text", text: `Flow ${flow_id} deleted.\n${JSON.stringify(result)}` },
+        ],
+      };
+    },
+  );
+}

--- a/src/tools/whatsapp-templates.ts
+++ b/src/tools/whatsapp-templates.ts
@@ -1,0 +1,443 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { metaApiClient } from "../meta/client.js";
+import { validateMetaId } from "../utils/format.js";
+import { buildFieldsParam, requireOneOf } from "../utils/validation.js";
+import {
+  WA_TEMPLATE_DEFAULT_FIELDS,
+  type MessageTemplate,
+} from "../meta/types/whatsapp.js";
+import { READ, CREATE, UPDATE, DELETE, WHATSAPP_WRITE_WARNING } from "./_register.js";
+
+const TEMPLATE_CATEGORY = z.enum(["MARKETING", "UTILITY", "AUTHENTICATION"]);
+const TEMPLATE_STATUS = z.enum([
+  "APPROVED", "PENDING", "REJECTED", "PAUSED", "DISABLED", "IN_APPEAL",
+]);
+
+const templateComponentSchema = z
+  .record(z.string(), z.unknown())
+  .describe("Template component object (type HEADER/BODY/FOOTER/BUTTONS plus its fields).");
+
+function toUnixSeconds(value: string, label: string): number {
+  if (/^\d{9,12}$/.test(value)) return parseInt(value, 10);
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+    throw new Error(`Invalid ${label}: use YYYY-MM-DD or a UNIX timestamp in seconds.`);
+  }
+  return Math.floor(Date.parse(`${value}T00:00:00Z`) / 1000);
+}
+
+function assertEnumTokens(values: string[], label: string): string[] {
+  for (const v of values) {
+    if (!/^[A-Z_]+$/.test(v)) {
+      throw new Error(`Invalid ${label} value: ${JSON.stringify(v).slice(0, 40)}`);
+    }
+  }
+  return values;
+}
+
+export function registerWhatsAppTemplateTools(server: McpServer): void {
+  // ─── Get Templates ────────────────────────────────────────────
+  server.registerTool(
+    "whatsapp_get_templates",
+    {
+      description:
+        "List message templates on a WhatsApp Business Account (filterable by name, status, category, language), " +
+        "or get full details (including components) for a single template by ID.",
+      inputSchema: {
+        waba_id: z.string().optional().describe("WhatsApp Business Account ID to list templates for."),
+        template_id: z.string().optional().describe("Template ID for single-template details."),
+        name: z.string().optional().describe("Filter by template name (prefix match)."),
+        status: TEMPLATE_STATUS.optional().describe("Filter by review status."),
+        category: TEMPLATE_CATEGORY.optional().describe("Filter by category."),
+        language: z.string().optional().describe("Filter by language code (e.g. en_US, es_MX)."),
+        fields: z.array(z.string()).optional().describe("Fields to return per template."),
+        limit: z.number().min(1).max(200).default(25).describe("Maximum templates to return."),
+      },
+      annotations: { ...READ },
+    },
+    async ({ waba_id, template_id, name, status, category, language, fields, limit }) => {
+      requireOneOf({ waba_id, template_id }, ["waba_id", "template_id"]);
+
+      if (template_id) {
+        const template = await metaApiClient.get<MessageTemplate>(
+          `/${validateMetaId(template_id, "template_id")}`,
+          {
+            fields: buildFieldsParam(fields, [
+              ...WA_TEMPLATE_DEFAULT_FIELDS,
+              "components",
+              "rejected_reason",
+              "parameter_format",
+            ]),
+          },
+        );
+        return {
+          content: [
+            {
+              type: "text",
+              text:
+                `Template: ${template.name ?? template.id}\n` +
+                `  Status: ${template.status ?? "N/A"}\n` +
+                `  Category: ${template.category ?? "N/A"}\n` +
+                `  Language: ${template.language ?? "N/A"}` +
+                (template.rejected_reason ? `\n  Rejected reason: ${template.rejected_reason}` : ""),
+            },
+            { type: "text", text: JSON.stringify(template, null, 2) },
+          ],
+        };
+      }
+
+      const params: Record<string, string | number> = {
+        fields: buildFieldsParam(fields, [...WA_TEMPLATE_DEFAULT_FIELDS]),
+      };
+      if (name) params.name = name;
+      if (status) params.status = status;
+      if (category) params.category = category;
+      if (language) params.language = language;
+
+      const templates = await metaApiClient.getPaginated<MessageTemplate>(
+        `/${validateMetaId(waba_id!, "waba_id")}/message_templates`,
+        params,
+        limit,
+      );
+
+      if (templates.length === 0) {
+        return {
+          content: [
+            { type: "text", text: `No message templates found on WABA ${waba_id} for the given filters.` },
+            { type: "text", text: "[]" },
+          ],
+        };
+      }
+
+      const lines = [
+        `Found ${templates.length} template(s) on WABA ${waba_id}:`,
+        ``,
+        ...templates.map(
+          (t) =>
+            `- ${t.name ?? t.id} [${t.language ?? "?"}] — ${t.status ?? "?"} / ${t.category ?? "?"} (ID: ${t.id})`,
+        ),
+      ];
+
+      return {
+        content: [
+          { type: "text", text: lines.join("\n") },
+          { type: "text", text: JSON.stringify(templates, null, 2) },
+        ],
+      };
+    },
+  );
+
+  // ─── Create Template ──────────────────────────────────────────
+  server.registerTool(
+    "whatsapp_create_template",
+    {
+      description:
+        `${WHATSAPP_WRITE_WARNING}Create a message template on a WhatsApp Business Account. ` +
+        "The template enters Meta's review queue (status PENDING). Name must be lowercase letters, " +
+        "digits and underscores. AUTHENTICATION templates only accept OTP-style components. " +
+        "Meta may recategorize the template unless allow_category_change is false.",
+      inputSchema: {
+        waba_id: z.string().describe("WhatsApp Business Account ID."),
+        name: z
+          .string()
+          .max(512)
+          .regex(/^[a-z0-9_]+$/, "Name must contain only lowercase letters, digits, and underscores")
+          .describe("Template name (lowercase, digits, underscores)."),
+        category: TEMPLATE_CATEGORY.describe("Template category."),
+        language: z
+          .string()
+          .regex(/^[a-z]{2}(_[A-Z]{2})?$/, "Use a locale code like en, en_US, es_MX")
+          .describe("Language/locale code (e.g. en_US, es_MX)."),
+        components: z
+          .array(templateComponentSchema)
+          .min(1)
+          .describe(
+            'Template components array, e.g. [{"type":"BODY","text":"Hi {{1}}"},{"type":"FOOTER","text":"Reply STOP to opt out"}].',
+          ),
+        allow_category_change: z
+          .boolean()
+          .default(true)
+          .describe("Let Meta recategorize automatically instead of rejecting on category mismatch."),
+        parameter_format: z
+          .enum(["POSITIONAL", "NAMED"])
+          .optional()
+          .describe("Placeholder style: {{1}} (POSITIONAL) or {{name}} (NAMED)."),
+      },
+      annotations: { ...CREATE },
+    },
+    async ({ waba_id, name, category, language, components, allow_category_change, parameter_format }) => {
+      const id = validateMetaId(waba_id, "waba_id");
+
+      const body: Record<string, unknown> = {
+        name,
+        category,
+        language,
+        components,
+        allow_category_change,
+      };
+      if (parameter_format) body.parameter_format = parameter_format;
+
+      const result = await metaApiClient.post<{ id: string; status?: string; category?: string }>(
+        `/${id}/message_templates`,
+        body,
+      );
+
+      return {
+        content: [
+          {
+            type: "text",
+            text:
+              `Template "${name}" (${language}) created on WABA ${waba_id}.\n` +
+              `  ID: ${result.id}\n` +
+              `  Status: ${result.status ?? "PENDING"}\n` +
+              `  Category: ${result.category ?? category}\n` +
+              `It must pass Meta's review before it can be sent.`,
+          },
+          { type: "text", text: JSON.stringify(result, null, 2) },
+        ],
+      };
+    },
+  );
+
+  // ─── Update Template ──────────────────────────────────────────
+  server.registerTool(
+    "whatsapp_update_template",
+    {
+      description:
+        `${WHATSAPP_WRITE_WARNING}Edit a message template's components, category, or message TTL. ` +
+        "Only templates in APPROVED, REJECTED, or PAUSED status can be edited. APPROVED templates " +
+        "can be edited at most once per 24 hours and 10 times per month; editing re-triggers review " +
+        "(status returns to PENDING). Do NOT retry on an edit-limit error.",
+      inputSchema: {
+        template_id: z.string().describe("Template ID to edit."),
+        components: z
+          .array(templateComponentSchema)
+          .optional()
+          .describe("Replacement components array (replaces ALL components)."),
+        category: TEMPLATE_CATEGORY.optional().describe("New category."),
+        message_send_ttl_seconds: z
+          .number()
+          .int()
+          .optional()
+          .describe("Custom time-to-live for sent messages, in seconds."),
+      },
+      annotations: { ...UPDATE },
+    },
+    async ({ template_id, components, category, message_send_ttl_seconds }) => {
+      const id = validateMetaId(template_id, "template_id");
+
+      const body: Record<string, unknown> = {};
+      if (components !== undefined) body.components = components;
+      if (category !== undefined) body.category = category;
+      if (message_send_ttl_seconds !== undefined) {
+        body.message_send_ttl_seconds = message_send_ttl_seconds;
+      }
+      if (Object.keys(body).length === 0) {
+        throw new Error("Provide at least one of components, category, or message_send_ttl_seconds.");
+      }
+
+      const result = await metaApiClient.post<{ success?: boolean }>(`/${id}`, body);
+      if (result?.success !== true) {
+        throw new Error(
+          `Meta did not confirm the update for template ${id}. Response: ${JSON.stringify(result)}`,
+        );
+      }
+
+      return {
+        content: [
+          {
+            type: "text",
+            text:
+              `Template ${template_id} updated (${Object.keys(body).join(", ")}).\n` +
+              `If components changed, the template re-enters review (status PENDING).\n${JSON.stringify(result)}`,
+          },
+        ],
+      };
+    },
+  );
+
+  // ─── Delete Template ──────────────────────────────────────────
+  server.registerTool(
+    "whatsapp_delete_template",
+    {
+      description:
+        `${WHATSAPP_WRITE_WARNING}Delete a message template by name. Without hsm_id, ALL language ` +
+        "versions of that name are deleted. Deleted template names cannot be reused for ~4 weeks " +
+        "(pending deletion). Cannot be undone.",
+      inputSchema: {
+        waba_id: z.string().describe("WhatsApp Business Account ID."),
+        name: z
+          .string()
+          .max(512)
+          .regex(/^[a-z0-9_]+$/, "Name must contain only lowercase letters, digits, and underscores")
+          .describe("Template name to delete."),
+        hsm_id: z
+          .string()
+          .optional()
+          .describe("Specific template ID to delete only one language version instead of all."),
+      },
+      annotations: { ...DELETE },
+    },
+    async ({ waba_id, name, hsm_id }) => {
+      const id = validateMetaId(waba_id, "waba_id");
+
+      const params: Record<string, string> = { name };
+      if (hsm_id) params.hsm_id = validateMetaId(hsm_id, "hsm_id");
+
+      const result = await metaApiClient.delete<{ success?: boolean }>(
+        `/${id}/message_templates`,
+        params,
+      );
+      if (result?.success !== true) {
+        throw new Error(
+          `Meta did not confirm the deletion of template "${name}". Response: ${JSON.stringify(result)}`,
+        );
+      }
+
+      return {
+        content: [
+          {
+            type: "text",
+            text:
+              `Template "${name}" ${hsm_id ? `(version ${hsm_id})` : "(all language versions)"} ` +
+              `deleted from WABA ${waba_id}.\n${JSON.stringify(result)}`,
+          },
+        ],
+      };
+    },
+  );
+
+  // ─── WABA Analytics ───────────────────────────────────────────
+  server.registerTool(
+    "whatsapp_get_analytics",
+    {
+      description:
+        "Get WhatsApp Business Account analytics: MESSAGING (messages sent/delivered), " +
+        "CONVERSATION (legacy conversation counts and cost), or PRICING (per-message pricing " +
+        "analytics, current model since July 2025).",
+      inputSchema: {
+        waba_id: z.string().describe("WhatsApp Business Account ID."),
+        metric_type: z
+          .enum(["MESSAGING", "CONVERSATION", "PRICING"])
+          .default("MESSAGING")
+          .describe("Which analytics family to query."),
+        start: z.string().describe("Start of range: YYYY-MM-DD or UNIX seconds."),
+        end: z.string().describe("End of range: YYYY-MM-DD or UNIX seconds."),
+        granularity: z
+          .enum(["HALF_HOUR", "DAY", "MONTH"])
+          .default("DAY")
+          .describe("Aggregation granularity (mapped automatically per metric family)."),
+        dimensions: z
+          .array(z.string())
+          .optional()
+          .describe(
+            "Breakdown dimensions for CONVERSATION/PRICING, e.g. CONVERSATION_CATEGORY, PRICING_CATEGORY, COUNTRY, PHONE.",
+          ),
+        phone_numbers: z
+          .array(z.string())
+          .optional()
+          .describe("Filter to specific phone numbers (display format, e.g. +16505551111)."),
+      },
+      annotations: { ...READ },
+    },
+    async ({ waba_id, metric_type, start, end, granularity, dimensions, phone_numbers }) => {
+      const id = validateMetaId(waba_id, "waba_id");
+      const startTs = toUnixSeconds(start, "start");
+      const endTs = toUnixSeconds(end, "end");
+
+      const fieldName =
+        metric_type === "CONVERSATION"
+          ? "conversation_analytics"
+          : metric_type === "PRICING"
+            ? "pricing_analytics"
+            : "analytics";
+      const gran =
+        metric_type === "MESSAGING"
+          ? granularity
+          : granularity === "DAY"
+            ? "DAILY"
+            : granularity === "MONTH"
+              ? "MONTHLY"
+              : "HALF_HOUR";
+
+      let field = `${fieldName}.start(${startTs}).end(${endTs}).granularity(${gran})`;
+      if (phone_numbers && phone_numbers.length > 0) {
+        for (const p of phone_numbers) {
+          if (!/^\+?\d{5,20}$/.test(p)) {
+            throw new Error(`Invalid phone number filter: ${JSON.stringify(p).slice(0, 40)}`);
+          }
+        }
+        field += `.phone_numbers(${JSON.stringify(phone_numbers)})`;
+      }
+      if (dimensions && dimensions.length > 0 && metric_type !== "MESSAGING") {
+        field += `.dimensions(${JSON.stringify(assertEnumTokens(dimensions, "dimension"))})`;
+      }
+
+      const result = await metaApiClient.get<Record<string, unknown>>(`/${id}`, { fields: field });
+      const data = result[fieldName] ?? result;
+
+      return {
+        content: [
+          { type: "text", text: `${metric_type} analytics for WABA ${waba_id} (${start} → ${end}, ${gran}):` },
+          { type: "text", text: JSON.stringify(data, null, 2) },
+        ],
+      };
+    },
+  );
+
+  // ─── Template Analytics ───────────────────────────────────────
+  server.registerTool(
+    "whatsapp_get_template_analytics",
+    {
+      description:
+        "Get per-template performance analytics (sent, delivered, read, clicked) for up to 10 templates. " +
+        "Window must be within the last 90 days; granularity is always DAILY. Requires template analytics " +
+        "to be enabled on the WABA (is_enabled_for_insights) — if Meta returns an error saying it is " +
+        "disabled, report it to the user instead of enabling it (enabling is irreversible).",
+      inputSchema: {
+        waba_id: z.string().describe("WhatsApp Business Account ID."),
+        start: z.string().describe("Start of range: YYYY-MM-DD or UNIX seconds (max 90 days back)."),
+        end: z.string().describe("End of range: YYYY-MM-DD or UNIX seconds."),
+        template_ids: z
+          .array(z.string())
+          .min(1)
+          .max(10)
+          .describe("Template IDs to report on (1-10)."),
+        metric_types: z
+          .array(z.enum(["SENT", "DELIVERED", "READ", "CLICKED"]))
+          .optional()
+          .describe("Metrics to include. Defaults to all."),
+      },
+      annotations: { ...READ },
+    },
+    async ({ waba_id, start, end, template_ids, metric_types }) => {
+      const id = validateMetaId(waba_id, "waba_id");
+      const ids = template_ids.map((t) => validateMetaId(t, "template_id"));
+
+      const params: Record<string, string | number> = {
+        start: toUnixSeconds(start, "start"),
+        end: toUnixSeconds(end, "end"),
+        granularity: "DAILY",
+        template_ids: JSON.stringify(ids),
+      };
+      if (metric_types && metric_types.length > 0) {
+        params.metric_types = JSON.stringify(metric_types);
+      }
+
+      const result = await metaApiClient.get<Record<string, unknown>>(
+        `/${id}/template_analytics`,
+        params,
+      );
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Template analytics for ${ids.length} template(s) on WABA ${waba_id} (${start} → ${end}):`,
+          },
+          { type: "text", text: JSON.stringify(result, null, 2) },
+        ],
+      };
+    },
+  );
+}

--- a/src/tools/whatsapp.ts
+++ b/src/tools/whatsapp.ts
@@ -1,0 +1,499 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { metaApiClient } from "../meta/client.js";
+import { validateMetaId } from "../utils/format.js";
+import { buildFieldsParam, requireOneOf } from "../utils/validation.js";
+import {
+  WABA_DEFAULT_FIELDS,
+  WA_PHONE_DEFAULT_FIELDS,
+  WA_PROFILE_FIELDS,
+  type WhatsAppBusinessAccount,
+  type WhatsAppPhoneNumber,
+  type WhatsAppBusinessProfile,
+} from "../meta/types/whatsapp.js";
+import { READ, CREATE, UPDATE, TOGGLE, WHATSAPP_WRITE_WARNING } from "./_register.js";
+
+const MAX_BUSINESSES_TO_SCAN = 10;
+
+const BUSINESS_VERTICAL = z.enum([
+  "UNDEFINED", "OTHER", "AUTO", "BEAUTY", "APPAREL", "EDU", "ENTERTAIN",
+  "EVENT_PLAN", "FINANCE", "GROCERY", "GOVT", "HOTEL", "HEALTH", "NONPROFIT",
+  "PROF_SERVICES", "RETAIL", "TRAVEL", "RESTAURANT", "NOT_A_BIZ",
+]);
+
+const PERMISSION_HINT =
+  "If Meta returns a permission error (code 200/10), the access token was issued " +
+  "without the whatsapp_business_management scope — re-authorize via the OAuth flow " +
+  "to grant WhatsApp permissions.";
+
+interface WabaWithSource extends WhatsAppBusinessAccount {
+  _source?: string;
+}
+
+export function registerWhatsAppTools(server: McpServer): void {
+  // ─── Get Business Accounts (WABAs) ────────────────────────────
+  server.registerTool(
+    "whatsapp_get_business_accounts",
+    {
+      description:
+        "List WhatsApp Business Accounts (WABAs) owned by or shared with a business, or get details for one WABA. " +
+        "Without business_id, discovers WABAs across the businesses the token can access. " +
+        `Use this first to find the waba_id required by the other whatsapp_* tools. ${PERMISSION_HINT}`,
+      inputSchema: {
+        business_id: z
+          .string()
+          .optional()
+          .describe("Business ID to list WABAs for. Omit to scan all accessible businesses."),
+        waba_id: z
+          .string()
+          .optional()
+          .describe("WhatsApp Business Account ID. Provide to fetch details for a single WABA."),
+        include_client_wabas: z
+          .boolean()
+          .default(true)
+          .describe("Also list WABAs shared with the business by clients (client_whatsapp_business_accounts)."),
+        fields: z.array(z.string()).optional().describe("Fields to return per WABA."),
+        limit: z.number().min(1).max(100).default(25).describe("Maximum WABAs to return."),
+      },
+      annotations: { ...READ },
+    },
+    async ({ business_id, waba_id, include_client_wabas, fields, limit }) => {
+      const fieldsParam = buildFieldsParam(fields, [...WABA_DEFAULT_FIELDS]);
+
+      if (waba_id) {
+        const waba = await metaApiClient.get<WhatsAppBusinessAccount>(
+          `/${validateMetaId(waba_id, "waba_id")}`,
+          { fields: `${fieldsParam},health_status` },
+        );
+        return {
+          content: [
+            {
+              type: "text",
+              text:
+                `WABA: ${waba.name ?? waba.id}\n` +
+                `  ID: ${waba.id}\n` +
+                `  Review status: ${waba.account_review_status ?? "N/A"}\n` +
+                `  Verification: ${waba.business_verification_status ?? "N/A"}\n` +
+                `  Template namespace: ${waba.message_template_namespace ?? "N/A"}`,
+            },
+            { type: "text", text: JSON.stringify(waba, null, 2) },
+          ],
+        };
+      }
+
+      let businessIds: { id: string; name?: string }[];
+      if (business_id) {
+        businessIds = [{ id: validateMetaId(business_id, "business_id") }];
+      } else {
+        const businesses = await metaApiClient.getPaginated<{ id: string; name?: string }>(
+          "/me/businesses",
+          { fields: "id,name" },
+          MAX_BUSINESSES_TO_SCAN,
+        );
+        if (businesses.length === 0) {
+          return {
+            content: [
+              {
+                type: "text",
+                text:
+                  "No businesses accessible with this token, so no WABAs can be discovered. " +
+                  PERMISSION_HINT,
+              },
+              { type: "text", text: "[]" },
+            ],
+          };
+        }
+        businessIds = businesses;
+      }
+
+      const wabas: WabaWithSource[] = [];
+      for (const biz of businessIds) {
+        const owned = await metaApiClient.getPaginated<WhatsAppBusinessAccount>(
+          `/${biz.id}/owned_whatsapp_business_accounts`,
+          { fields: fieldsParam },
+          limit,
+        );
+        wabas.push(...owned.map((w) => ({ ...w, _source: `owned by ${biz.name ?? biz.id}` })));
+
+        if (include_client_wabas) {
+          const client = await metaApiClient.getPaginated<WhatsAppBusinessAccount>(
+            `/${biz.id}/client_whatsapp_business_accounts`,
+            { fields: fieldsParam },
+            limit,
+          );
+          wabas.push(...client.map((w) => ({ ...w, _source: `shared with ${biz.name ?? biz.id}` })));
+        }
+        if (wabas.length >= limit) break;
+      }
+
+      const unique = [...new Map(wabas.map((w) => [w.id, w])).values()].slice(0, limit);
+
+      if (unique.length === 0) {
+        return {
+          content: [
+            {
+              type: "text",
+              text:
+                `No WhatsApp Business Accounts found across ${businessIds.length} business(es). ` +
+                PERMISSION_HINT,
+            },
+            { type: "text", text: "[]" },
+          ],
+        };
+      }
+
+      const lines = [
+        `Found ${unique.length} WhatsApp Business Account(s):`,
+        ``,
+        ...unique.map(
+          (w) =>
+            `- ${w.name ?? "Unnamed"} (ID: ${w.id})` +
+            `${w.account_review_status ? ` — review: ${w.account_review_status}` : ""}` +
+            `${w._source ? ` [${w._source}]` : ""}`,
+        ),
+      ];
+
+      return {
+        content: [
+          { type: "text", text: lines.join("\n") },
+          { type: "text", text: JSON.stringify(unique, null, 2) },
+        ],
+      };
+    },
+  );
+
+  // ─── Get Phone Numbers ────────────────────────────────────────
+  server.registerTool(
+    "whatsapp_get_phone_numbers",
+    {
+      description:
+        "List phone numbers registered on a WhatsApp Business Account, or get details for a single phone number. " +
+        "Shows verification status, quality rating, and messaging throughput.",
+      inputSchema: {
+        waba_id: z
+          .string()
+          .optional()
+          .describe("WhatsApp Business Account ID to list phone numbers for."),
+        phone_number_id: z
+          .string()
+          .optional()
+          .describe("Phone number ID for single-number details."),
+        fields: z.array(z.string()).optional().describe("Fields to return per phone number."),
+        limit: z.number().min(1).max(100).default(25).describe("Maximum phone numbers to return."),
+      },
+      annotations: { ...READ },
+    },
+    async ({ waba_id, phone_number_id, fields, limit }) => {
+      requireOneOf({ waba_id, phone_number_id }, ["waba_id", "phone_number_id"]);
+      const fieldsParam = buildFieldsParam(fields, [...WA_PHONE_DEFAULT_FIELDS]);
+
+      if (phone_number_id) {
+        const phone = await metaApiClient.get<WhatsAppPhoneNumber>(
+          `/${validateMetaId(phone_number_id, "phone_number_id")}`,
+          { fields: `${fieldsParam},messaging_limit_tier` },
+        );
+        return {
+          content: [
+            {
+              type: "text",
+              text:
+                `Phone: ${phone.display_phone_number ?? phone.id} (${phone.verified_name ?? "N/A"})\n` +
+                `  ID: ${phone.id}\n` +
+                `  Verification: ${phone.code_verification_status ?? "N/A"}\n` +
+                `  Quality: ${phone.quality_rating ?? "N/A"}\n` +
+                `  Status: ${phone.status ?? "N/A"}`,
+            },
+            { type: "text", text: JSON.stringify(phone, null, 2) },
+          ],
+        };
+      }
+
+      const phones = await metaApiClient.getPaginated<WhatsAppPhoneNumber>(
+        `/${validateMetaId(waba_id!, "waba_id")}/phone_numbers`,
+        { fields: fieldsParam },
+        limit,
+      );
+
+      if (phones.length === 0) {
+        return {
+          content: [
+            { type: "text", text: `No phone numbers found on WABA ${waba_id}.` },
+            { type: "text", text: "[]" },
+          ],
+        };
+      }
+
+      const lines = [
+        `Found ${phones.length} phone number(s) on WABA ${waba_id}:`,
+        ``,
+        ...phones.map(
+          (p) =>
+            `- ${p.display_phone_number ?? p.id} "${p.verified_name ?? "N/A"}" (ID: ${p.id})` +
+            ` — verification: ${p.code_verification_status ?? "N/A"}, quality: ${p.quality_rating ?? "N/A"}`,
+        ),
+      ];
+
+      return {
+        content: [
+          { type: "text", text: lines.join("\n") },
+          { type: "text", text: JSON.stringify(phones, null, 2) },
+        ],
+      };
+    },
+  );
+
+  // ─── Register Phone ───────────────────────────────────────────
+  server.registerTool(
+    "whatsapp_register_phone",
+    {
+      description:
+        `${WHATSAPP_WRITE_WARNING}Register a phone number for use with the WhatsApp Cloud API. ` +
+        "Requires the number's 6-digit two-step verification PIN. If the PIN is rejected, the number " +
+        "already has two-step verification enabled with a different PIN — do not retry with guesses.",
+      inputSchema: {
+        phone_number_id: z.string().describe("Phone number ID to register."),
+        pin: z
+          .string()
+          .regex(/^\d{6}$/, "PIN must be exactly 6 digits")
+          .describe("6-digit two-step verification PIN."),
+        data_localization_region: z
+          .string()
+          .length(2)
+          .optional()
+          .describe("Optional 2-letter country code for local storage of messages (e.g. 'BR', 'IN')."),
+      },
+      annotations: { ...UPDATE },
+    },
+    async ({ phone_number_id, pin, data_localization_region }) => {
+      const id = validateMetaId(phone_number_id, "phone_number_id");
+      const body: Record<string, unknown> = { messaging_product: "whatsapp", pin };
+      if (data_localization_region) body.data_localization_region = data_localization_region;
+
+      const result = await metaApiClient.post<{ success?: boolean }>(`/${id}/register`, body);
+      if (result?.success !== true) {
+        throw new Error(
+          `Meta did not confirm the registration for phone ${id}. Response: ${JSON.stringify(result)}`,
+        );
+      }
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Phone number ${phone_number_id} registered for Cloud API use.\n${JSON.stringify(result)}`,
+          },
+        ],
+      };
+    },
+  );
+
+  // ─── Deregister Phone ─────────────────────────────────────────
+  server.registerTool(
+    "whatsapp_deregister_phone",
+    {
+      description:
+        `${WHATSAPP_WRITE_WARNING}Deregister a phone number from the WhatsApp Cloud API. ` +
+        "Reversible: the number stays on the WABA and can be re-registered with whatsapp_register_phone.",
+      inputSchema: {
+        phone_number_id: z.string().describe("Phone number ID to deregister."),
+      },
+      annotations: { ...TOGGLE },
+    },
+    async ({ phone_number_id }) => {
+      const id = validateMetaId(phone_number_id, "phone_number_id");
+      const result = await metaApiClient.post<{ success?: boolean }>(`/${id}/deregister`, {});
+      if (result?.success !== true) {
+        throw new Error(
+          `Meta did not confirm the deregistration for phone ${id}. Response: ${JSON.stringify(result)}`,
+        );
+      }
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Phone number ${phone_number_id} deregistered from Cloud API.\n${JSON.stringify(result)}`,
+          },
+        ],
+      };
+    },
+  );
+
+  // ─── Request Verification Code ────────────────────────────────
+  server.registerTool(
+    "whatsapp_request_verification_code",
+    {
+      description:
+        `${WHATSAPP_WRITE_WARNING}Request an ownership verification code for a not-yet-verified phone number, ` +
+        "delivered via SMS or voice call. Each call sends a new code. Only applies to numbers whose " +
+        "code_verification_status is not VERIFIED.",
+      inputSchema: {
+        phone_number_id: z.string().describe("Phone number ID to verify."),
+        code_method: z.enum(["SMS", "VOICE"]).describe("How to deliver the code."),
+        language: z
+          .string()
+          .default("en_US")
+          .describe("Locale for the code message (e.g. en_US, es_ES)."),
+      },
+      annotations: { ...CREATE },
+    },
+    async ({ phone_number_id, code_method, language }) => {
+      const id = validateMetaId(phone_number_id, "phone_number_id");
+      const result = await metaApiClient.post<{ success?: boolean }>(`/${id}/request_code`, {
+        code_method,
+        language,
+      });
+      if (result?.success !== true) {
+        throw new Error(
+          `Meta did not confirm the code request for phone ${id}. Response: ${JSON.stringify(result)}`,
+        );
+      }
+
+      return {
+        content: [
+          {
+            type: "text",
+            text:
+              `Verification code requested for ${phone_number_id} via ${code_method}.\n` +
+              `Complete verification with whatsapp_verify_code once received.\n${JSON.stringify(result)}`,
+          },
+        ],
+      };
+    },
+  );
+
+  // ─── Verify Code ──────────────────────────────────────────────
+  server.registerTool(
+    "whatsapp_verify_code",
+    {
+      description:
+        `${WHATSAPP_WRITE_WARNING}Submit the verification code received via whatsapp_request_verification_code ` +
+        "to complete phone number ownership verification.",
+      inputSchema: {
+        phone_number_id: z.string().describe("Phone number ID being verified."),
+        code: z
+          .string()
+          .regex(/^\d{4,8}$/, "Code must be 4-8 digits")
+          .describe("Verification code received via SMS or voice."),
+      },
+      annotations: { ...UPDATE },
+    },
+    async ({ phone_number_id, code }) => {
+      const id = validateMetaId(phone_number_id, "phone_number_id");
+      const result = await metaApiClient.post<{ success?: boolean }>(`/${id}/verify_code`, { code });
+      if (result?.success !== true) {
+        throw new Error(
+          `Meta did not confirm the verification for phone ${id}. Response: ${JSON.stringify(result)}`,
+        );
+      }
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Phone number ${phone_number_id} verified.\n${JSON.stringify(result)}`,
+          },
+        ],
+      };
+    },
+  );
+
+  // ─── Get Business Profile ─────────────────────────────────────
+  server.registerTool(
+    "whatsapp_get_business_profile",
+    {
+      description:
+        "Get the WhatsApp business profile shown to customers for a phone number: about text, address, " +
+        "description, email, websites, vertical, and profile picture URL.",
+      inputSchema: {
+        phone_number_id: z.string().describe("Phone number ID."),
+      },
+      annotations: { ...READ },
+    },
+    async ({ phone_number_id }) => {
+      const id = validateMetaId(phone_number_id, "phone_number_id");
+      const response = await metaApiClient.get<{ data: WhatsAppBusinessProfile[] }>(
+        `/${id}/whatsapp_business_profile`,
+        { fields: WA_PROFILE_FIELDS.join(",") },
+      );
+      const profile = response.data?.[0] ?? {};
+
+      const lines = [
+        `Business profile for phone ${phone_number_id}:`,
+        `  About: ${profile.about ?? "N/A"}`,
+        `  Description: ${profile.description ?? "N/A"}`,
+        `  Address: ${profile.address ?? "N/A"}`,
+        `  Email: ${profile.email ?? "N/A"}`,
+        `  Websites: ${profile.websites?.join(", ") ?? "N/A"}`,
+        `  Vertical: ${profile.vertical ?? "N/A"}`,
+      ];
+
+      return {
+        content: [
+          { type: "text", text: lines.join("\n") },
+          { type: "text", text: JSON.stringify(profile, null, 2) },
+        ],
+      };
+    },
+  );
+
+  // ─── Update Business Profile ──────────────────────────────────
+  server.registerTool(
+    "whatsapp_update_business_profile",
+    {
+      description:
+        `${WHATSAPP_WRITE_WARNING}Update the WhatsApp business profile for a phone number. ` +
+        "Only provided fields are changed. Profile picture updates are not supported here " +
+        "(they require a resumable media upload).",
+      inputSchema: {
+        phone_number_id: z.string().describe("Phone number ID."),
+        about: z.string().max(139).optional().describe("Profile about text (max 139 chars)."),
+        address: z.string().max(256).optional().describe("Business address."),
+        description: z.string().max(512).optional().describe("Business description (max 512 chars)."),
+        email: z.string().email().optional().describe("Contact email."),
+        websites: z
+          .array(z.string().url())
+          .max(2)
+          .optional()
+          .describe("Up to 2 website URLs."),
+        vertical: BUSINESS_VERTICAL.optional().describe("Business industry vertical."),
+      },
+      annotations: { ...UPDATE },
+    },
+    async ({ phone_number_id, about, address, description, email, websites, vertical }) => {
+      const id = validateMetaId(phone_number_id, "phone_number_id");
+
+      const body: Record<string, unknown> = { messaging_product: "whatsapp" };
+      if (about !== undefined) body.about = about;
+      if (address !== undefined) body.address = address;
+      if (description !== undefined) body.description = description;
+      if (email !== undefined) body.email = email;
+      if (websites !== undefined) body.websites = websites;
+      if (vertical !== undefined) body.vertical = vertical;
+
+      if (Object.keys(body).length === 1) {
+        throw new Error("Provide at least one profile field to update.");
+      }
+
+      const result = await metaApiClient.post<{ success?: boolean }>(
+        `/${id}/whatsapp_business_profile`,
+        body,
+      );
+      if (result?.success !== true) {
+        throw new Error(
+          `Meta did not confirm the profile update for phone ${id}. Response: ${JSON.stringify(result)}`,
+        );
+      }
+
+      const updated = Object.keys(body).filter((k) => k !== "messaging_product");
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Business profile updated for ${phone_number_id} (fields: ${updated.join(", ")}).\n${JSON.stringify(result)}`,
+          },
+        ],
+      };
+    },
+  );
+}

--- a/src/transport/http.ts
+++ b/src/transport/http.ts
@@ -233,6 +233,7 @@ function renderConsentPage(ctx: ConsentContext): string {
         <li>• Leer y gestionar cuentas publicitarias de Meta</li>
         <li>• Crear, actualizar y pausar campañas</li>
         <li>• Acceder a reportes e insights</li>
+        <li>• Gestionar WhatsApp Business (números, plantillas, flows)</li>
       </ul>
     </div>
 

--- a/tests/meta/client.test.ts
+++ b/tests/meta/client.test.ts
@@ -330,6 +330,30 @@ describe("MetaApiClient", () => {
       expect(vi.mocked(fetch)).toHaveBeenCalledTimes(1);
     });
 
+    it.each([
+      "/111/message_templates",
+      "/111/flows",
+      "/333/message_qrdls",
+      "/333/request_code",
+    ])("does NOT retry POST to WhatsApp creating edge %s on 5xx", async (path) => {
+      const retryClient = new MetaApiClient({
+        maxRetries: 3,
+        timeout: 5000,
+      });
+
+      const serverErrorResponse = mockFetchResponse({
+        error: { message: "Server error", type: "API_ERROR", code: 1 },
+      });
+
+      vi.stubGlobal("fetch", vi.fn().mockResolvedValue(serverErrorResponse));
+
+      // WhatsApp creating edges live on plain-numeric WABA/phone paths. A retry
+      // after a server-side success would mint a duplicate flow/QR/template or a
+      // second real SMS, so they must not be transport-retried.
+      await expect(retryClient.post(path, { name: "x" })).rejects.toThrow();
+      expect(vi.mocked(fetch)).toHaveBeenCalledTimes(1);
+    });
+
     it("uses caller-provided account scope for /copies write pacing", async () => {
       const scopedClient = new MetaApiClient({
         maxRetries: 0,

--- a/tests/tools/registration.test.ts
+++ b/tests/tools/registration.test.ts
@@ -3,13 +3,14 @@ import { registerAllTools } from "../../src/tools/index.js";
 import { createMockMcpServer } from "../setup.js";
 
 describe("registerAllTools", () => {
-  it("registers exactly 97 tools total", () => {
+  it("registers exactly 124 tools total", () => {
     // 79 v2 tools renamed (with account_insights removed → 79) + 14 new in v3 +
     //   3 audience-sharing tools (share / unshare / get-shared-accounts) +
-    //   1 invoices tool (ads_get_invoices).
+    //   1 invoices tool (ads_get_invoices) +
+    //   27 WhatsApp Business tools (whatsapp_*).
     const server = createMockMcpServer();
     registerAllTools(server as never);
-    expect(server.registerTool).toHaveBeenCalledTimes(97);
+    expect(server.registerTool).toHaveBeenCalledTimes(124);
   });
 
   it("registers all tools with unique names", () => {
@@ -21,14 +22,24 @@ describe("registerAllTools", () => {
     expect(uniqueNames.size).toBe(names.length);
   });
 
-  it("all tool names start with ads_ (no meta_ prefix)", () => {
+  it("all tool names start with ads_ or whatsapp_ (no meta_ prefix)", () => {
     const server = createMockMcpServer();
     registerAllTools(server as never);
 
     for (const tool of server._registeredTools) {
-      expect(tool.name).toMatch(/^ads_/);
+      expect(tool.name).toMatch(/^(ads|whatsapp)_/);
       expect(tool.name).not.toMatch(/^meta_/);
     }
+  });
+
+  it("registers exactly 27 whatsapp_ tools", () => {
+    const server = createMockMcpServer();
+    registerAllTools(server as never);
+
+    const whatsappTools = server._registeredTools.filter((t) =>
+      t.name.startsWith("whatsapp_"),
+    );
+    expect(whatsappTools.length).toBe(27);
   });
 
   it("all tools have non-empty descriptions", () => {
@@ -112,6 +123,16 @@ describe("registerAllTools", () => {
     expect(names).toContain("ads_create_async_report");
     expect(names).toContain("ads_get_billing_info");
     expect(names).toContain("ads_get_invoices");
+
+    // WhatsApp Business tools
+    expect(names).toContain("whatsapp_get_business_accounts");
+    expect(names).toContain("whatsapp_get_phone_numbers");
+    expect(names).toContain("whatsapp_get_templates");
+    expect(names).toContain("whatsapp_create_template");
+    expect(names).toContain("whatsapp_delete_template");
+    expect(names).toContain("whatsapp_get_flows");
+    expect(names).toContain("whatsapp_get_qr_codes");
+    expect(names).toContain("whatsapp_subscribe_webhook");
 
     // Renamed in v3
     expect(names).toContain("ads_get_pages_for_business");

--- a/tests/tools/whatsapp-config.test.ts
+++ b/tests/tools/whatsapp-config.test.ts
@@ -1,0 +1,221 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { registerWhatsAppConfigTools } from "../../src/tools/whatsapp-config.js";
+import { createMockMcpServer, setupTestToken, cleanupTestToken, mockFetchResponse } from "../setup.js";
+
+describe("registerWhatsAppConfigTools", () => {
+  beforeEach(() => {
+    setupTestToken();
+  });
+
+  afterEach(() => {
+    cleanupTestToken();
+    vi.restoreAllMocks();
+  });
+
+  it("registers exactly 7 tools", () => {
+    const server = createMockMcpServer();
+    registerWhatsAppConfigTools(server as never);
+    expect(server.registerTool).toHaveBeenCalledTimes(7);
+  });
+
+  it("registers tools with correct names", () => {
+    const server = createMockMcpServer();
+    registerWhatsAppConfigTools(server as never);
+    const names = server._registeredTools.map((t) => t.name);
+    expect(names).toEqual([
+      "whatsapp_get_qr_codes",
+      "whatsapp_create_qr_code",
+      "whatsapp_update_qr_code",
+      "whatsapp_delete_qr_code",
+      "whatsapp_get_webhook_subscriptions",
+      "whatsapp_subscribe_webhook",
+      "whatsapp_unsubscribe_webhook",
+    ]);
+  });
+
+  describe("whatsapp_get_qr_codes handler", () => {
+    it("lists QR codes with deep links", async () => {
+      const server = createMockMcpServer();
+      registerWhatsAppConfigTools(server as never);
+
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue(
+          mockFetchResponse({
+            data: [
+              {
+                code: "ABC123XYZ",
+                prefilled_message: "Hola, quiero info",
+                deep_link_url: "https://wa.me/message/ABC123XYZ",
+              },
+            ],
+          }),
+        ),
+      );
+
+      const handler = server._registeredTools[0].handler;
+      const result = await handler({ phone_number_id: "333", code: undefined }) as {
+        content: Array<{ type: string; text: string }>;
+      };
+
+      expect(result.content[0].text).toContain("Found 1 QR code(s)");
+      expect(result.content[0].text).toContain("https://wa.me/message/ABC123XYZ");
+    });
+
+    it("unwraps a bare single-code object when fetching by code", async () => {
+      const server = createMockMcpServer();
+      registerWhatsAppConfigTools(server as never);
+
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue(
+          mockFetchResponse({
+            code: "ABC123XYZ",
+            prefilled_message: "Hola",
+            deep_link_url: "https://wa.me/message/ABC123XYZ",
+          }),
+        ),
+      );
+
+      const handler = server._registeredTools[0].handler;
+      const result = await handler({ phone_number_id: "333", code: "ABC123XYZ" }) as {
+        content: Array<{ type: string; text: string }>;
+      };
+
+      expect(result.content[0].text).toContain("Found 1 QR code(s)");
+      expect(result.content[0].text).toContain("ABC123XYZ");
+    });
+
+    it("rejects malformed QR code ids", async () => {
+      const server = createMockMcpServer();
+      registerWhatsAppConfigTools(server as never);
+
+      const handler = server._registeredTools[0].handler;
+      await expect(
+        handler({ phone_number_id: "333", code: "../evil" }),
+      ).rejects.toThrow(/Invalid QR code id/);
+    });
+  });
+
+  describe("whatsapp_create_qr_code handler", () => {
+    it("posts the prefilled message and returns the deep link", async () => {
+      const server = createMockMcpServer();
+      registerWhatsAppConfigTools(server as never);
+
+      const fetchMock = vi.fn().mockResolvedValue(
+        mockFetchResponse({
+          code: "ABC123XYZ",
+          prefilled_message: "Hola",
+          deep_link_url: "https://wa.me/message/ABC123XYZ",
+          qr_image_url: "https://example.com/qr.svg",
+        }),
+      );
+      vi.stubGlobal("fetch", fetchMock);
+
+      const handler = server._registeredTools[1].handler;
+      const result = await handler({
+        phone_number_id: "333",
+        prefilled_message: "Hola",
+        generate_qr_image: "SVG",
+      }) as { content: Array<{ type: string; text: string }> };
+
+      expect(result.content[0].text).toContain("QR code created");
+      expect(result.content[0].text).toContain("https://example.com/qr.svg");
+
+      const url = new URL(fetchMock.mock.calls[0][0] as string);
+      expect(url.pathname).toContain("/333/message_qrdls");
+      const body = JSON.parse((fetchMock.mock.calls[0][1] as RequestInit).body as string);
+      expect(body).toEqual({ prefilled_message: "Hola", generate_qr_image: "SVG" });
+    });
+  });
+
+  describe("whatsapp_delete_qr_code handler", () => {
+    it("deletes by code in the path", async () => {
+      const server = createMockMcpServer();
+      registerWhatsAppConfigTools(server as never);
+
+      const fetchMock = vi.fn().mockResolvedValue(mockFetchResponse({ success: true }));
+      vi.stubGlobal("fetch", fetchMock);
+
+      const handler = server._registeredTools[3].handler;
+      await handler({ phone_number_id: "333", code: "ABC123XYZ" });
+
+      const url = new URL(fetchMock.mock.calls[0][0] as string);
+      expect(url.pathname).toContain("/333/message_qrdls/ABC123XYZ");
+      expect((fetchMock.mock.calls[0][1] as RequestInit).method).toBe("DELETE");
+    });
+  });
+
+  describe("webhook subscription handlers", () => {
+    it("lists subscribed apps", async () => {
+      const server = createMockMcpServer();
+      registerWhatsAppConfigTools(server as never);
+
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue(
+          mockFetchResponse({
+            data: [{ whatsapp_business_api_data: { id: "555", name: "ByAds App" } }],
+          }),
+        ),
+      );
+
+      const handler = server._registeredTools[4].handler;
+      const result = await handler({ waba_id: "111" }) as {
+        content: Array<{ type: string; text: string }>;
+      };
+
+      expect(result.content[0].text).toContain("1 app(s) subscribed");
+      expect(result.content[0].text).toContain("ByAds App");
+    });
+
+    it("subscribe rejects override_callback_uri without verify_token", async () => {
+      const server = createMockMcpServer();
+      registerWhatsAppConfigTools(server as never);
+
+      const handler = server._registeredTools[5].handler;
+      await expect(
+        handler({
+          waba_id: "111",
+          override_callback_uri: "https://example.com/webhook",
+          verify_token: undefined,
+        }),
+      ).rejects.toThrow(/together/);
+    });
+
+    it("subscribes the app with a POST to subscribed_apps", async () => {
+      const server = createMockMcpServer();
+      registerWhatsAppConfigTools(server as never);
+
+      const fetchMock = vi.fn().mockResolvedValue(mockFetchResponse({ success: true }));
+      vi.stubGlobal("fetch", fetchMock);
+
+      const handler = server._registeredTools[5].handler;
+      const result = await handler({
+        waba_id: "111",
+        override_callback_uri: undefined,
+        verify_token: undefined,
+      }) as { content: Array<{ type: string; text: string }> };
+
+      expect(result.content[0].text).toContain("App subscribed");
+      const url = new URL(fetchMock.mock.calls[0][0] as string);
+      expect(url.pathname).toContain("/111/subscribed_apps");
+      expect((fetchMock.mock.calls[0][1] as RequestInit).method).toBe("POST");
+    });
+
+    it("unsubscribes with DELETE", async () => {
+      const server = createMockMcpServer();
+      registerWhatsAppConfigTools(server as never);
+
+      const fetchMock = vi.fn().mockResolvedValue(mockFetchResponse({ success: true }));
+      vi.stubGlobal("fetch", fetchMock);
+
+      const handler = server._registeredTools[6].handler;
+      await handler({ waba_id: "111" });
+
+      const url = new URL(fetchMock.mock.calls[0][0] as string);
+      expect(url.pathname).toContain("/111/subscribed_apps");
+      expect((fetchMock.mock.calls[0][1] as RequestInit).method).toBe("DELETE");
+    });
+  });
+});

--- a/tests/tools/whatsapp-flows.test.ts
+++ b/tests/tools/whatsapp-flows.test.ts
@@ -1,0 +1,180 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { registerWhatsAppFlowTools } from "../../src/tools/whatsapp-flows.js";
+import { createMockMcpServer, setupTestToken, cleanupTestToken, mockFetchResponse } from "../setup.js";
+
+describe("registerWhatsAppFlowTools", () => {
+  beforeEach(() => {
+    setupTestToken();
+  });
+
+  afterEach(() => {
+    cleanupTestToken();
+    vi.restoreAllMocks();
+  });
+
+  it("registers exactly 6 tools", () => {
+    const server = createMockMcpServer();
+    registerWhatsAppFlowTools(server as never);
+    expect(server.registerTool).toHaveBeenCalledTimes(6);
+  });
+
+  it("registers tools with correct names", () => {
+    const server = createMockMcpServer();
+    registerWhatsAppFlowTools(server as never);
+    const names = server._registeredTools.map((t) => t.name);
+    expect(names).toEqual([
+      "whatsapp_get_flows",
+      "whatsapp_create_flow",
+      "whatsapp_update_flow",
+      "whatsapp_publish_flow",
+      "whatsapp_deprecate_flow",
+      "whatsapp_delete_flow",
+    ]);
+  });
+
+  describe("whatsapp_get_flows handler", () => {
+    it("lists flows and flags validation errors", async () => {
+      const server = createMockMcpServer();
+      registerWhatsAppFlowTools(server as never);
+
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue(
+          mockFetchResponse({
+            data: [
+              { id: "901", name: "Lead Gen", status: "DRAFT", validation_errors: [{ error: "MISSING_ACTION" }] },
+              { id: "902", name: "Survey", status: "PUBLISHED", validation_errors: [] },
+            ],
+          }),
+        ),
+      );
+
+      const handler = server._registeredTools[0].handler;
+      const result = await handler({
+        waba_id: "111",
+        flow_id: undefined,
+        fields: undefined,
+        limit: 25,
+      }) as { content: Array<{ type: string; text: string }> };
+
+      expect(result.content[0].text).toContain("Found 2 flow(s)");
+      expect(result.content[0].text).toContain("Lead Gen — DRAFT");
+      expect(result.content[0].text).toContain("has validation errors");
+    });
+  });
+
+  describe("whatsapp_create_flow handler", () => {
+    it("posts JSON with name and categories and surfaces validation errors", async () => {
+      const server = createMockMcpServer();
+      registerWhatsAppFlowTools(server as never);
+
+      const fetchMock = vi.fn().mockResolvedValue(
+        mockFetchResponse({ id: "901", validation_errors: [{ error: "MISSING_ACTION" }] }),
+      );
+      vi.stubGlobal("fetch", fetchMock);
+
+      const handler = server._registeredTools[1].handler;
+      const result = await handler({
+        waba_id: "111",
+        name: "Lead Gen",
+        categories: ["LEAD_GENERATION"],
+        flow_json: '{"version":"7.0","screens":[]}',
+        clone_flow_id: undefined,
+        endpoint_uri: undefined,
+        publish: undefined,
+      }) as { content: Array<{ type: string; text: string }> };
+
+      expect(result.content[0].text).toContain('Flow "Lead Gen" created');
+      expect(result.content[0].text).toContain("Validation errors");
+
+      const url = new URL(fetchMock.mock.calls[0][0] as string);
+      expect(url.pathname).toContain("/111/flows");
+      const body = JSON.parse((fetchMock.mock.calls[0][1] as RequestInit).body as string);
+      expect(body.categories).toEqual(["LEAD_GENERATION"]);
+      expect(body.flow_json).toBe('{"version":"7.0","screens":[]}');
+    });
+  });
+
+  describe("whatsapp_update_flow handler", () => {
+    it("uploads flow_json as a multipart asset to /assets", async () => {
+      const server = createMockMcpServer();
+      registerWhatsAppFlowTools(server as never);
+
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(mockFetchResponse({ success: true }))
+        .mockResolvedValueOnce(mockFetchResponse({ success: true, validation_errors: [] }));
+      vi.stubGlobal("fetch", fetchMock);
+
+      const handler = server._registeredTools[2].handler;
+      const result = await handler({
+        flow_id: "901",
+        name: "Lead Gen v2",
+        categories: undefined,
+        endpoint_uri: undefined,
+        flow_json: '{"version":"7.0","screens":[]}',
+      }) as { content: Array<{ type: string; text: string }> };
+
+      expect(result.content[0].text).toContain("Flow 901 updated");
+      expect(result.content[0].text).toContain("flow content replaced");
+
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+      const metadataUrl = new URL(fetchMock.mock.calls[0][0] as string);
+      expect(metadataUrl.pathname).toMatch(/\/901$/);
+      const assetUrl = new URL(fetchMock.mock.calls[1][0] as string);
+      expect(assetUrl.pathname).toContain("/901/assets");
+      const assetInit = fetchMock.mock.calls[1][1] as RequestInit;
+      expect(assetInit.body).toBeInstanceOf(FormData);
+      expect((assetInit.body as FormData).get("asset_type")).toBe("FLOW_JSON");
+    });
+
+    it("rejects when nothing to update", async () => {
+      const server = createMockMcpServer();
+      registerWhatsAppFlowTools(server as never);
+
+      const handler = server._registeredTools[2].handler;
+      await expect(
+        handler({
+          flow_id: "901",
+          name: undefined,
+          categories: undefined,
+          endpoint_uri: undefined,
+          flow_json: undefined,
+        }),
+      ).rejects.toThrow(/at least one/i);
+    });
+  });
+
+  describe("lifecycle handlers", () => {
+    it("publishes a flow via /publish", async () => {
+      const server = createMockMcpServer();
+      registerWhatsAppFlowTools(server as never);
+
+      const fetchMock = vi.fn().mockResolvedValue(mockFetchResponse({ success: true }));
+      vi.stubGlobal("fetch", fetchMock);
+
+      const handler = server._registeredTools[3].handler;
+      const result = await handler({ flow_id: "901" }) as {
+        content: Array<{ type: string; text: string }>;
+      };
+
+      expect(result.content[0].text).toContain("Flow 901 published");
+      const url = new URL(fetchMock.mock.calls[0][0] as string);
+      expect(url.pathname).toContain("/901/publish");
+    });
+
+    it("deletes a flow with DELETE", async () => {
+      const server = createMockMcpServer();
+      registerWhatsAppFlowTools(server as never);
+
+      const fetchMock = vi.fn().mockResolvedValue(mockFetchResponse({ success: true }));
+      vi.stubGlobal("fetch", fetchMock);
+
+      const handler = server._registeredTools[5].handler;
+      await handler({ flow_id: "901" });
+
+      const init = fetchMock.mock.calls[0][1] as RequestInit;
+      expect(init.method).toBe("DELETE");
+    });
+  });
+});

--- a/tests/tools/whatsapp-templates.test.ts
+++ b/tests/tools/whatsapp-templates.test.ts
@@ -1,0 +1,271 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { registerWhatsAppTemplateTools } from "../../src/tools/whatsapp-templates.js";
+import { createMockMcpServer, setupTestToken, cleanupTestToken, mockFetchResponse } from "../setup.js";
+
+describe("registerWhatsAppTemplateTools", () => {
+  beforeEach(() => {
+    setupTestToken();
+  });
+
+  afterEach(() => {
+    cleanupTestToken();
+    vi.restoreAllMocks();
+  });
+
+  it("registers exactly 6 tools", () => {
+    const server = createMockMcpServer();
+    registerWhatsAppTemplateTools(server as never);
+    expect(server.registerTool).toHaveBeenCalledTimes(6);
+  });
+
+  it("registers tools with correct names", () => {
+    const server = createMockMcpServer();
+    registerWhatsAppTemplateTools(server as never);
+    const names = server._registeredTools.map((t) => t.name);
+    expect(names).toEqual([
+      "whatsapp_get_templates",
+      "whatsapp_create_template",
+      "whatsapp_update_template",
+      "whatsapp_delete_template",
+      "whatsapp_get_analytics",
+      "whatsapp_get_template_analytics",
+    ]);
+  });
+
+  describe("whatsapp_get_templates handler", () => {
+    it("lists templates with filters", async () => {
+      const server = createMockMcpServer();
+      registerWhatsAppTemplateTools(server as never);
+
+      const fetchMock = vi.fn().mockResolvedValue(
+        mockFetchResponse({
+          data: [
+            { id: "801", name: "order_update", status: "APPROVED", category: "UTILITY", language: "es_MX" },
+          ],
+        }),
+      );
+      vi.stubGlobal("fetch", fetchMock);
+
+      const handler = server._registeredTools[0].handler;
+      const result = await handler({
+        waba_id: "111",
+        template_id: undefined,
+        name: undefined,
+        status: "APPROVED",
+        category: undefined,
+        language: undefined,
+        fields: undefined,
+        limit: 25,
+      }) as { content: Array<{ type: string; text: string }> };
+
+      expect(result.content[0].text).toContain("Found 1 template(s)");
+      expect(result.content[0].text).toContain("order_update");
+
+      const url = new URL(fetchMock.mock.calls[0][0] as string);
+      expect(url.pathname).toContain("/111/message_templates");
+      expect(url.searchParams.get("status")).toBe("APPROVED");
+    });
+
+    it("handles empty template list", async () => {
+      const server = createMockMcpServer();
+      registerWhatsAppTemplateTools(server as never);
+
+      vi.stubGlobal("fetch", vi.fn().mockResolvedValue(mockFetchResponse({ data: [] })));
+
+      const handler = server._registeredTools[0].handler;
+      const result = await handler({
+        waba_id: "111",
+        template_id: undefined,
+        name: undefined,
+        status: undefined,
+        category: undefined,
+        language: undefined,
+        fields: undefined,
+        limit: 25,
+      }) as { content: Array<{ type: string; text: string }> };
+
+      expect(result.content[0].text).toContain("No message templates found");
+    });
+  });
+
+  describe("whatsapp_create_template handler", () => {
+    it("posts a JSON body with the components array", async () => {
+      const server = createMockMcpServer();
+      registerWhatsAppTemplateTools(server as never);
+
+      const fetchMock = vi.fn().mockResolvedValue(
+        mockFetchResponse({ id: "801", status: "PENDING", category: "UTILITY" }),
+      );
+      vi.stubGlobal("fetch", fetchMock);
+
+      const components = [
+        { type: "BODY", text: "Your order {{1}} has shipped." },
+        { type: "FOOTER", text: "Reply STOP to opt out" },
+      ];
+
+      const handler = server._registeredTools[1].handler;
+      const result = await handler({
+        waba_id: "111",
+        name: "order_shipped",
+        category: "UTILITY",
+        language: "es_MX",
+        components,
+        allow_category_change: true,
+        parameter_format: undefined,
+      }) as { content: Array<{ type: string; text: string }> };
+
+      expect(result.content[0].text).toContain('Template "order_shipped"');
+      expect(result.content[0].text).toContain("PENDING");
+
+      const url = new URL(fetchMock.mock.calls[0][0] as string);
+      expect(url.pathname).toContain("/111/message_templates");
+      const init = fetchMock.mock.calls[0][1] as RequestInit;
+      expect(init.method).toBe("POST");
+      expect((init.headers as Record<string, string>)["Content-Type"]).toBe("application/json");
+      const body = JSON.parse(init.body as string);
+      expect(body.components).toEqual(components);
+      expect(body.name).toBe("order_shipped");
+      expect(body.allow_category_change).toBe(true);
+    });
+  });
+
+  describe("whatsapp_update_template handler", () => {
+    it("rejects when no editable field is provided", async () => {
+      const server = createMockMcpServer();
+      registerWhatsAppTemplateTools(server as never);
+
+      const handler = server._registeredTools[2].handler;
+      await expect(
+        handler({
+          template_id: "801",
+          components: undefined,
+          category: undefined,
+          message_send_ttl_seconds: undefined,
+        }),
+      ).rejects.toThrow(/at least one/i);
+    });
+  });
+
+  describe("whatsapp_delete_template handler", () => {
+    it("sends DELETE with name and hsm_id as query params", async () => {
+      const server = createMockMcpServer();
+      registerWhatsAppTemplateTools(server as never);
+
+      const fetchMock = vi.fn().mockResolvedValue(mockFetchResponse({ success: true }));
+      vi.stubGlobal("fetch", fetchMock);
+
+      const handler = server._registeredTools[3].handler;
+      const result = await handler({
+        waba_id: "111",
+        name: "order_shipped",
+        hsm_id: "801",
+      }) as { content: Array<{ type: string; text: string }> };
+
+      expect(result.content[0].text).toContain('Template "order_shipped"');
+
+      const url = new URL(fetchMock.mock.calls[0][0] as string);
+      expect(url.pathname).toContain("/111/message_templates");
+      expect(url.searchParams.get("name")).toBe("order_shipped");
+      expect(url.searchParams.get("hsm_id")).toBe("801");
+      const init = fetchMock.mock.calls[0][1] as RequestInit;
+      expect(init.method).toBe("DELETE");
+    });
+  });
+
+  describe("whatsapp_get_analytics handler", () => {
+    it("builds the nested analytics field expression", async () => {
+      const server = createMockMcpServer();
+      registerWhatsAppTemplateTools(server as never);
+
+      const fetchMock = vi.fn().mockResolvedValue(
+        mockFetchResponse({ analytics: { data_points: [] } }),
+      );
+      vi.stubGlobal("fetch", fetchMock);
+
+      const handler = server._registeredTools[4].handler;
+      await handler({
+        waba_id: "111",
+        metric_type: "MESSAGING",
+        start: "2026-07-01",
+        end: "2026-07-20",
+        granularity: "DAY",
+        dimensions: undefined,
+        phone_numbers: undefined,
+      });
+
+      const url = new URL(fetchMock.mock.calls[0][0] as string);
+      const fields = url.searchParams.get("fields")!;
+      expect(fields).toMatch(/^analytics\.start\(\d+\)\.end\(\d+\)\.granularity\(DAY\)$/);
+    });
+
+    it("maps granularity vocabulary for conversation analytics", async () => {
+      const server = createMockMcpServer();
+      registerWhatsAppTemplateTools(server as never);
+
+      const fetchMock = vi.fn().mockResolvedValue(
+        mockFetchResponse({ conversation_analytics: { data: [] } }),
+      );
+      vi.stubGlobal("fetch", fetchMock);
+
+      const handler = server._registeredTools[4].handler;
+      await handler({
+        waba_id: "111",
+        metric_type: "CONVERSATION",
+        start: "2026-07-01",
+        end: "2026-07-20",
+        granularity: "DAY",
+        dimensions: ["CONVERSATION_CATEGORY", "COUNTRY"],
+        phone_numbers: undefined,
+      });
+
+      const fields = new URL(fetchMock.mock.calls[0][0] as string).searchParams.get("fields")!;
+      expect(fields).toContain("conversation_analytics.start(");
+      expect(fields).toContain(".granularity(DAILY)");
+      expect(fields).toContain('.dimensions(["CONVERSATION_CATEGORY","COUNTRY"])');
+    });
+
+    it("rejects malformed dimension tokens", async () => {
+      const server = createMockMcpServer();
+      registerWhatsAppTemplateTools(server as never);
+
+      const handler = server._registeredTools[4].handler;
+      await expect(
+        handler({
+          waba_id: "111",
+          metric_type: "PRICING",
+          start: "2026-07-01",
+          end: "2026-07-20",
+          granularity: "DAY",
+          dimensions: ["COUNTRY).evil("],
+          phone_numbers: undefined,
+        }),
+      ).rejects.toThrow(/Invalid dimension/);
+    });
+  });
+
+  describe("whatsapp_get_template_analytics handler", () => {
+    it("passes start/end/template_ids with DAILY granularity", async () => {
+      const server = createMockMcpServer();
+      registerWhatsAppTemplateTools(server as never);
+
+      const fetchMock = vi.fn().mockResolvedValue(mockFetchResponse({ data: [] }));
+      vi.stubGlobal("fetch", fetchMock);
+
+      const handler = server._registeredTools[5].handler;
+      await handler({
+        waba_id: "111",
+        start: "2026-07-01",
+        end: "2026-07-20",
+        template_ids: ["801", "802"],
+        metric_types: ["SENT", "READ"],
+      });
+
+      const url = new URL(fetchMock.mock.calls[0][0] as string);
+      expect(url.pathname).toContain("/111/template_analytics");
+      expect(url.searchParams.get("granularity")).toBe("DAILY");
+      expect(url.searchParams.get("template_ids")).toBe('["801","802"]');
+      expect(url.searchParams.get("metric_types")).toBe('["SENT","READ"]');
+      expect(url.searchParams.get("start")).toMatch(/^\d+$/);
+    });
+  });
+});

--- a/tests/tools/whatsapp.test.ts
+++ b/tests/tools/whatsapp.test.ts
@@ -1,0 +1,263 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { registerWhatsAppTools } from "../../src/tools/whatsapp.js";
+import { createMockMcpServer, setupTestToken, cleanupTestToken, mockFetchResponse } from "../setup.js";
+
+describe("registerWhatsAppTools", () => {
+  beforeEach(() => {
+    setupTestToken();
+  });
+
+  afterEach(() => {
+    cleanupTestToken();
+    vi.restoreAllMocks();
+  });
+
+  it("registers exactly 8 tools", () => {
+    const server = createMockMcpServer();
+    registerWhatsAppTools(server as never);
+    expect(server.registerTool).toHaveBeenCalledTimes(8);
+  });
+
+  it("registers tools with correct names", () => {
+    const server = createMockMcpServer();
+    registerWhatsAppTools(server as never);
+    const names = server._registeredTools.map((t) => t.name);
+    expect(names).toEqual([
+      "whatsapp_get_business_accounts",
+      "whatsapp_get_phone_numbers",
+      "whatsapp_register_phone",
+      "whatsapp_deregister_phone",
+      "whatsapp_request_verification_code",
+      "whatsapp_verify_code",
+      "whatsapp_get_business_profile",
+      "whatsapp_update_business_profile",
+    ]);
+  });
+
+  describe("whatsapp_get_business_accounts handler", () => {
+    it("lists owned and client WABAs for an explicit business", async () => {
+      const server = createMockMcpServer();
+      registerWhatsAppTools(server as never);
+
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(
+          mockFetchResponse({ data: [{ id: "111", name: "Main WABA", account_review_status: "APPROVED" }] }),
+        )
+        .mockResolvedValueOnce(
+          mockFetchResponse({ data: [{ id: "222", name: "Client WABA" }] }),
+        );
+      vi.stubGlobal("fetch", fetchMock);
+
+      const handler = server._registeredTools[0].handler;
+      const result = await handler({
+        business_id: "9001",
+        waba_id: undefined,
+        include_client_wabas: true,
+        fields: undefined,
+        limit: 25,
+      }) as { content: Array<{ type: string; text: string }> };
+
+      expect(result.content[0].text).toContain("Found 2 WhatsApp Business Account(s)");
+      expect(result.content[0].text).toContain("Main WABA");
+      expect(result.content[0].text).toContain("Client WABA");
+
+      const firstUrl = new URL(fetchMock.mock.calls[0][0] as string);
+      expect(firstUrl.pathname).toContain("/9001/owned_whatsapp_business_accounts");
+      const secondUrl = new URL(fetchMock.mock.calls[1][0] as string);
+      expect(secondUrl.pathname).toContain("/9001/client_whatsapp_business_accounts");
+    });
+
+    it("discovers businesses via /me/businesses when no business_id given", async () => {
+      const server = createMockMcpServer();
+      registerWhatsAppTools(server as never);
+
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(mockFetchResponse({ data: [{ id: "9001", name: "ByAds" }] }))
+        .mockResolvedValueOnce(mockFetchResponse({ data: [{ id: "111", name: "Main WABA" }] }))
+        .mockResolvedValueOnce(mockFetchResponse({ data: [] }));
+      vi.stubGlobal("fetch", fetchMock);
+
+      const handler = server._registeredTools[0].handler;
+      const result = await handler({
+        business_id: undefined,
+        waba_id: undefined,
+        include_client_wabas: true,
+        fields: undefined,
+        limit: 25,
+      }) as { content: Array<{ type: string; text: string }> };
+
+      const firstUrl = new URL(fetchMock.mock.calls[0][0] as string);
+      expect(firstUrl.pathname).toContain("/me/businesses");
+      expect(result.content[0].text).toContain("Main WABA");
+      expect(result.content[0].text).toContain("owned by ByAds");
+    });
+
+    it("fetches single WABA details when waba_id is given", async () => {
+      const server = createMockMcpServer();
+      registerWhatsAppTools(server as never);
+
+      const fetchMock = vi.fn().mockResolvedValue(
+        mockFetchResponse({ id: "111", name: "Main WABA", account_review_status: "APPROVED" }),
+      );
+      vi.stubGlobal("fetch", fetchMock);
+
+      const handler = server._registeredTools[0].handler;
+      const result = await handler({
+        business_id: undefined,
+        waba_id: "111",
+        include_client_wabas: true,
+        fields: undefined,
+        limit: 25,
+      }) as { content: Array<{ type: string; text: string }> };
+
+      expect(result.content[0].text).toContain("WABA: Main WABA");
+      const url = new URL(fetchMock.mock.calls[0][0] as string);
+      expect(url.searchParams.get("fields")).toContain("health_status");
+    });
+  });
+
+  describe("whatsapp_get_phone_numbers handler", () => {
+    it("lists phone numbers on a WABA", async () => {
+      const server = createMockMcpServer();
+      registerWhatsAppTools(server as never);
+
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue(
+          mockFetchResponse({
+            data: [
+              {
+                id: "333",
+                display_phone_number: "+1 650 555 1111",
+                verified_name: "ByAds",
+                code_verification_status: "VERIFIED",
+                quality_rating: "GREEN",
+              },
+            ],
+          }),
+        ),
+      );
+
+      const handler = server._registeredTools[1].handler;
+      const result = await handler({
+        waba_id: "111",
+        phone_number_id: undefined,
+        fields: undefined,
+        limit: 25,
+      }) as { content: Array<{ type: string; text: string }> };
+
+      expect(result.content[0].text).toContain("Found 1 phone number(s)");
+      expect(result.content[0].text).toContain("+1 650 555 1111");
+      expect(result.content[0].text).toContain("GREEN");
+    });
+
+    it("requires waba_id or phone_number_id", async () => {
+      const server = createMockMcpServer();
+      registerWhatsAppTools(server as never);
+
+      const handler = server._registeredTools[1].handler;
+      await expect(
+        handler({ waba_id: undefined, phone_number_id: undefined, fields: undefined, limit: 25 }),
+      ).rejects.toThrow(/waba_id/);
+    });
+  });
+
+  describe("whatsapp_register_phone handler", () => {
+    it("posts JSON with messaging_product and pin", async () => {
+      const server = createMockMcpServer();
+      registerWhatsAppTools(server as never);
+
+      const fetchMock = vi.fn().mockResolvedValue(mockFetchResponse({ success: true }));
+      vi.stubGlobal("fetch", fetchMock);
+
+      const handler = server._registeredTools[2].handler;
+      const result = await handler({
+        phone_number_id: "333",
+        pin: "123456",
+        data_localization_region: undefined,
+      }) as { content: Array<{ type: string; text: string }> };
+
+      expect(result.content[0].text).toContain("registered");
+
+      const url = new URL(fetchMock.mock.calls[0][0] as string);
+      expect(url.pathname).toContain("/333/register");
+      const init = fetchMock.mock.calls[0][1] as RequestInit;
+      expect(init.method).toBe("POST");
+      expect(JSON.parse(init.body as string)).toEqual({
+        messaging_product: "whatsapp",
+        pin: "123456",
+      });
+    });
+  });
+
+  describe("whatsapp_get_business_profile handler", () => {
+    it("unwraps the profile from the data array", async () => {
+      const server = createMockMcpServer();
+      registerWhatsAppTools(server as never);
+
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue(
+          mockFetchResponse({
+            data: [{ about: "We do ads", vertical: "PROF_SERVICES", websites: ["https://byads.co"] }],
+          }),
+        ),
+      );
+
+      const handler = server._registeredTools[6].handler;
+      const result = await handler({ phone_number_id: "333" }) as {
+        content: Array<{ type: string; text: string }>;
+      };
+
+      expect(result.content[0].text).toContain("About: We do ads");
+      expect(result.content[0].text).toContain("https://byads.co");
+    });
+  });
+
+  describe("whatsapp_update_business_profile handler", () => {
+    it("rejects when no profile fields are provided", async () => {
+      const server = createMockMcpServer();
+      registerWhatsAppTools(server as never);
+
+      const handler = server._registeredTools[7].handler;
+      await expect(
+        handler({
+          phone_number_id: "333",
+          about: undefined,
+          address: undefined,
+          description: undefined,
+          email: undefined,
+          websites: undefined,
+          vertical: undefined,
+        }),
+      ).rejects.toThrow(/at least one/i);
+    });
+
+    it("posts only the provided fields plus messaging_product", async () => {
+      const server = createMockMcpServer();
+      registerWhatsAppTools(server as never);
+
+      const fetchMock = vi.fn().mockResolvedValue(mockFetchResponse({ success: true }));
+      vi.stubGlobal("fetch", fetchMock);
+
+      const handler = server._registeredTools[7].handler;
+      await handler({
+        phone_number_id: "333",
+        about: "New about",
+        address: undefined,
+        description: undefined,
+        email: undefined,
+        websites: undefined,
+        vertical: undefined,
+      });
+
+      const init = fetchMock.mock.calls[0][1] as RequestInit;
+      expect(JSON.parse(init.body as string)).toEqual({
+        messaging_product: "whatsapp",
+        about: "New about",
+      });
+    });
+  });
+});


### PR DESCRIPTION
…tas)

Añade 4 módulos con prefijo whatsapp_* (97 → 124 herramientas):
- whatsapp.ts (8): descubrimiento de WABAs, números de teléfono (registro/verificación), perfil de negocio
- whatsapp-templates.ts (6): CRUD de plantillas de mensajes + analytics (mensajería/conversaciones/pricing + por plantilla)
- whatsapp-flows.ts (6): ciclo de vida de Flows (crear con Flow JSON, publicar, deprecar, eliminar)
- whatsapp-config.ts (7): códigos QR (message_qrdls) y suscripción a webhooks (subscribed_apps)

Soporte:
- Nuevo scope OAuth whatsapp_business_management y bullet en la página de consentimiento
- client.delete() acepta query params (borrado de plantillas por nombre)
- isCreatingRequest excluye de reintento las edges de creación de WhatsApp (message_templates/flows/message_qrdls/request_code) para evitar duplicados y SMS repetidos
- Todas las escrituras validan success:true y fallan de forma explícita
- Suscripción/desuscripción de webhooks anotadas como TOGGLE (reversible)

Excluidos por diseño: envío de mensajes, media upload, endpoint receptor de webhooks.

<!--
Thanks for contributing to meta-ads-mcp.

Please complete the sections below. PRs that skip the security checklist or
the verification steps are likely to be sent back. See CONTRIBUTING.md for the
full contribution guide.
-->

## Summary

<!-- One or two sentences: what changes and why. -->

## Why

<!-- The motivation. Link an issue if there is one (Fixes #123). -->

## How to verify

<!-- Reproducible steps. Commands, URLs, logs, screenshots — whatever makes
the reviewer's life easier. -->

```bash
# example
npm test
```

## Tests

<!-- Which tests cover this change? If none, explain why. -->

- [ ] New tests added under `tests/` mirroring the source path
- [ ] Existing tests still pass (`npm test`)
- [ ] Manual verification against a real dev environment (describe below)

## Checklist

- [ ] `npm run lint`, `npm run typecheck`, `npm test`, `npm run build` all pass locally
- [ ] No secrets in the diff (env vars, tokens, keys). If unsure, run `gitleaks git --staged --config .gitleaks.toml`
- [ ] Updated relevant docs (`README.md`, `SECURITY.md`, `CONTRIBUTING.md`) if behavior changed
- [ ] Conventional commit prefix in title (`feat:`, `fix:`, `chore:`, `docs:`, `refactor:`, `test:`, `ci:`)

## Auth / security surface

Tick **all** that apply. If any box is ticked, expect extra review scrutiny and
explain the threat-model impact in the description.

- [ ] Touches `src/auth/`, `src/store/`, or `src/transport/security-config.ts`
- [ ] Modifies the OAuth flow, session cookie shape, or Firestore document layout
- [ ] Adds, removes, or rotates an environment variable referenced as a secret
- [ ] Changes a GitHub Actions workflow under `.github/workflows/`
- [ ] Adds a new third-party dependency (production or dev)
- [ ] Loosens an existing access check or allowlist

If none of the above apply, write *None* below and the bot will not block on
the security reviewer.

> _Threat-model notes:_
