### PR TITLE
release: v3.4.0 — WhatsApp Business management + invoices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [3.4.0] — 2026-07-22
+
 ### Added
 
 - **WhatsApp Business management (27 new `whatsapp_*` tools)** — full

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@byadsco/meta-ads-mcp",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@byadsco/meta-ads-mcp",
-      "version": "3.3.0",
+      "version": "3.4.0",
       "license": "MIT",
       "dependencies": {
         "@google-cloud/firestore": "^8.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@byadsco/meta-ads-mcp",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "description": "MCP server for Meta Ads (Facebook/Instagram) management - agency multi-account",
   "author": {
     "name": "Santiago Bastidas",


### PR DESCRIPTION
## Por qué

Los PRs #100 (gestión de WhatsApp Business, 27 tools `whatsapp_*`) y #96 (`ads_get_invoices`) se mergearon a `main` **sin subir la versión** en `package.json`. El job `release` de [deploy.yml](.github/workflows/deploy.yml) solo auto-publica un GitHub Release cuando la versión cambia en `main`, y es idempotente: como `v3.3.0` ya existía, saltó silenciosamente y **no se creó release** para esas features.

## Qué hace este PR

- Sube `package.json` (y `package-lock.json`) de **3.3.0 → 3.4.0** (bump menor: features nuevas retrocompatibles).
- Finaliza el `[Unreleased]` del CHANGELOG como `[3.4.0] — 2026-07-22` (agrupa WhatsApp + invoices).

Al mergear a `main`, el job `release` auto-publicará el GitHub Release **v3.4.0** con notas generadas.

## Verificación

- pre-deploy-guard (quick): PASS (file guard, secret scan, gitleaks, typecheck).
- Sin cambios de código — solo versión + CHANGELOG. El código de las features ya pasó lint/typecheck/test/build en sus PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)