### PR TITLE
feat: ads_bulk_create_video_ads — video URLs to live ads in one call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,9 +17,11 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   A video rejected by Meta does not abort the batch — each item reports its own
   outcome and failure stage — but an account-wide error (expired token, rate
   limit, abuse signal) stops it immediately instead of retrying under a block.
-  The call is capped at 240s so it always returns under the Cloud Run request
-  timeout with the ad IDs it already created; videos left over come back marked
-  `skipped`, making a re-run of just those safe from paid duplicates.
+  The call aims to finish within 180s, well under the Cloud Run request timeout,
+  so it returns the IDs it already created; videos left over come back marked
+  `skipped`, making a re-run of just those safe from paid duplicates. As with
+  `ads_run_report_and_wait`, the budget is best-effort — an individual Graph
+  request can still overrun it.
 
 ## [3.4.1] — 2026-07-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,14 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - `ads_bulk_create_video_ads` — turns a list of public video URLs into ads in a
   single call: uploads each video, waits for Meta to finish processing, picks the
   preferred thumbnail automatically, builds the creative and creates the ad in the
-  target ad set. Ads are created `PAUSED` by default and a failing video no longer
-  aborts the rest of the batch — each item reports its own outcome and failure stage.
+  target ad set. Ads are created `PAUSED` by default.
+
+  A video rejected by Meta does not abort the batch — each item reports its own
+  outcome and failure stage — but an account-wide error (expired token, rate
+  limit, abuse signal) stops it immediately instead of retrying under a block.
+  The call is capped at 240s so it always returns under the Cloud Run request
+  timeout with the ad IDs it already created; videos left over come back marked
+  `skipped`, making a re-run of just those safe from paid duplicates.
 
 ## [3.4.1] — 2026-07-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Added
+
+- `ads_bulk_create_video_ads` — turns a list of public video URLs into ads in a
+  single call: uploads each video, waits for Meta to finish processing, picks the
+  preferred thumbnail automatically, builds the creative and creates the ad in the
+  target ad set. Ads are created `PAUSED` by default and a failing video no longer
+  aborts the rest of the batch — each item reports its own outcome and failure stage.
+
 ## [3.4.1] — 2026-07-22
 
 ### Security

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 - [Who is this for?](#who-is-this-for)
 - [Aligned with Meta's official MCP](#aligned-with-metas-official-mcp)
 - [Features](#features)
-- [Tools (124 total)](#tools-124-total)
+- [Tools (125 total)](#tools-125-total)
 - [Quick start](#quick-start)
 - [Authentication — three modes](#authentication--three-modes)
 - [Setting up Sign in with Meta](#setting-up-sign-in-with-meta)
@@ -62,7 +62,7 @@ both servers.
 | | Meta's official MCP (`mcp.facebook.com/ads`) | This project |
 |---|---|---|
 | Auth model | Per-user OAuth in your AI client | **Multi-tenant**: agency operator handles N client accounts from one server |
-| Tool surface | 29 tools (campaigns, ads, catalogs, 5 insight views, opportunity_score, dataset, errors, help) | **124 tools** including the official 29-equivalent + audiences, lookalikes, lead forms, automated rules, A/B studies, async reports, billing invoices, custom conversions, asset uploads, comment moderation, cross-account macros, and full WhatsApp Business management (templates, phone numbers, flows, QR codes) |
+| Tool surface | 29 tools (campaigns, ads, catalogs, 5 insight views, opportunity_score, dataset, errors, help) | **125 tools** including the official 29-equivalent + audiences, lookalikes, lead forms, automated rules, A/B studies, async reports, billing invoices, custom conversions, asset uploads, comment moderation, cross-account macros, and full WhatsApp Business management (templates, phone numbers, flows, QR codes) |
 | Hosting | Hosted by Meta | Self-hosted on Cloud Run / your infra; tokens encrypted at rest in Firestore |
 | Cross-account | Per-user, single Meta login | Yes — `ads_portfolio_summary` aggregates across N accounts |
 | Token control | Lives in your AI client | Server-side System User token registry per agency operator |
@@ -78,7 +78,7 @@ When to use which:
 
 ## Features
 
-- **124 tools** covering campaign management, creatives, targeting, audiences, reporting, comments, billing, invoices, tokens, Instagram workflows, WhatsApp Business management, rate-limit observability, semantic insight views, diagnostics, help-center search, and agency-tier cross-account macros.
+- **125 tools** covering campaign management, creatives, targeting, audiences, reporting, comments, billing, invoices, tokens, Instagram workflows, WhatsApp Business management, rate-limit observability, semantic insight views, diagnostics, help-center search, and agency-tier cross-account macros.
 - **Aligned vocabulary** with Meta's official MCP server so agents transfer cleanly between both.
 - **Sign in with Meta (Facebook Login)** — replaces shared PINs. Each user lands their own long-lived (60-day) Meta token.
 - **System User token registry** — for tokens that don't expire, register them per user from the consent UI.
@@ -94,7 +94,7 @@ When to use which:
 - **Async reports with safe polling** — `ads_run_report_and_wait` one-shot with 5 s-min / 60 s-max backoff, proper `Job Failed` / `Job Skipped` handling.
 - **Retry logic** — exponential backoff on truly transient errors only (never on throttled requests).
 
-## Tools (124 total)
+## Tools (125 total)
 
 Ads tools use the `ads_*` naming convention, aligned with Meta's official MCP server; WhatsApp Business tools use `whatsapp_*`. Read tools declare `readOnlyHint: true`; mutating tools declare `destructiveHint` / `idempotentHint` and prefix descriptions with a `⚠️` warning.
 
@@ -122,6 +122,7 @@ Ads tools use the `ads_*` naming convention, aligned with Meta's official MCP se
 | Diagnostics | 3 | `ads_get_opportunity_score`, `ads_get_dataset_quality`, `ads_get_errors` |
 | Help search | 1 | `ads_get_help_article` — curated Meta Business Help Center search |
 | Agency macros | 2 | `ads_diagnose_underperformance`, `ads_portfolio_summary` (cross-account) |
+| Bulk ad creation | 1 | `ads_bulk_create_video_ads` — video URLs → upload, processing wait, auto-thumbnail, creative and ad in one call |
 | Instagram | 2 | IG account and media lookup |
 | Tokens | 4 | List / set-active / register / delete |
 | Rate Status | 1 | Live view of quota usage, open circuits and write-pacer state |

--- a/src/tools/bulk-ads.ts
+++ b/src/tools/bulk-ads.ts
@@ -15,7 +15,7 @@ const MAX_VIDEOS_PER_CALL = 20;
 // makes a retry create paid duplicates. A single Graph request can still take
 // up to its own timeout, so these reserves keep headroom rather than pretending
 // to be an exact clock.
-const BATCH_BUDGET_MS = 240_000;
+const BATCH_BUDGET_MS = 180_000;
 const ITEM_START_RESERVE_MS = 30_000;
 const FINALIZE_RESERVE_MS = 15_000;
 
@@ -167,7 +167,7 @@ export function registerBulkAdTools(server: McpServer): void {
           result.skipped = true;
           result.error = systemicError
             ? "Not attempted — the batch stopped after an error that affects every video."
-            : "Not attempted — the batch time budget ran out. Re-run with the remaining videos.";
+            : "Not attempted — too little of the batch time budget left to start another video. Re-run with the remaining videos.";
           results.push(result);
           continue;
         }
@@ -258,9 +258,17 @@ export function registerBulkAdTools(server: McpServer): void {
           result.error = err instanceof Error ? err.message : String(err);
           result.failed_stage = err instanceof StageError ? err.stage : stage;
 
-          const signature = `${result.failed_stage}:${result.error}`;
-          repeatedFailures = signature === lastFailure ? repeatedFailures + 1 : 1;
-          lastFailure = signature;
+          // Only Meta's own verdicts can betray a shared bad input. Locally
+          // decided rejections (unsafe URL, missing thumbnail) are per-video by
+          // construction and would otherwise halt a batch over two bad URLs.
+          if (err instanceof McpError) {
+            const signature = `${result.failed_stage}:${result.error}`;
+            repeatedFailures = signature === lastFailure ? repeatedFailures + 1 : 1;
+            lastFailure = signature;
+          } else {
+            lastFailure = undefined;
+            repeatedFailures = 0;
+          }
 
           if (!isItemScopedError(err) || repeatedFailures >= REPEATED_FAILURE_LIMIT) {
             systemicError = err;
@@ -274,9 +282,11 @@ export function registerBulkAdTools(server: McpServer): void {
       const skipped = results.filter((r) => r.skipped);
       const failed = results.filter((r) => !r.ad_id && !r.skipped);
 
-      // Nothing was created, so there are no IDs worth preserving: surface the
-      // account-wide error the way every other tool does.
-      if (systemicError && created.length === 0) throw systemicError;
+      // Throw only when the batch left nothing behind on Meta's side. A video or
+      // creative without its ad still has an ID the caller needs to finish or
+      // clean up, and an exception would discard the whole report.
+      const leftArtifacts = results.some((r) => r.video_id ?? r.creative_id ?? r.ad_id);
+      if (systemicError && !leftArtifacts) throw systemicError;
 
       const lines = [
         `Created ${created.length} of ${results.length} ad(s) in ad set ${adSetIdValidated} with status ${status}.`,
@@ -308,7 +318,7 @@ export function registerBulkAdTools(server: McpServer): void {
         lines.push(
           "",
           `Not attempted (${skipped.length}):`,
-          ...skipped.map((r) => `• ${r.ad_name} — ${r.file_url}`),
+          ...skipped.map((r) => `• ${r.ad_name} — ${r.file_url}\n  ${r.error}`),
         );
       }
 

--- a/src/tools/bulk-ads.ts
+++ b/src/tools/bulk-ads.ts
@@ -12,8 +12,17 @@ const MAX_VIDEOS_PER_CALL = 20;
 
 // Cloud Run kills the request at 300s (--timeout=300 in deploy.yml). Finishing
 // under that is what keeps already-created ad IDs in the response: losing them
-// makes a retry create paid duplicates.
+// makes a retry create paid duplicates. A single Graph request can still take
+// up to its own timeout, so these reserves keep headroom rather than pretending
+// to be an exact clock.
 const BATCH_BUDGET_MS = 240_000;
+const ITEM_START_RESERVE_MS = 30_000;
+const FINALIZE_RESERVE_MS = 15_000;
+
+// A shared bad input (page_id, ad_set_id, creative option) fails every video the
+// same way. Meta reports it per request, so the only signal is the repetition:
+// stop rather than push 20 doomed uploads.
+const REPEATED_FAILURE_LIMIT = 2;
 
 interface VideoStatus {
   status?: { video_status?: string };
@@ -87,7 +96,7 @@ export function registerBulkAdTools(server: McpServer): void {
   server.registerTool(
     "ads_bulk_create_video_ads",
     {
-      description: `${WRITE_WARNING}Turn a list of public video URLs into ads in one call: uploads each video, waits for Meta to finish processing, auto-selects a thumbnail, builds the creative, and creates the ad in the given ad set. Ads are created PAUSED by default. Per-video copy overrides the shared defaults. A video rejected by Meta does not abort the rest — every item reports its own outcome and the stage it failed at — but an expired token, rate limit or abuse signal stops the batch immediately. The whole call is capped at ${BATCH_BUDGET_MS / 1000}s so it always returns the IDs it created; videos left unprocessed come back marked "skipped", and re-running with only those is safe. Use this instead of chaining ads_upload_ad_video → ads_create_ad_creative → ads_create_ad manually.`,
+      description: `${WRITE_WARNING}Turn a list of public video URLs into ads in one call: uploads each video, waits for Meta to finish processing, auto-selects a thumbnail, builds the creative, and creates the ad in the given ad set. Ads are created PAUSED by default. Per-video copy overrides the shared defaults. A video rejected by Meta does not abort the rest — every item reports its own outcome and the stage it failed at — but an expired token, rate limit or abuse signal stops the batch immediately, as does the same failure repeating (which means a shared input like page_id or ad_set_id is wrong). The whole call is capped at ${BATCH_BUDGET_MS / 1000}s so it always returns the IDs it created; videos left unprocessed come back marked "skipped", and re-running with only those is safe. Use this instead of chaining ads_upload_ad_video → ads_create_ad_creative → ads_create_ad manually.`,
       inputSchema: {
         account_id: z.string().describe("Ad account ID"),
         ad_set_id: z.string().describe("Ad set ID that will hold the new ads"),
@@ -144,18 +153,20 @@ export function registerBulkAdTools(server: McpServer): void {
         : undefined;
 
       const batchDeadline = Date.now() + BATCH_BUDGET_MS;
+      const remainingMs = () => batchDeadline - Date.now();
       const results: ItemResult[] = [];
       let systemicError: unknown;
+      let lastFailure: string | undefined;
+      let repeatedFailures = 0;
 
       for (const [index, video] of videos.entries()) {
         const adName = video.ad_name ?? video.video_name ?? `Video ad ${index + 1}`;
         const result: ItemResult = { file_url: video.file_url, ad_name: adName };
 
-        const remainingMs = batchDeadline - Date.now();
-        if (systemicError || remainingMs <= 0) {
+        if (systemicError || remainingMs() <= ITEM_START_RESERVE_MS) {
           result.skipped = true;
           result.error = systemicError
-            ? "Not attempted — the batch stopped after an account-wide error."
+            ? "Not attempted — the batch stopped after an error that affects every video."
             : "Not attempted — the batch time budget ran out. Re-run with the remaining videos.";
           results.push(result);
           continue;
@@ -179,7 +190,8 @@ export function registerBulkAdTools(server: McpServer): void {
           result.video_id = uploaded.id;
 
           stage = "processing";
-          const budgetSeconds = Math.min(max_wait_seconds, Math.floor(remainingMs / 1000));
+          const waitBudgetMs = Math.max(0, remainingMs() - FINALIZE_RESERVE_MS);
+          const budgetSeconds = Math.min(max_wait_seconds, Math.floor(waitBudgetMs / 1000));
           const ready = await waitForVideoReady(uploaded.id, budgetSeconds);
 
           stage = "creative";
@@ -240,10 +252,19 @@ export function registerBulkAdTools(server: McpServer): void {
             status,
           });
           result.ad_id = ad.id;
+          lastFailure = undefined;
+          repeatedFailures = 0;
         } catch (err) {
           result.error = err instanceof Error ? err.message : String(err);
           result.failed_stage = err instanceof StageError ? err.stage : stage;
-          if (!isItemScopedError(err)) systemicError = err;
+
+          const signature = `${result.failed_stage}:${result.error}`;
+          repeatedFailures = signature === lastFailure ? repeatedFailures + 1 : 1;
+          lastFailure = signature;
+
+          if (!isItemScopedError(err) || repeatedFailures >= REPEATED_FAILURE_LIMIT) {
+            systemicError = err;
+          }
         }
 
         results.push(result);
@@ -263,7 +284,7 @@ export function registerBulkAdTools(server: McpServer): void {
       if (systemicError) {
         lines.push(
           "",
-          `⚠️ The batch stopped early on an account-wide error: ${
+          `⚠️ The batch stopped early — this error affects every video, not just one: ${
             systemicError instanceof Error ? systemicError.message : String(systemicError)
           }`,
           "Fix that first, then re-run with the skipped videos only.",

--- a/src/tools/bulk-ads.ts
+++ b/src/tools/bulk-ads.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { McpError, ErrorCode } from "@modelcontextprotocol/sdk/types.js";
 import { metaApiClient } from "../meta/client.js";
 import { normalizeAccountId, validateMetaId } from "../utils/format.js";
 import { assertSafePublicUrl, UnsafeUrlError } from "../utils/url-guard.js";
@@ -8,6 +9,11 @@ import { CREATE, WRITE_WARNING } from "./_register.js";
 
 const POLL_INTERVAL_MS = 5000;
 const MAX_VIDEOS_PER_CALL = 20;
+
+// Cloud Run kills the request at 300s (--timeout=300 in deploy.yml). Finishing
+// under that is what keeps already-created ad IDs in the response: losing them
+// makes a retry create paid duplicates.
+const BATCH_BUDGET_MS = 240_000;
 
 interface VideoStatus {
   status?: { video_status?: string };
@@ -23,6 +29,7 @@ interface ItemResult {
   creative_id?: string;
   ad_id?: string;
   thumbnail_url?: string;
+  skipped?: boolean;
   error?: string;
   failed_stage?: Stage;
 }
@@ -33,6 +40,18 @@ class StageError extends Error {
   }
 }
 
+/**
+ * Meta errors that only condemn the current video (bad file, rejected params)
+ * versus ones that condemn every remaining video (expired token, rate limit,
+ * abuse signal, open circuit). Only the former may be isolated per item —
+ * retrying the rest under a throttle or abuse signal makes the block worse.
+ */
+function isItemScopedError(err: unknown): boolean {
+  if (err instanceof StageError || err instanceof UnsafeUrlError) return true;
+  if (err instanceof McpError) return err.code === ErrorCode.InvalidParams;
+  return false;
+}
+
 async function waitForVideoReady(videoId: string, maxWaitSeconds: number): Promise<VideoStatus> {
   const deadline = Date.now() + maxWaitSeconds * 1000;
 
@@ -41,16 +60,17 @@ async function waitForVideoReady(videoId: string, maxWaitSeconds: number): Promi
       fields: "status,thumbnails{uri,is_preferred}",
     });
 
-    if (video.status?.video_status === "ready") return video;
+    const videoStatus = video.status?.video_status;
+    if (videoStatus === "ready") return video;
 
-    if (video.status?.video_status === "error") {
+    if (videoStatus === "error") {
       throw new StageError("processing", `Meta reported a processing error for video ${videoId}.`);
     }
 
-    if (Date.now() >= deadline) {
+    if (Date.now() + POLL_INTERVAL_MS >= deadline) {
       throw new StageError(
         "processing",
-        `Video ${videoId} was still "${video.status?.video_status ?? "unknown"}" after ${maxWaitSeconds}s. It keeps processing on Meta's side — retry later with ads_create_ad_creative using this video_id.`,
+        `Video ${videoId} was still "${videoStatus ?? "unknown"}" when the ${maxWaitSeconds}s processing budget ran out. The video is uploaded and keeps processing on Meta's side — finish it later with ads_create_ad_creative using this video_id.`,
       );
     }
 
@@ -67,7 +87,7 @@ export function registerBulkAdTools(server: McpServer): void {
   server.registerTool(
     "ads_bulk_create_video_ads",
     {
-      description: `${WRITE_WARNING}Turn a list of public video URLs into live ads in one call: uploads each video, waits for Meta to finish processing, auto-selects a thumbnail, builds the creative, and creates the ad in the given ad set. Ads are created PAUSED by default. Per-video copy overrides the shared defaults. One video failing does not abort the rest — every item reports its own outcome and the stage it failed at. Use this instead of chaining ads_upload_ad_video → ads_create_ad_creative → ads_create_ad manually.`,
+      description: `${WRITE_WARNING}Turn a list of public video URLs into ads in one call: uploads each video, waits for Meta to finish processing, auto-selects a thumbnail, builds the creative, and creates the ad in the given ad set. Ads are created PAUSED by default. Per-video copy overrides the shared defaults. A video rejected by Meta does not abort the rest — every item reports its own outcome and the stage it failed at — but an expired token, rate limit or abuse signal stops the batch immediately. The whole call is capped at ${BATCH_BUDGET_MS / 1000}s so it always returns the IDs it created; videos left unprocessed come back marked "skipped", and re-running with only those is safe. Use this instead of chaining ads_upload_ad_video → ads_create_ad_creative → ads_create_ad manually.`,
       inputSchema: {
         account_id: z.string().describe("Ad account ID"),
         ad_set_id: z.string().describe("Ad set ID that will hold the new ads"),
@@ -79,13 +99,13 @@ export function registerBulkAdTools(server: McpServer): void {
         videos: z
           .array(
             z.object({
-              file_url: z.string().describe("Public URL of the video file (MP4/MOV)"),
-              ad_name: z.string().optional().describe("Name of the resulting ad. Defaults to the video name or file URL."),
-              video_name: z.string().optional().describe("Name of the video in the ad account library"),
+              file_url: z.string().min(1).describe("Public https URL of the video file (MP4/MOV)"),
+              ad_name: z.string().min(1).optional().describe("Name of the resulting ad. Defaults to the video name, then to 'Video ad N'."),
+              video_name: z.string().min(1).optional().describe("Name of the video in the ad account library"),
               message: z.string().optional().describe("Primary text. Overrides the shared message."),
               headline: z.string().optional().describe("Headline. Overrides the shared headline."),
               description: z.string().optional().describe("Description below the headline. Overrides the shared description."),
-              link_url: z.string().optional().describe("Destination URL. Overrides the shared link_url."),
+              link_url: z.string().min(1).optional().describe("Destination URL. Overrides the shared link_url."),
               call_to_action_type: ctaEnum.optional().describe("CTA button. Overrides the shared call_to_action_type."),
             }),
           )
@@ -95,7 +115,7 @@ export function registerBulkAdTools(server: McpServer): void {
         message: z.string().optional().describe("Shared primary text applied to every video without its own message"),
         headline: z.string().optional().describe("Shared headline applied to every video without its own headline"),
         description: z.string().optional().describe("Shared description applied to every video without its own description"),
-        link_url: z.string().optional().describe("Shared destination URL applied to every video without its own link_url"),
+        link_url: z.string().min(1).optional().describe("Shared destination URL applied to every video without its own link_url"),
         call_to_action_type: ctaEnum.optional().describe("Shared CTA button applied to every video without its own CTA"),
         url_tags: z.string().optional().describe("Query params appended to clicked URLs (e.g. 'utm_source=meta&utm_medium=paid')"),
         status: z
@@ -105,9 +125,9 @@ export function registerBulkAdTools(server: McpServer): void {
         max_wait_seconds: z
           .number()
           .min(0)
-          .max(600)
-          .default(180)
-          .describe("How long to wait for each video to finish processing before giving up on it"),
+          .max(240)
+          .default(120)
+          .describe("Per-video cap on waiting for Meta to finish processing. Also bounded by the batch-wide time budget."),
       },
       annotations: { ...CREATE },
     },
@@ -123,14 +143,25 @@ export function registerBulkAdTools(server: McpServer): void {
         ? validateMetaId(instagram_actor_id, "instagram_actor")
         : undefined;
 
+      const batchDeadline = Date.now() + BATCH_BUDGET_MS;
       const results: ItemResult[] = [];
+      let systemicError: unknown;
 
       for (const [index, video] of videos.entries()) {
         const adName = video.ad_name ?? video.video_name ?? `Video ad ${index + 1}`;
         const result: ItemResult = { file_url: video.file_url, ad_name: adName };
 
-        // A bulk tool must not lose the successful items to one bad input, so each
-        // stage failure is recorded per item instead of rejecting the whole call.
+        const remainingMs = batchDeadline - Date.now();
+        if (systemicError || remainingMs <= 0) {
+          result.skipped = true;
+          result.error = systemicError
+            ? "Not attempted — the batch stopped after an account-wide error."
+            : "Not attempted — the batch time budget ran out. Re-run with the remaining videos.";
+          results.push(result);
+          continue;
+        }
+
+        let stage: Stage = "upload";
         try {
           try {
             await assertSafePublicUrl(video.file_url);
@@ -147,7 +178,11 @@ export function registerBulkAdTools(server: McpServer): void {
           });
           result.video_id = uploaded.id;
 
-          const ready = await waitForVideoReady(uploaded.id, max_wait_seconds);
+          stage = "processing";
+          const budgetSeconds = Math.min(max_wait_seconds, Math.floor(remainingMs / 1000));
+          const ready = await waitForVideoReady(uploaded.id, budgetSeconds);
+
+          stage = "creative";
           const thumbnailUrl = pickThumbnail(ready);
           if (!thumbnailUrl) {
             throw new StageError(
@@ -191,43 +226,49 @@ export function registerBulkAdTools(server: McpServer): void {
           };
           if (url_tags) creativeBody.url_tags = url_tags;
 
-          let creative: { id: string };
-          try {
-            creative = await metaApiClient.postForm<{ id: string }>(
-              `/${accountPath}/adcreatives`,
-              creativeBody,
-            );
-          } catch (err) {
-            throw new StageError("creative", err instanceof Error ? err.message : String(err));
-          }
+          const creative = await metaApiClient.postForm<{ id: string }>(
+            `/${accountPath}/adcreatives`,
+            creativeBody,
+          );
           result.creative_id = creative.id;
 
-          let ad: { id: string };
-          try {
-            ad = await metaApiClient.postForm<{ id: string }>(`/${accountPath}/ads`, {
-              name: adName,
-              adset_id: adSetIdValidated,
-              creative: JSON.stringify({ creative_id: creative.id }),
-              status,
-            });
-          } catch (err) {
-            throw new StageError("ad", err instanceof Error ? err.message : String(err));
-          }
+          stage = "ad";
+          const ad = await metaApiClient.postForm<{ id: string }>(`/${accountPath}/ads`, {
+            name: adName,
+            adset_id: adSetIdValidated,
+            creative: JSON.stringify({ creative_id: creative.id }),
+            status,
+          });
           result.ad_id = ad.id;
         } catch (err) {
           result.error = err instanceof Error ? err.message : String(err);
-          result.failed_stage = err instanceof StageError ? err.stage : "upload";
+          result.failed_stage = err instanceof StageError ? err.stage : stage;
+          if (!isItemScopedError(err)) systemicError = err;
         }
 
         results.push(result);
       }
 
       const created = results.filter((r) => r.ad_id);
-      const failed = results.filter((r) => !r.ad_id);
+      const skipped = results.filter((r) => r.skipped);
+      const failed = results.filter((r) => !r.ad_id && !r.skipped);
+
+      // Nothing was created, so there are no IDs worth preserving: surface the
+      // account-wide error the way every other tool does.
+      if (systemicError && created.length === 0) throw systemicError;
 
       const lines = [
         `Created ${created.length} of ${results.length} ad(s) in ad set ${adSetIdValidated} with status ${status}.`,
       ];
+      if (systemicError) {
+        lines.push(
+          "",
+          `⚠️ The batch stopped early on an account-wide error: ${
+            systemicError instanceof Error ? systemicError.message : String(systemicError)
+          }`,
+          "Fix that first, then re-run with the skipped videos only.",
+        );
+      }
       if (created.length > 0) {
         lines.push(
           "",
@@ -240,6 +281,13 @@ export function registerBulkAdTools(server: McpServer): void {
           "",
           "Failed:",
           ...failed.map((r) => `• ${r.ad_name} — failed at ${r.failed_stage}: ${r.error}`),
+        );
+      }
+      if (skipped.length > 0) {
+        lines.push(
+          "",
+          `Not attempted (${skipped.length}):`,
+          ...skipped.map((r) => `• ${r.ad_name} — ${r.file_url}`),
         );
       }
 

--- a/src/tools/bulk-ads.ts
+++ b/src/tools/bulk-ads.ts
@@ -1,0 +1,254 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { metaApiClient } from "../meta/client.js";
+import { normalizeAccountId, validateMetaId } from "../utils/format.js";
+import { assertSafePublicUrl, UnsafeUrlError } from "../utils/url-guard.js";
+import { ctaEnum } from "./creatives.js";
+import { CREATE, WRITE_WARNING } from "./_register.js";
+
+const POLL_INTERVAL_MS = 5000;
+const MAX_VIDEOS_PER_CALL = 20;
+
+interface VideoStatus {
+  status?: { video_status?: string };
+  thumbnails?: { data?: Array<{ uri?: string; is_preferred?: boolean }> };
+}
+
+type Stage = "upload" | "processing" | "creative" | "ad";
+
+interface ItemResult {
+  file_url: string;
+  ad_name: string;
+  video_id?: string;
+  creative_id?: string;
+  ad_id?: string;
+  thumbnail_url?: string;
+  error?: string;
+  failed_stage?: Stage;
+}
+
+class StageError extends Error {
+  constructor(readonly stage: Stage, message: string) {
+    super(message);
+  }
+}
+
+async function waitForVideoReady(videoId: string, maxWaitSeconds: number): Promise<VideoStatus> {
+  const deadline = Date.now() + maxWaitSeconds * 1000;
+
+  for (;;) {
+    const video = await metaApiClient.get<VideoStatus>(`/${videoId}`, {
+      fields: "status,thumbnails{uri,is_preferred}",
+    });
+
+    if (video.status?.video_status === "ready") return video;
+
+    if (video.status?.video_status === "error") {
+      throw new StageError("processing", `Meta reported a processing error for video ${videoId}.`);
+    }
+
+    if (Date.now() >= deadline) {
+      throw new StageError(
+        "processing",
+        `Video ${videoId} was still "${video.status?.video_status ?? "unknown"}" after ${maxWaitSeconds}s. It keeps processing on Meta's side — retry later with ads_create_ad_creative using this video_id.`,
+      );
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
+  }
+}
+
+function pickThumbnail(video: VideoStatus): string | undefined {
+  const thumbs = video.thumbnails?.data ?? [];
+  return (thumbs.find((t) => t.is_preferred) ?? thumbs[0])?.uri;
+}
+
+export function registerBulkAdTools(server: McpServer): void {
+  server.registerTool(
+    "ads_bulk_create_video_ads",
+    {
+      description: `${WRITE_WARNING}Turn a list of public video URLs into live ads in one call: uploads each video, waits for Meta to finish processing, auto-selects a thumbnail, builds the creative, and creates the ad in the given ad set. Ads are created PAUSED by default. Per-video copy overrides the shared defaults. One video failing does not abort the rest — every item reports its own outcome and the stage it failed at. Use this instead of chaining ads_upload_ad_video → ads_create_ad_creative → ads_create_ad manually.`,
+      inputSchema: {
+        account_id: z.string().describe("Ad account ID"),
+        ad_set_id: z.string().describe("Ad set ID that will hold the new ads"),
+        page_id: z.string().describe("Facebook Page ID used as the ad's identity"),
+        instagram_actor_id: z
+          .string()
+          .optional()
+          .describe("Instagram account ID for IG placements (from ads_get_instagram_account)"),
+        videos: z
+          .array(
+            z.object({
+              file_url: z.string().describe("Public URL of the video file (MP4/MOV)"),
+              ad_name: z.string().optional().describe("Name of the resulting ad. Defaults to the video name or file URL."),
+              video_name: z.string().optional().describe("Name of the video in the ad account library"),
+              message: z.string().optional().describe("Primary text. Overrides the shared message."),
+              headline: z.string().optional().describe("Headline. Overrides the shared headline."),
+              description: z.string().optional().describe("Description below the headline. Overrides the shared description."),
+              link_url: z.string().optional().describe("Destination URL. Overrides the shared link_url."),
+              call_to_action_type: ctaEnum.optional().describe("CTA button. Overrides the shared call_to_action_type."),
+            }),
+          )
+          .min(1)
+          .max(MAX_VIDEOS_PER_CALL)
+          .describe(`Videos to turn into ads (max ${MAX_VIDEOS_PER_CALL} per call)`),
+        message: z.string().optional().describe("Shared primary text applied to every video without its own message"),
+        headline: z.string().optional().describe("Shared headline applied to every video without its own headline"),
+        description: z.string().optional().describe("Shared description applied to every video without its own description"),
+        link_url: z.string().optional().describe("Shared destination URL applied to every video without its own link_url"),
+        call_to_action_type: ctaEnum.optional().describe("Shared CTA button applied to every video without its own CTA"),
+        url_tags: z.string().optional().describe("Query params appended to clicked URLs (e.g. 'utm_source=meta&utm_medium=paid')"),
+        status: z
+          .enum(["ACTIVE", "PAUSED"])
+          .default("PAUSED")
+          .describe("Status of the created ads. PAUSED by default so nothing starts spending unreviewed."),
+        max_wait_seconds: z
+          .number()
+          .min(0)
+          .max(600)
+          .default(180)
+          .describe("How long to wait for each video to finish processing before giving up on it"),
+      },
+      annotations: { ...CREATE },
+    },
+    async ({
+      account_id, ad_set_id, page_id, instagram_actor_id, videos,
+      message, headline, description, link_url, call_to_action_type,
+      url_tags, status, max_wait_seconds,
+    }) => {
+      const accountPath = normalizeAccountId(account_id);
+      const adSetIdValidated = validateMetaId(ad_set_id, "adset");
+      const pageIdValidated = validateMetaId(page_id, "page");
+      const instagramActorIdValidated = instagram_actor_id
+        ? validateMetaId(instagram_actor_id, "instagram_actor")
+        : undefined;
+
+      const results: ItemResult[] = [];
+
+      for (const [index, video] of videos.entries()) {
+        const adName = video.ad_name ?? video.video_name ?? `Video ad ${index + 1}`;
+        const result: ItemResult = { file_url: video.file_url, ad_name: adName };
+
+        // A bulk tool must not lose the successful items to one bad input, so each
+        // stage failure is recorded per item instead of rejecting the whole call.
+        try {
+          try {
+            await assertSafePublicUrl(video.file_url);
+          } catch (err) {
+            if (err instanceof UnsafeUrlError) {
+              throw new StageError("upload", `Refusing to forward file_url to Meta: ${err.message}`);
+            }
+            throw err;
+          }
+
+          const uploaded = await metaApiClient.postForm<{ id: string }>(`/${accountPath}/advideos`, {
+            file_url: video.file_url,
+            ...(video.video_name ? { name: video.video_name } : {}),
+          });
+          result.video_id = uploaded.id;
+
+          const ready = await waitForVideoReady(uploaded.id, max_wait_seconds);
+          const thumbnailUrl = pickThumbnail(ready);
+          if (!thumbnailUrl) {
+            throw new StageError(
+              "creative",
+              `Meta returned no thumbnail for video ${uploaded.id}; video creatives require one.`,
+            );
+          }
+          result.thumbnail_url = thumbnailUrl;
+
+          const videoData: Record<string, unknown> = {
+            video_id: uploaded.id,
+            image_url: thumbnailUrl,
+          };
+          const itemMessage = video.message ?? message;
+          const itemHeadline = video.headline ?? headline;
+          const itemDescription = video.description ?? description;
+          const itemLinkUrl = video.link_url ?? link_url;
+          const itemCta = video.call_to_action_type ?? call_to_action_type;
+
+          if (itemMessage) videoData.message = itemMessage;
+          if (itemHeadline) videoData.title = itemHeadline;
+          if (itemDescription) videoData.link_description = itemDescription;
+          if (itemCta || itemLinkUrl) {
+            videoData.call_to_action = {
+              type: itemCta ?? "LEARN_MORE",
+              value: itemLinkUrl ? { link: itemLinkUrl } : undefined,
+            };
+          }
+
+          const objectStorySpec: Record<string, unknown> = {
+            page_id: pageIdValidated,
+            video_data: videoData,
+          };
+          if (instagramActorIdValidated) {
+            objectStorySpec.instagram_user_id = instagramActorIdValidated;
+          }
+
+          const creativeBody: Record<string, string | number | boolean> = {
+            name: `${adName} — creative`,
+            object_story_spec: JSON.stringify(objectStorySpec),
+          };
+          if (url_tags) creativeBody.url_tags = url_tags;
+
+          let creative: { id: string };
+          try {
+            creative = await metaApiClient.postForm<{ id: string }>(
+              `/${accountPath}/adcreatives`,
+              creativeBody,
+            );
+          } catch (err) {
+            throw new StageError("creative", err instanceof Error ? err.message : String(err));
+          }
+          result.creative_id = creative.id;
+
+          let ad: { id: string };
+          try {
+            ad = await metaApiClient.postForm<{ id: string }>(`/${accountPath}/ads`, {
+              name: adName,
+              adset_id: adSetIdValidated,
+              creative: JSON.stringify({ creative_id: creative.id }),
+              status,
+            });
+          } catch (err) {
+            throw new StageError("ad", err instanceof Error ? err.message : String(err));
+          }
+          result.ad_id = ad.id;
+        } catch (err) {
+          result.error = err instanceof Error ? err.message : String(err);
+          result.failed_stage = err instanceof StageError ? err.stage : "upload";
+        }
+
+        results.push(result);
+      }
+
+      const created = results.filter((r) => r.ad_id);
+      const failed = results.filter((r) => !r.ad_id);
+
+      const lines = [
+        `Created ${created.length} of ${results.length} ad(s) in ad set ${adSetIdValidated} with status ${status}.`,
+      ];
+      if (created.length > 0) {
+        lines.push(
+          "",
+          "Created:",
+          ...created.map((r) => `• ${r.ad_name} — ad ${r.ad_id} (creative ${r.creative_id}, video ${r.video_id})`),
+        );
+      }
+      if (failed.length > 0) {
+        lines.push(
+          "",
+          "Failed:",
+          ...failed.map((r) => `• ${r.ad_name} — failed at ${r.failed_stage}: ${r.error}`),
+        );
+      }
+
+      return {
+        content: [
+          { type: "text", text: lines.join("\n") },
+          { type: "text", text: JSON.stringify(results, null, 2) },
+        ],
+      };
+    },
+  );
+}

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -24,6 +24,7 @@ import { registerEntityTools } from "./entities.js";
 import { registerDiagnosticTools } from "./diagnostics.js";
 import { registerHelpTools } from "./help.js";
 import { registerMacroTools } from "./macros.js";
+import { registerBulkAdTools } from "./bulk-ads.js";
 import { registerWhatsAppTools } from "./whatsapp.js";
 import { registerWhatsAppTemplateTools } from "./whatsapp-templates.js";
 import { registerWhatsAppFlowTools } from "./whatsapp-flows.js";
@@ -69,6 +70,7 @@ export function registerAllTools(server: McpServer): void {
 
   // ─── Agency Macros (cross-account) ──────────────────────
   registerMacroTools(server);        // 2 tools — diagnose_underperformance, portfolio_summary
+  registerBulkAdTools(server);       // 1 tool  — ads_bulk_create_video_ads (upload → creative → ad)
 
   // ─── Instagram ──────────────────────────────────────────
   registerInstagramTools(server);    // 2 tools — IG account & media lookup
@@ -82,5 +84,5 @@ export function registerAllTools(server: McpServer): void {
   // ─── Token Management ────────────────────────────────────
   registerTokenTools(server);        // 4 tools — list / set-active / register / delete
 
-  // Total: 124 tools (79 renamed + 14 new in v3 + 3 audience-sharing + 1 invoices + 27 WhatsApp)
+  // Total: 125 tools (79 renamed + 14 new in v3 + 3 audience-sharing + 1 invoices + 27 WhatsApp + 1 bulk video ads)
 }

--- a/tests/tools/bulk-ads.test.ts
+++ b/tests/tools/bulk-ads.test.ts
@@ -1,0 +1,307 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { registerBulkAdTools } from "../../src/tools/bulk-ads.js";
+import { createMockMcpServer, setupTestToken, cleanupTestToken, mockFetchResponse } from "../setup.js";
+
+// Keep every real guard rule (protocol, private-IP literals) and stub only DNS,
+// so test hostnames need no network yet SSRF rejections stay genuine.
+vi.mock("../../src/utils/url-guard.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../src/utils/url-guard.js")>();
+  return {
+    ...actual,
+    assertSafePublicUrl: (raw: string) =>
+      actual.assertSafePublicUrl(raw, {
+        resolve: async () => [{ address: "93.184.216.34" }],
+      }),
+  };
+});
+
+const BASE_ARGS = {
+  account_id: "act_123",
+  ad_set_id: "456",
+  page_id: "789",
+  status: "PAUSED" as const,
+  max_wait_seconds: 0,
+};
+
+function handlerFor(name: string) {
+  const server = createMockMcpServer();
+  registerBulkAdTools(server as never);
+  const tool = server._registeredTools.find((t) => t.name === name);
+  if (!tool) throw new Error(`tool ${name} not registered`);
+  return tool;
+}
+
+function urlOf(call: unknown[]): string {
+  return String(call[0]);
+}
+
+describe("registerBulkAdTools", () => {
+  beforeEach(() => {
+    setupTestToken();
+  });
+
+  afterEach(() => {
+    cleanupTestToken();
+    vi.restoreAllMocks();
+  });
+
+  it("registers exactly 1 tool", () => {
+    const server = createMockMcpServer();
+    registerBulkAdTools(server as never);
+    expect(server.registerTool).toHaveBeenCalledTimes(1);
+  });
+
+  it("registers the tool with the expected name and write annotation", () => {
+    const tool = handlerFor("ads_bulk_create_video_ads");
+    expect(tool.name).toBe("ads_bulk_create_video_ads");
+    expect(tool.annotations?.readOnlyHint).not.toBe(true);
+  });
+
+  describe("ads_bulk_create_video_ads handler", () => {
+    it("uploads, waits, builds the creative and creates the ad for each video", async () => {
+      const tool = handlerFor("ads_bulk_create_video_ads");
+
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(mockFetchResponse({ id: "vid_1" }))
+        .mockResolvedValueOnce(
+          mockFetchResponse({
+            status: { video_status: "ready" },
+            thumbnails: { data: [{ uri: "https://cdn.example/a.jpg" }, { uri: "https://cdn.example/b.jpg", is_preferred: true }] },
+          }),
+        )
+        .mockResolvedValueOnce(mockFetchResponse({ id: "cre_1" }))
+        .mockResolvedValueOnce(mockFetchResponse({ id: "ad_1" }));
+      vi.stubGlobal("fetch", fetchMock);
+
+      const res = await tool.handler({
+        ...BASE_ARGS,
+        videos: [{ file_url: "https://cdn.example/video.mp4", ad_name: "Aprovado 13" }],
+        message: "texto",
+        headline: "titular",
+        link_url: "https://example.com",
+        call_to_action_type: "SIGN_UP",
+      });
+
+      const urls = fetchMock.mock.calls.map(urlOf);
+      expect(urls[0]).toContain("/act_123/advideos");
+      expect(urls[1]).toContain("/vid_1");
+      expect(urls[2]).toContain("/act_123/adcreatives");
+      expect(urls[3]).toContain("/act_123/ads");
+
+      const payload = JSON.parse(res.content[1].text);
+      expect(payload[0]).toMatchObject({
+        video_id: "vid_1",
+        creative_id: "cre_1",
+        ad_id: "ad_1",
+        thumbnail_url: "https://cdn.example/b.jpg",
+      });
+      expect(res.content[0].text).toContain("Created 1 of 1");
+    });
+
+    it("prefers the is_preferred thumbnail and falls back to the first one", async () => {
+      const tool = handlerFor("ads_bulk_create_video_ads");
+
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(mockFetchResponse({ id: "vid_1" }))
+        .mockResolvedValueOnce(
+          mockFetchResponse({
+            status: { video_status: "ready" },
+            thumbnails: { data: [{ uri: "https://cdn.example/first.jpg" }] },
+          }),
+        )
+        .mockResolvedValueOnce(mockFetchResponse({ id: "cre_1" }))
+        .mockResolvedValueOnce(mockFetchResponse({ id: "ad_1" }));
+      vi.stubGlobal("fetch", fetchMock);
+
+      const res = await tool.handler({
+        ...BASE_ARGS,
+        videos: [{ file_url: "https://cdn.example/video.mp4" }],
+      });
+
+      expect(JSON.parse(res.content[1].text)[0].thumbnail_url).toBe("https://cdn.example/first.jpg");
+    });
+
+    it("applies per-video copy over the shared defaults", async () => {
+      const tool = handlerFor("ads_bulk_create_video_ads");
+
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(mockFetchResponse({ id: "vid_1" }))
+        .mockResolvedValueOnce(
+          mockFetchResponse({
+            status: { video_status: "ready" },
+            thumbnails: { data: [{ uri: "https://cdn.example/t.jpg", is_preferred: true }] },
+          }),
+        )
+        .mockResolvedValueOnce(mockFetchResponse({ id: "cre_1" }))
+        .mockResolvedValueOnce(mockFetchResponse({ id: "ad_1" }));
+      vi.stubGlobal("fetch", fetchMock);
+
+      await tool.handler({
+        ...BASE_ARGS,
+        videos: [{ file_url: "https://cdn.example/v.mp4", message: "propio", headline: "propio-h" }],
+        message: "compartido",
+        headline: "compartido-h",
+        description: "compartido-d",
+      });
+
+      const creativeBody = String(fetchMock.mock.calls[2][1]?.body ?? "");
+      const spec = JSON.parse(decodeURIComponent(creativeBody).match(/object_story_spec=([^&]*)/)![1]);
+      expect(spec.video_data.message).toBe("propio");
+      expect(spec.video_data.title).toBe("propio-h");
+      expect(spec.video_data.link_description).toBe("compartido-d");
+    });
+
+    it("keeps successful items when one video fails", async () => {
+      const tool = handlerFor("ads_bulk_create_video_ads");
+
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(mockFetchResponse({ id: "vid_1" }))
+        .mockResolvedValueOnce(
+          mockFetchResponse({
+            status: { video_status: "ready" },
+            thumbnails: { data: [{ uri: "https://cdn.example/t.jpg", is_preferred: true }] },
+          }),
+        )
+        .mockResolvedValueOnce(mockFetchResponse({ id: "cre_1" }))
+        .mockResolvedValueOnce(mockFetchResponse({ id: "ad_1" }))
+        .mockResolvedValueOnce(
+          mockFetchResponse({ error: { message: "Invalid file", code: 100 } }, { status: 400 }),
+        );
+      vi.stubGlobal("fetch", fetchMock);
+
+      const res = await tool.handler({
+        ...BASE_ARGS,
+        videos: [
+          { file_url: "https://cdn.example/ok.mp4", ad_name: "bueno" },
+          { file_url: "https://cdn.example/bad.mp4", ad_name: "malo" },
+        ],
+      });
+
+      const payload = JSON.parse(res.content[1].text);
+      expect(payload[0].ad_id).toBe("ad_1");
+      expect(payload[1].ad_id).toBeUndefined();
+      expect(payload[1].error).toBeTruthy();
+      expect(res.content[0].text).toContain("Created 1 of 2");
+      expect(res.content[0].text).toContain("malo");
+    });
+
+    it("reports a processing timeout without creating the ad", async () => {
+      const tool = handlerFor("ads_bulk_create_video_ads");
+
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(mockFetchResponse({ id: "vid_1" }))
+        .mockResolvedValueOnce(mockFetchResponse({ status: { video_status: "processing" } }));
+      vi.stubGlobal("fetch", fetchMock);
+
+      const res = await tool.handler({
+        ...BASE_ARGS,
+        videos: [{ file_url: "https://cdn.example/slow.mp4" }],
+      });
+
+      const payload = JSON.parse(res.content[1].text);
+      expect(payload[0].failed_stage).toBe("processing");
+      expect(payload[0].ad_id).toBeUndefined();
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+
+    it("surfaces a Meta processing error immediately", async () => {
+      const tool = handlerFor("ads_bulk_create_video_ads");
+
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(mockFetchResponse({ id: "vid_1" }))
+        .mockResolvedValueOnce(mockFetchResponse({ status: { video_status: "error" } }));
+      vi.stubGlobal("fetch", fetchMock);
+
+      const res = await tool.handler({
+        ...BASE_ARGS,
+        videos: [{ file_url: "https://cdn.example/broken.mp4" }],
+      });
+
+      expect(JSON.parse(res.content[1].text)[0].failed_stage).toBe("processing");
+    });
+
+    it("fails the item when Meta returns no thumbnail", async () => {
+      const tool = handlerFor("ads_bulk_create_video_ads");
+
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(mockFetchResponse({ id: "vid_1" }))
+        .mockResolvedValueOnce(mockFetchResponse({ status: { video_status: "ready" }, thumbnails: { data: [] } }));
+      vi.stubGlobal("fetch", fetchMock);
+
+      const res = await tool.handler({
+        ...BASE_ARGS,
+        videos: [{ file_url: "https://cdn.example/v.mp4" }],
+      });
+
+      const payload = JSON.parse(res.content[1].text);
+      expect(payload[0].failed_stage).toBe("creative");
+      expect(payload[0].error).toContain("thumbnail");
+    });
+
+    it("refuses a private file_url without calling Meta", async () => {
+      const tool = handlerFor("ads_bulk_create_video_ads");
+      const fetchMock = vi.fn();
+      vi.stubGlobal("fetch", fetchMock);
+
+      const res = await tool.handler({
+        ...BASE_ARGS,
+        videos: [{ file_url: "https://169.254.169.254/latest/meta-data/" }],
+      });
+
+      const payload = JSON.parse(res.content[1].text);
+      expect(payload[0].failed_stage).toBe("upload");
+      expect(payload[0].error).toMatch(/Refusing to forward/);
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it("rejects a malformed ad_set_id before any network call", async () => {
+      const tool = handlerFor("ads_bulk_create_video_ads");
+      const fetchMock = vi.fn();
+      vi.stubGlobal("fetch", fetchMock);
+
+      await expect(
+        tool.handler({
+          ...BASE_ARGS,
+          ad_set_id: "456/../me",
+          videos: [{ file_url: "https://cdn.example/v.mp4" }],
+        }),
+      ).rejects.toThrow();
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it("creates ads PAUSED by default", async () => {
+      const tool = handlerFor("ads_bulk_create_video_ads");
+
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(mockFetchResponse({ id: "vid_1" }))
+        .mockResolvedValueOnce(
+          mockFetchResponse({
+            status: { video_status: "ready" },
+            thumbnails: { data: [{ uri: "https://cdn.example/t.jpg", is_preferred: true }] },
+          }),
+        )
+        .mockResolvedValueOnce(mockFetchResponse({ id: "cre_1" }))
+        .mockResolvedValueOnce(mockFetchResponse({ id: "ad_1" }));
+      vi.stubGlobal("fetch", fetchMock);
+
+      await tool.handler({
+        account_id: "act_123",
+        ad_set_id: "456",
+        page_id: "789",
+        max_wait_seconds: 0,
+        status: "PAUSED",
+        videos: [{ file_url: "https://cdn.example/v.mp4" }],
+      });
+
+      expect(String(fetchMock.mock.calls[3][1]?.body ?? "")).toContain("status=PAUSED");
+    });
+  });
+});

--- a/tests/tools/bulk-ads.test.ts
+++ b/tests/tools/bulk-ads.test.ts
@@ -363,7 +363,7 @@ describe("registerBulkAdTools", () => {
       expect(payload[0].ad_id).toBe("ad_1");
       expect(payload[1].error).toBeTruthy();
       expect(payload[2].skipped).toBe(true);
-      expect(res.content[0].text).toContain("account-wide error");
+      expect(res.content[0].text).toContain("affects every video");
     }, 30_000);
 
     it("throws the account-wide error when nothing was created", async () => {
@@ -384,6 +384,104 @@ describe("registerBulkAdTools", () => {
         }),
       ).rejects.toThrow(/token|expired/i);
     });
+
+    it("stops after the same failure repeats, instead of burning the whole batch", async () => {
+      const tool = handlerFor("ads_bulk_create_video_ads");
+
+      // A shared bad page_id/ad_set_id looks item-scoped (InvalidParams) but
+      // condemns every video: identical failures must halt the run.
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(mockFetchResponse({ id: "vid_1" }))
+        .mockResolvedValueOnce(
+          mockFetchResponse({
+            status: { video_status: "ready" },
+            thumbnails: { data: [{ uri: "https://cdn.example/t.jpg", is_preferred: true }] },
+          }),
+        )
+        .mockResolvedValueOnce(mockFetchResponse({ id: "cre_1" }))
+        .mockResolvedValueOnce(mockFetchResponse({ id: "ad_1" }))
+        .mockResolvedValue(
+          mockFetchResponse({ error: { message: "Invalid parameter", code: 100 } }, { status: 400 }),
+        );
+      vi.stubGlobal("fetch", fetchMock);
+
+      const res = await tool.handler({
+        ...BASE_ARGS,
+        videos: [
+          { file_url: "https://cdn.example/a.mp4", ad_name: "uno" },
+          { file_url: "https://cdn.example/b.mp4", ad_name: "dos" },
+          { file_url: "https://cdn.example/c.mp4", ad_name: "tres" },
+          { file_url: "https://cdn.example/d.mp4", ad_name: "cuatro" },
+        ],
+      });
+
+      const payload = JSON.parse(res.content[1].text);
+      expect(payload[0].ad_id).toBe("ad_1");
+      expect(payload[1].error).toBeTruthy();
+      expect(payload[2].error).toBeTruthy();
+      expect(payload[3].skipped).toBe(true);
+      // 4 calls for the first video, then one doomed upload each for videos 2-3.
+      expect(fetchMock).toHaveBeenCalledTimes(6);
+    }, 30_000);
+
+    it("throws when the same failure repeats and nothing was created", async () => {
+      const tool = handlerFor("ads_bulk_create_video_ads");
+
+      const fetchMock = vi.fn().mockResolvedValue(
+        mockFetchResponse({ error: { message: "Invalid parameter", code: 100 } }, { status: 400 }),
+      );
+      vi.stubGlobal("fetch", fetchMock);
+
+      await expect(
+        tool.handler({
+          ...BASE_ARGS,
+          videos: [
+            { file_url: "https://cdn.example/a.mp4" },
+            { file_url: "https://cdn.example/b.mp4" },
+            { file_url: "https://cdn.example/c.mp4" },
+          ],
+        }),
+      ).rejects.toThrow(/Invalid parameter/);
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    }, 30_000);
+
+    it("keeps going when failures differ between videos", async () => {
+      const tool = handlerFor("ads_bulk_create_video_ads");
+
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(mockFetchResponse({ id: "vid_1" }))
+        .mockResolvedValueOnce(mockFetchResponse({ status: { video_status: "ready" }, thumbnails: { data: [] } }))
+        .mockResolvedValueOnce(mockFetchResponse({ id: "vid_2" }))
+        .mockResolvedValueOnce(mockFetchResponse({ status: { video_status: "ready" }, thumbnails: { data: [] } }))
+        .mockResolvedValueOnce(mockFetchResponse({ id: "vid_3" }))
+        .mockResolvedValueOnce(
+          mockFetchResponse({
+            status: { video_status: "ready" },
+            thumbnails: { data: [{ uri: "https://cdn.example/t.jpg", is_preferred: true }] },
+          }),
+        )
+        .mockResolvedValueOnce(mockFetchResponse({ id: "cre_3" }))
+        .mockResolvedValueOnce(mockFetchResponse({ id: "ad_3" }));
+      vi.stubGlobal("fetch", fetchMock);
+
+      const res = await tool.handler({
+        ...BASE_ARGS,
+        videos: [
+          { file_url: "https://cdn.example/a.mp4" },
+          { file_url: "https://cdn.example/b.mp4" },
+          { file_url: "https://cdn.example/c.mp4" },
+        ],
+      });
+
+      // Each no-thumbnail message names its own video_id, so the signatures
+      // differ and the third video still gets its ad.
+      const payload = JSON.parse(res.content[1].text);
+      expect(payload[0].failed_stage).toBe("creative");
+      expect(payload[1].failed_stage).toBe("creative");
+      expect(payload[2].ad_id).toBe("ad_3");
+    }, 30_000);
 
     it("labels a failure at the ad stage without losing the creative id", async () => {
       const tool = handlerFor("ads_bulk_create_video_ads");

--- a/tests/tools/bulk-ads.test.ts
+++ b/tests/tools/bulk-ads.test.ts
@@ -2,15 +2,18 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { registerBulkAdTools } from "../../src/tools/bulk-ads.js";
 import { createMockMcpServer, setupTestToken, cleanupTestToken, mockFetchResponse } from "../setup.js";
 
-// Keep every real guard rule (protocol, private-IP literals) and stub only DNS,
-// so test hostnames need no network yet SSRF rejections stay genuine.
+// Keep every real guard rule (protocol, private-IP checks) and stub only DNS,
+// so test hostnames need no network yet SSRF rejections stay genuine. Tests
+// point `address` at a private range to exercise the resolve-time rejection.
+const guardState = vi.hoisted(() => ({ address: "93.184.216.34" }));
+
 vi.mock("../../src/utils/url-guard.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../../src/utils/url-guard.js")>();
   return {
     ...actual,
     assertSafePublicUrl: (raw: string) =>
       actual.assertSafePublicUrl(raw, {
-        resolve: async () => [{ address: "93.184.216.34" }],
+        resolve: async () => [{ address: guardState.address }],
       }),
   };
 });
@@ -42,6 +45,7 @@ describe("registerBulkAdTools", () => {
 
   afterEach(() => {
     cleanupTestToken();
+    guardState.address = "93.184.216.34";
     vi.restoreAllMocks();
   });
 
@@ -276,7 +280,13 @@ describe("registerBulkAdTools", () => {
       expect(fetchMock).not.toHaveBeenCalled();
     });
 
-    it("creates ads PAUSED by default", async () => {
+    it("defaults the ad status to PAUSED in the schema", () => {
+      const tool = handlerFor("ads_bulk_create_video_ads");
+      const schema = tool.schema as { status: { parse: (value: unknown) => unknown } };
+      expect(schema.status.parse(undefined)).toBe("PAUSED");
+    });
+
+    it("sends the chosen status when creating the ad", async () => {
       const tool = handlerFor("ads_bulk_create_video_ads");
 
       const fetchMock = vi
@@ -293,15 +303,115 @@ describe("registerBulkAdTools", () => {
       vi.stubGlobal("fetch", fetchMock);
 
       await tool.handler({
-        account_id: "act_123",
-        ad_set_id: "456",
-        page_id: "789",
-        max_wait_seconds: 0,
-        status: "PAUSED",
+        ...BASE_ARGS,
         videos: [{ file_url: "https://cdn.example/v.mp4" }],
       });
 
       expect(String(fetchMock.mock.calls[3][1]?.body ?? "")).toContain("status=PAUSED");
+    });
+
+    it("rejects a hostname that resolves to a private address", async () => {
+      guardState.address = "10.0.0.5";
+
+      const tool = handlerFor("ads_bulk_create_video_ads");
+      const fetchMock = vi.fn();
+      vi.stubGlobal("fetch", fetchMock);
+
+      const res = await tool.handler({
+        ...BASE_ARGS,
+        videos: [{ file_url: "https://internal.example/v.mp4" }],
+      });
+
+      const payload = JSON.parse(res.content[1].text);
+      expect(payload[0].failed_stage).toBe("upload");
+      expect(payload[0].error).toMatch(/private IP/);
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it("stops the batch on an account-wide error and keeps the ads already created", async () => {
+      const tool = handlerFor("ads_bulk_create_video_ads");
+
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(mockFetchResponse({ id: "vid_1" }))
+        .mockResolvedValueOnce(
+          mockFetchResponse({
+            status: { video_status: "ready" },
+            thumbnails: { data: [{ uri: "https://cdn.example/t.jpg", is_preferred: true }] },
+          }),
+        )
+        .mockResolvedValueOnce(mockFetchResponse({ id: "cre_1" }))
+        .mockResolvedValueOnce(mockFetchResponse({ id: "ad_1" }))
+        .mockResolvedValue(
+          mockFetchResponse(
+            { error: { message: "Error validating access token: Session has expired", code: 190 } },
+            { status: 401 },
+          ),
+        );
+      vi.stubGlobal("fetch", fetchMock);
+
+      const res = await tool.handler({
+        ...BASE_ARGS,
+        videos: [
+          { file_url: "https://cdn.example/a.mp4", ad_name: "uno" },
+          { file_url: "https://cdn.example/b.mp4", ad_name: "dos" },
+          { file_url: "https://cdn.example/c.mp4", ad_name: "tres" },
+        ],
+      });
+
+      const payload = JSON.parse(res.content[1].text);
+      expect(payload[0].ad_id).toBe("ad_1");
+      expect(payload[1].error).toBeTruthy();
+      expect(payload[2].skipped).toBe(true);
+      expect(res.content[0].text).toContain("account-wide error");
+    }, 30_000);
+
+    it("throws the account-wide error when nothing was created", async () => {
+      const tool = handlerFor("ads_bulk_create_video_ads");
+
+      const fetchMock = vi.fn().mockResolvedValue(
+        mockFetchResponse(
+          { error: { message: "Error validating access token: Session has expired", code: 190 } },
+          { status: 401 },
+        ),
+      );
+      vi.stubGlobal("fetch", fetchMock);
+
+      await expect(
+        tool.handler({
+          ...BASE_ARGS,
+          videos: [{ file_url: "https://cdn.example/a.mp4" }, { file_url: "https://cdn.example/b.mp4" }],
+        }),
+      ).rejects.toThrow(/token|expired/i);
+    });
+
+    it("labels a failure at the ad stage without losing the creative id", async () => {
+      const tool = handlerFor("ads_bulk_create_video_ads");
+
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(mockFetchResponse({ id: "vid_1" }))
+        .mockResolvedValueOnce(
+          mockFetchResponse({
+            status: { video_status: "ready" },
+            thumbnails: { data: [{ uri: "https://cdn.example/t.jpg", is_preferred: true }] },
+          }),
+        )
+        .mockResolvedValueOnce(mockFetchResponse({ id: "cre_1" }))
+        .mockResolvedValueOnce(
+          mockFetchResponse({ error: { message: "Invalid adset", code: 100 } }, { status: 400 }),
+        );
+      vi.stubGlobal("fetch", fetchMock);
+
+      const res = await tool.handler({
+        ...BASE_ARGS,
+        videos: [{ file_url: "https://cdn.example/v.mp4" }],
+      });
+
+      const payload = JSON.parse(res.content[1].text);
+      expect(payload[0].failed_stage).toBe("ad");
+      expect(payload[0].creative_id).toBe("cre_1");
+      expect(payload[0].ad_id).toBeUndefined();
     });
   });
 });

--- a/tests/tools/bulk-ads.test.ts
+++ b/tests/tools/bulk-ads.test.ts
@@ -425,6 +425,87 @@ describe("registerBulkAdTools", () => {
       expect(fetchMock).toHaveBeenCalledTimes(6);
     }, 30_000);
 
+    it("does not let two locally-rejected URLs stop a healthy batch", async () => {
+      const tool = handlerFor("ads_bulk_create_video_ads");
+
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(mockFetchResponse({ id: "vid_3" }))
+        .mockResolvedValueOnce(
+          mockFetchResponse({
+            status: { video_status: "ready" },
+            thumbnails: { data: [{ uri: "https://cdn.example/t.jpg", is_preferred: true }] },
+          }),
+        )
+        .mockResolvedValueOnce(mockFetchResponse({ id: "cre_3" }))
+        .mockResolvedValueOnce(mockFetchResponse({ id: "ad_3" }));
+      vi.stubGlobal("fetch", fetchMock);
+
+      // Both http:// URLs yield the identical guard message; that must not be
+      // mistaken for a shared bad input and skip the valid third video.
+      const res = await tool.handler({
+        ...BASE_ARGS,
+        videos: [
+          { file_url: "http://a.example/v.mp4" },
+          { file_url: "http://b.example/v.mp4" },
+          { file_url: "https://cdn.example/good.mp4" },
+        ],
+      });
+
+      const payload = JSON.parse(res.content[1].text);
+      expect(payload[0].failed_stage).toBe("upload");
+      expect(payload[1].failed_stage).toBe("upload");
+      expect(payload[2].skipped).toBeUndefined();
+      expect(payload[2].ad_id).toBe("ad_3");
+    }, 30_000);
+
+    it("reports partial artifacts instead of throwing them away", async () => {
+      const tool = handlerFor("ads_bulk_create_video_ads");
+
+      // Creatives get built, then every ad creation fails identically: the run
+      // stops but the video and creative IDs must survive in the report.
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(mockFetchResponse({ id: "vid_1" }))
+        .mockResolvedValueOnce(
+          mockFetchResponse({
+            status: { video_status: "ready" },
+            thumbnails: { data: [{ uri: "https://cdn.example/t.jpg", is_preferred: true }] },
+          }),
+        )
+        .mockResolvedValueOnce(mockFetchResponse({ id: "cre_1" }))
+        .mockResolvedValueOnce(
+          mockFetchResponse({ error: { message: "Invalid adset", code: 100 } }, { status: 400 }),
+        )
+        .mockResolvedValueOnce(mockFetchResponse({ id: "vid_2" }))
+        .mockResolvedValueOnce(
+          mockFetchResponse({
+            status: { video_status: "ready" },
+            thumbnails: { data: [{ uri: "https://cdn.example/t.jpg", is_preferred: true }] },
+          }),
+        )
+        .mockResolvedValueOnce(mockFetchResponse({ id: "cre_2" }))
+        .mockResolvedValue(
+          mockFetchResponse({ error: { message: "Invalid adset", code: 100 } }, { status: 400 }),
+        );
+      vi.stubGlobal("fetch", fetchMock);
+
+      const res = await tool.handler({
+        ...BASE_ARGS,
+        videos: [
+          { file_url: "https://cdn.example/a.mp4" },
+          { file_url: "https://cdn.example/b.mp4" },
+          { file_url: "https://cdn.example/c.mp4" },
+        ],
+      });
+
+      const payload = JSON.parse(res.content[1].text);
+      expect(payload[0].creative_id).toBe("cre_1");
+      expect(payload[1].creative_id).toBe("cre_2");
+      expect(payload[0].ad_id).toBeUndefined();
+      expect(payload[2].skipped).toBe(true);
+    }, 60_000);
+
     it("throws when the same failure repeats and nothing was created", async () => {
       const tool = handlerFor("ads_bulk_create_video_ads");
 

--- a/tests/tools/registration.test.ts
+++ b/tests/tools/registration.test.ts
@@ -3,14 +3,15 @@ import { registerAllTools } from "../../src/tools/index.js";
 import { createMockMcpServer } from "../setup.js";
 
 describe("registerAllTools", () => {
-  it("registers exactly 124 tools total", () => {
+  it("registers exactly 125 tools total", () => {
     // 79 v2 tools renamed (with account_insights removed → 79) + 14 new in v3 +
     //   3 audience-sharing tools (share / unshare / get-shared-accounts) +
     //   1 invoices tool (ads_get_invoices) +
-    //   27 WhatsApp Business tools (whatsapp_*).
+    //   27 WhatsApp Business tools (whatsapp_*) +
+    //   1 bulk video-ad macro (ads_bulk_create_video_ads).
     const server = createMockMcpServer();
     registerAllTools(server as never);
-    expect(server.registerTool).toHaveBeenCalledTimes(124);
+    expect(server.registerTool).toHaveBeenCalledTimes(125);
   });
 
   it("registers all tools with unique names", () => {


### PR DESCRIPTION
## Why

Creating a video ad today means chaining three tools by hand — `ads_upload_ad_video` → `ads_create_ad_creative` → `ads_create_ad` — plus knowing that Meta rejects a video creative without a thumbnail, and that a freshly uploaded video is not usable until it finishes processing. Doing that for a batch of approved creatives is tedious and error-prone for an agent.

This adds one tool that does the whole flow, for a list of videos.

Context: this started as an attempt to read creatives directly from the Business **Biblioteca multimedia** (asset library folders). That turned out to be impossible — the Business Creative Asset Management API is allowlist-gated and returns `(#10) Application does not have permission` for this app, and the folder assets never appear in `/act_x/advideos` (verified across 50 ad accounts). Uploading approved files straight to the ad account is the path that works today, so this tool automates it.

## What it does

Per video: SSRF-checked upload → poll until `status.video_status === "ready"` → pick the `is_preferred` thumbnail → build `object_story_spec.video_data` → create the ad. Shared copy (message/headline/CTA/link) applies to all videos; each video can override any of it.

Ads are created **PAUSED** by default so nothing spends before review.

## Failure handling

The interesting part, and where the review effort went:

- A video Meta rejects does **not** abort the batch. Each item reports its own `failed_stage` (`upload` / `processing` / `creative` / `ad`) and keeps its IDs.
- An **account-wide** error (expired token, rate limit, abuse signal) stops the batch immediately — retrying 19 more times under a throttle makes the block worse.
- The **same Meta error repeating** also stops it: a wrong `page_id` or `ad_set_id` is reported per request but condemns every video. Locally-decided rejections (unsafe URL, missing thumbnail) never trigger this, since they are per-video by construction.
- The batch aims to finish within **180s**, under Cloud Run's 300s request timeout, so the response carries the IDs it created. Leftover videos come back marked `skipped`, making a re-run of only those safe from paid duplicates.
- It throws only when the run left nothing behind on Meta's side; if a video or creative was made without its ad, the report survives so the caller can finish or clean up.

## Review

Audited with Codex over three passes (8 findings, then 2, then 3). Fixed across `27efb3a`, `082dba9`, `708054b`: the batch time budget, systemic-vs-item error classification, stage labelling during polling, the deadline overshoot, `.min(1)` on names and URLs, and the two heuristic defects above.

**Known limitation, deliberately not fixed here:** a soft budget is not a hard deadline — an individual Graph request can still overrun it. Enforcing it properly means threading an `AbortSignal` through the shared `metaApiClient` for all 125 tools. The existing `ads_run_report_and_wait` allows a 3600s wait under exactly the same pattern, so this tool is already the more conservative of the two. Worth a follow-up if we want real deadlines.

DNS-rebinding resistance in `assertSafePublicUrl` is likewise unchanged and shared with `ads_upload_ad_video` — no regression, out of scope.

## Verification

- `npm run lint`, `npm run typecheck`, `npm test` (459 passing), `npm run build` — all green
- gitleaks + project regex scan on the staged diff — no findings
- 22 tests for the new tool, covering the happy path, thumbnail preference, per-video overrides, both stop conditions, the false-positive case, partial-artifact preservation, private-IP rejection, and malformed IDs
- Tool count 124 → 125, bumped consistently in `src/tools/index.ts`, `tests/tools/registration.test.ts` and `README.md`

Not yet exercised against the live API — worth a real run on a test ad set before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)