### PR TITLE
fix: accept effective_link_url as a virtual field; add UTM (url_tags) editing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,12 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - **`ads_update_ad_url_tags` — edit the UTM parameters of live ads (1-50 per
   call).** Meta creatives are immutable (`POST /{creative_id}` only accepts
   `name` / `status` / `adlabels`), so the tool clones each ad's creative with
-  the new `url_tags` and repoints the ad at the clone. It reuses the existing
-  post via `object_story_id` when the creative has one, preserving likes and
-  comments, and falls back to cloning `object_story_spec`. Ads sharing a
+  the new `url_tags` and repoints the ad at the clone. Every strategy
+  re-references the source wholesale rather than rebuilding it field by field
+  — the existing Facebook post (`object_story_id`, preserving likes and
+  comments), the creative spec (`object_story_spec`), or the Instagram post
+  (`source_instagram_media_id`) — so media, copy, destination link and CTA
+  survive even when they are not readable back individually. Ads sharing a
   creative mint a single replacement. Ads whose `url_tags` already match are
   skipped, which makes re-running a batch safe; dynamic (`asset_feed_spec`)
   creatives are reported as skipped rather than silently altered. `url_tags:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Security
+
+- **`npm audit` clean again — 0 vulnerabilities.** Advisories published after
+  v3.4.1 had turned CI red on `main`: `ip-address` (SSRF / trust-boundary
+  bypass via leading-zero octets, CIDR suffixes and IPv4-mapped IPv6),
+  `fast-uri` (host confusion via backslash authority introducer),
+  `brace-expansion` (DoS) and `hono` (ReDoS in CORS middleware). Resolved by
+  patch-level bumps of six transitive packages; lockfile only, no direct
+  dependency changed.
+
 ### Added
 
 - **`ads_update_ad_url_tags` — edit the UTM parameters of live ads (1-50 per

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,41 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Added
+
+- **`ads_update_ad_url_tags` — edit the UTM parameters of live ads (1-50 per
+  call).** Meta creatives are immutable (`POST /{creative_id}` only accepts
+  `name` / `status` / `adlabels`), so the tool clones each ad's creative with
+  the new `url_tags` and repoints the ad at the clone. It reuses the existing
+  post via `object_story_id` when the creative has one, preserving likes and
+  comments, and falls back to cloning `object_story_spec`. Ads sharing a
+  creative mint a single replacement. Ads whose `url_tags` already match are
+  skipped, which makes re-running a batch safe; dynamic (`asset_feed_spec`)
+  creatives are reported as skipped rather than silently altered. `url_tags:
+  ""` removes tracking parameters, a leading `?` is stripped, and `dry_run:
+  true` previews the plan without writing. The response reports every ad as
+  updated / skipped / failed and warns that updated ads re-enter Meta review.
+- **`url_tags` in creative reads** — added to the creative default fields (so
+  `ads_get_creative_details` and `ads_get_ad_creatives` surface UTMs) and
+  `ads_get_ad_creatives` gained an optional `fields` param, making an
+  account-wide UTM audit a single call.
+
+### Fixed
+
+- **`effective_link_url` no longer fails with Meta error #100.** The field is
+  derived by this server, not stored by Meta, but it appears in responses — so
+  clients echoed it back in `fields` and every such call died with
+  `-32602 Invalid parameter: (#100) Tried accessing nonexisting field`. Both
+  creative read tools now accept it as a virtual field: it is stripped from the
+  Graph request, its sources (`link_url`, `object_story_spec`,
+  `asset_feed_spec`) are requested instead, and the derived value is still
+  returned.
+- **Empty updates no longer report a false success.** `ads_update_ad_creative`
+  called without `name`, and `ads_update_ad` called with no updatable field,
+  used to POST an empty body to Meta and answer "updated successfully". Both
+  now fail with an explanation — the creative error points at
+  `ads_update_ad_url_tags` for UTM changes.
+
 ## [3.4.1] — 2026-07-22
 
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,12 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   — the existing Facebook post (`object_story_id`, preserving likes and
   comments), the creative spec (`object_story_spec`), or the Instagram post
   (`source_instagram_media_id`) — so media, copy, destination link and CTA
-  survive even when they are not readable back individually. Ads sharing a
-  creative mint a single replacement. Ads whose `url_tags` already match are
+  survive even when they are not readable back individually. Fields that live
+  beside the story rather than inside it are carried explicitly: `link_url`,
+  `degrees_of_freedom_spec` (dropping it would silently reset an ad's
+  Advantage+ creative enhancements), `adlabels`, and the rebuilt
+  `call_to_action` for Instagram creatives, which store their CTA on the
+  creative itself. Ads sharing a creative mint a single replacement. Ads whose `url_tags` already match are
   skipped, which makes re-running a batch safe; dynamic (`asset_feed_spec`)
   creatives are reported as skipped rather than silently altered. `url_tags:
   ""` removes tracking parameters, a leading `?` is stripped, and `dry_run:

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 - [Who is this for?](#who-is-this-for)
 - [Aligned with Meta's official MCP](#aligned-with-metas-official-mcp)
 - [Features](#features)
-- [Tools (124 total)](#tools-124-total)
+- [Tools (125 total)](#tools-125-total)
 - [Quick start](#quick-start)
 - [Authentication — three modes](#authentication--three-modes)
 - [Setting up Sign in with Meta](#setting-up-sign-in-with-meta)
@@ -62,7 +62,7 @@ both servers.
 | | Meta's official MCP (`mcp.facebook.com/ads`) | This project |
 |---|---|---|
 | Auth model | Per-user OAuth in your AI client | **Multi-tenant**: agency operator handles N client accounts from one server |
-| Tool surface | 29 tools (campaigns, ads, catalogs, 5 insight views, opportunity_score, dataset, errors, help) | **124 tools** including the official 29-equivalent + audiences, lookalikes, lead forms, automated rules, A/B studies, async reports, billing invoices, custom conversions, asset uploads, comment moderation, cross-account macros, and full WhatsApp Business management (templates, phone numbers, flows, QR codes) |
+| Tool surface | 29 tools (campaigns, ads, catalogs, 5 insight views, opportunity_score, dataset, errors, help) | **125 tools** including the official 29-equivalent + audiences, lookalikes, lead forms, automated rules, A/B studies, async reports, billing invoices, custom conversions, asset uploads, comment moderation, cross-account macros, and full WhatsApp Business management (templates, phone numbers, flows, QR codes) |
 | Hosting | Hosted by Meta | Self-hosted on Cloud Run / your infra; tokens encrypted at rest in Firestore |
 | Cross-account | Per-user, single Meta login | Yes — `ads_portfolio_summary` aggregates across N accounts |
 | Token control | Lives in your AI client | Server-side System User token registry per agency operator |
@@ -78,7 +78,7 @@ When to use which:
 
 ## Features
 
-- **124 tools** covering campaign management, creatives, targeting, audiences, reporting, comments, billing, invoices, tokens, Instagram workflows, WhatsApp Business management, rate-limit observability, semantic insight views, diagnostics, help-center search, and agency-tier cross-account macros.
+- **125 tools** covering campaign management, creatives, targeting, audiences, reporting, comments, billing, invoices, tokens, Instagram workflows, WhatsApp Business management, rate-limit observability, semantic insight views, diagnostics, help-center search, and agency-tier cross-account macros.
 - **Aligned vocabulary** with Meta's official MCP server so agents transfer cleanly between both.
 - **Sign in with Meta (Facebook Login)** — replaces shared PINs. Each user lands their own long-lived (60-day) Meta token.
 - **System User token registry** — for tokens that don't expire, register them per user from the consent UI.
@@ -94,7 +94,7 @@ When to use which:
 - **Async reports with safe polling** — `ads_run_report_and_wait` one-shot with 5 s-min / 60 s-max backoff, proper `Job Failed` / `Job Skipped` handling.
 - **Retry logic** — exponential backoff on truly transient errors only (never on throttled requests).
 
-## Tools (124 total)
+## Tools (125 total)
 
 Ads tools use the `ads_*` naming convention, aligned with Meta's official MCP server; WhatsApp Business tools use `whatsapp_*`. Read tools declare `readOnlyHint: true`; mutating tools declare `destructiveHint` / `idempotentHint` and prefix descriptions with a `⚠️` warning.
 
@@ -103,7 +103,7 @@ Ads tools use the `ads_*` naming convention, aligned with Meta's official MCP se
 | Accounts | 3 | `ads_get_ad_accounts`, `ads_get_account_info`, `ads_get_pages_for_business` |
 | Campaigns | 5 | CRUD + status management |
 | Ad Sets | 6 | CRUD + clone bundle (native ad-copy, 100% creative-type coverage incl. dynamic/Advantage+) |
-| Ads | 5 | CRUD with creative assignment |
+| Ads | 6 | CRUD with creative assignment, UTM (`url_tags`) editing |
 | Creatives | 9 | List, details, create/update, image/video library and uploads |
 | Generic entity helpers | 3 | `ads_get_ad_entities`, `ads_update_entity`, `ads_activate_entity` (mirror official MCP) |
 | Insights — power tool | 1 | `ads_get_insights` — full control over breakdowns, attribution, time series |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1895,16 +1895,16 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/buffer-equal-constant-time": {
@@ -2734,9 +2734,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "funding": [
         {
           "type": "github",
@@ -3053,9 +3053,9 @@
       "license": "MIT"
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -3167,9 +3167,9 @@
       "license": "MIT"
     },
     "node_modules/hono": {
-      "version": "4.12.27",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.27.tgz",
-      "integrity": "sha512-1yrb/+w6HWQJrUCLkJ2IF5jNIPvvFkblV5RNOYl6bV+OA6p9GLcMpHFFGTosSvHvcAUibuUukRqhlYI4z32C7Q==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.0.tgz",
+      "integrity": "sha512-jhunvfHWxd7J5EFfSgH4xsYJzSe/lfqbUCxiyyeaQasUsXeEHXtzVid+7EOGByc5JnFa23SSFL3Y2RV/z1T+eQ==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -3264,9 +3264,9 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.4.0.tgz",
+      "integrity": "sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -4211,9 +4211,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.22",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.22.tgz",
-      "integrity": "sha512-KBDEIpLrvpv16pp3K0Fw+UCoZfopFjjgeB+0tA/aaThfEE74kKDLrgg603YvOWJyg3+WYtyq3xYsQWsIyZlPqQ==",
+      "version": "8.5.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
       "dev": true,
       "funding": [
         {

--- a/src/meta/types/creative.ts
+++ b/src/meta/types/creative.ts
@@ -37,6 +37,7 @@ export interface AdCreative {
   source_instagram_media_id?: string;
   effective_instagram_media_id?: string;
   degrees_of_freedom_spec?: Record<string, unknown>;
+  adlabels?: Array<{ id?: string; name?: string }>;
 }
 
 /** Fields this server derives locally; they are stripped before hitting Meta. */

--- a/src/meta/types/creative.ts
+++ b/src/meta/types/creative.ts
@@ -32,7 +32,19 @@ export interface AdCreative {
   effective_link_url?: string;
   effective_object_story_id?: string;
   status?: string;
+  url_tags?: string;
+  instagram_user_id?: string;
 }
+
+/** Fields this server derives locally; they are stripped before hitting Meta. */
+export const SYNTHETIC_CREATIVE_FIELDS = ["effective_link_url"] as const;
+
+/** Real fields extractEffectiveLinkUrl reads to derive effective_link_url. */
+export const EFFECTIVE_LINK_URL_SOURCE_FIELDS = [
+  "link_url",
+  "object_story_spec",
+  "asset_feed_spec",
+] as const;
 
 export interface ImageUploadResult {
   images: Record<
@@ -61,4 +73,5 @@ export const CREATIVE_DEFAULT_FIELDS = [
   "link_url",
   "effective_object_story_id",
   "status",
+  "url_tags",
 ] as const;

--- a/src/meta/types/creative.ts
+++ b/src/meta/types/creative.ts
@@ -34,6 +34,9 @@ export interface AdCreative {
   status?: string;
   url_tags?: string;
   instagram_user_id?: string;
+  source_instagram_media_id?: string;
+  effective_instagram_media_id?: string;
+  degrees_of_freedom_spec?: Record<string, unknown>;
 }
 
 /** Fields this server derives locally; they are stripped before hitting Meta. */

--- a/src/tools/ads.ts
+++ b/src/tools/ads.ts
@@ -2,12 +2,95 @@ import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { metaApiClient } from "../meta/client.js";
 import { normalizeAccountId, validateMetaId } from "../utils/format.js";
-import { buildFieldsParam } from "../utils/validation.js";
+import { buildFieldsParam, normalizeUrlTags, requireOneOf } from "../utils/validation.js";
 import { AD_DEFAULT_FIELDS } from "../meta/types/ad.js";
-import type { Ad, MetaApiResponse } from "../meta/types/index.js";
+import type { Ad, AdCreative, MetaApiResponse } from "../meta/types/index.js";
 import { READ, CREATE, UPDATE, DELETE, WRITE_WARNING } from "./_register.js";
 
 const statusEnum = z.enum(["ACTIVE", "PAUSED", "DELETED", "ARCHIVED"]);
+
+const CREATIVE_REBUILD_FIELDS =
+  "id,name,object_story_spec,asset_feed_spec,effective_object_story_id,url_tags,instagram_user_id";
+
+type RebuildStrategy = "reuse_post" | "clone_spec";
+
+interface CreativeGroup {
+  creative_id: string;
+  account_id: string;
+  ad_ids: string[];
+}
+
+interface PlannedRebuild {
+  ad_id: string;
+  old_creative_id: string;
+  strategy: RebuildStrategy;
+}
+
+interface UpdatedAd {
+  ad_id: string;
+  old_creative_id: string;
+  new_creative_id: string;
+}
+
+interface SkippedAd {
+  ad_id: string;
+  reason: string;
+}
+
+interface FailedAd {
+  ad_id: string;
+  error: string;
+  new_creative_id?: string;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return typeof value === "object" && value !== null ? value as Record<string, unknown> : undefined;
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function resolveInstagramUserId(creative: AdCreative): string | undefined {
+  if (creative.instagram_user_id) return creative.instagram_user_id;
+  const embedded = asRecord(creative.object_story_spec)?.["instagram_user_id"];
+  return typeof embedded === "string" ? embedded : undefined;
+}
+
+// Meta creatives are immutable except for name/status/adlabels, so changing
+// url_tags means minting a replacement. Reusing the existing post keeps the
+// ad's social proof (likes/comments); cloning the spec is the fallback.
+function planRebuild(creative: AdCreative): RebuildStrategy | { reason: string } {
+  if (creative.asset_feed_spec) {
+    return {
+      reason: "dynamic creative (asset_feed_spec) — url_tags cannot be rebuilt without collapsing its asset variations",
+    };
+  }
+  if (creative.effective_object_story_id) return "reuse_post";
+  if (asRecord(creative.object_story_spec)) return "clone_spec";
+  return { reason: "creative has no reusable post or object_story_spec to rebuild from" };
+}
+
+function buildReplacementCreativeBody(
+  creative: AdCreative,
+  strategy: RebuildStrategy,
+  urlTags: string,
+): Record<string, string | number | boolean> {
+  const body: Record<string, string | number | boolean> = {};
+  if (creative.name) body.name = creative.name;
+
+  if (strategy === "reuse_post") {
+    body.object_story_id = creative.effective_object_story_id as string;
+    const instagramUserId = resolveInstagramUserId(creative);
+    if (instagramUserId) body.instagram_user_id = instagramUserId;
+  } else {
+    body.object_story_spec = JSON.stringify(creative.object_story_spec);
+  }
+
+  if (urlTags !== "") body.url_tags = urlTags;
+
+  return body;
+}
 
 export function registerAdTools(server: McpServer): void {
   // ─── Get Ads ─────────────────────────────────────────────────
@@ -145,7 +228,7 @@ export function registerAdTools(server: McpServer): void {
   server.registerTool(
     "ads_update_ad",
     {
-      description: `${WRITE_WARNING}Update an existing ad's name, status, or creative.`,
+      description: `${WRITE_WARNING}Update an existing ad's name, status, or creative. To change UTM parameters use ads_update_ad_url_tags — url_tags live on the creative, which is immutable.`,
       inputSchema: {
         ad_id: z.string().describe("Ad ID to update"),
         name: z.string().optional(),
@@ -155,6 +238,12 @@ export function registerAdTools(server: McpServer): void {
       annotations: { ...UPDATE },
     },
     async ({ ad_id, name, status, creative_id }) => {
+      requireOneOf(
+        { name, status, creative_id },
+        ["name", "status", "creative_id"],
+        "Nothing to update: provide at least one of name, status or creative_id.",
+      );
+
       const id = validateMetaId(ad_id, "ad");
       const body: Record<string, string | number | boolean> = {};
       if (name !== undefined) body.name = name;
@@ -170,6 +259,189 @@ export function registerAdTools(server: McpServer): void {
       return {
         content: [
           { type: "text", text: `Ad ${id} updated successfully.\nChanges: ${JSON.stringify(body)}` },
+        ],
+      };
+    },
+  );
+
+  // ─── Update Ad URL Tags (UTMs) ───────────────────────────────
+  server.registerTool(
+    "ads_update_ad_url_tags",
+    {
+      description: `${WRITE_WARNING}Change the UTM parameters (url_tags) of one or more live ads. Meta creatives are immutable, so each ad's creative is cloned with the new url_tags and the ad is repointed at the clone — the existing post is reused when possible, preserving likes and comments. Side effect: every updated ad re-enters Meta review. Ads whose url_tags already match are skipped, so re-running is safe. Dynamic creatives (asset_feed_spec) are reported as skipped. Use dry_run to preview.`,
+      inputSchema: {
+        ad_ids: z
+          .array(z.string())
+          .min(1)
+          .max(50)
+          .describe("Ad IDs to update (1-50)"),
+        url_tags: z
+          .string()
+          .describe("New UTM query string, e.g. 'utm_source=meta&utm_medium=paid'. A leading '?' is stripped. Pass an empty string to remove tracking parameters."),
+        dry_run: z
+          .boolean()
+          .default(false)
+          .describe("Preview the plan without creating creatives or touching ads"),
+      },
+      annotations: { ...UPDATE },
+    },
+    async ({ ad_ids, url_tags, dry_run }) => {
+      const requestedTags = normalizeUrlTags(url_tags);
+      const updated: UpdatedAd[] = [];
+      const skipped: SkippedAd[] = [];
+      const failed: FailedAd[] = [];
+      const planned: PlannedRebuild[] = [];
+
+      const groups = new Map<string, CreativeGroup>();
+      for (const rawAdId of ad_ids) {
+        try {
+          const adId = validateMetaId(rawAdId, "ad");
+          const ad = await metaApiClient.get<Ad & { account_id?: string }>(`/${adId}`, {
+            fields: "account_id,creative{id}",
+          });
+
+          if (!ad.creative?.id) {
+            failed.push({ ad_id: rawAdId, error: "Ad has no creative to rebuild." });
+            continue;
+          }
+          if (!ad.account_id) {
+            failed.push({ ad_id: rawAdId, error: "Ad did not report an account_id." });
+            continue;
+          }
+
+          const creativeId = ad.creative.id;
+          const group = groups.get(creativeId);
+          if (group) {
+            group.ad_ids.push(adId);
+          } else {
+            groups.set(creativeId, {
+              creative_id: creativeId,
+              account_id: ad.account_id,
+              ad_ids: [adId],
+            });
+          }
+        } catch (err) {
+          failed.push({ ad_id: rawAdId, error: errorMessage(err) });
+        }
+      }
+
+      const actionable: Array<{ group: CreativeGroup; creative: AdCreative; strategy: RebuildStrategy }> = [];
+      for (const group of groups.values()) {
+        try {
+          const creative = await metaApiClient.get<AdCreative>(
+            `/${validateMetaId(group.creative_id, "creative")}`,
+            { fields: CREATIVE_REBUILD_FIELDS },
+          );
+
+          if (normalizeUrlTags(creative.url_tags ?? "") === requestedTags) {
+            for (const adId of group.ad_ids) {
+              skipped.push({ ad_id: adId, reason: "url_tags already set to the requested value" });
+            }
+            continue;
+          }
+
+          const plan = planRebuild(creative);
+          if (typeof plan !== "string") {
+            for (const adId of group.ad_ids) {
+              skipped.push({ ad_id: adId, reason: plan.reason });
+            }
+            continue;
+          }
+
+          actionable.push({ group, creative, strategy: plan });
+          for (const adId of group.ad_ids) {
+            planned.push({ ad_id: adId, old_creative_id: group.creative_id, strategy: plan });
+          }
+        } catch (err) {
+          const message = errorMessage(err);
+          for (const adId of group.ad_ids) {
+            failed.push({ ad_id: adId, error: message });
+          }
+        }
+      }
+
+      if (!dry_run) {
+        for (const { group, creative, strategy } of actionable) {
+          let newCreativeId: string;
+          try {
+            const body = buildReplacementCreativeBody(creative, strategy, requestedTags);
+            const created = await metaApiClient.postForm<{ id: string }>(
+              `/${normalizeAccountId(group.account_id)}/adcreatives`,
+              body,
+            );
+            newCreativeId = created.id;
+          } catch (err) {
+            const message = errorMessage(err);
+            for (const adId of group.ad_ids) {
+              failed.push({ ad_id: adId, error: `Failed to create the replacement creative: ${message}` });
+            }
+            continue;
+          }
+
+          for (const adId of group.ad_ids) {
+            try {
+              await metaApiClient.postForm<{ success: boolean }>(
+                `/${adId}`,
+                { creative: JSON.stringify({ creative_id: newCreativeId }) },
+                { accountId: normalizeAccountId(group.account_id) },
+              );
+              updated.push({
+                ad_id: adId,
+                old_creative_id: group.creative_id,
+                new_creative_id: newCreativeId,
+              });
+            } catch (err) {
+              failed.push({
+                ad_id: adId,
+                error: `Creative ${newCreativeId} was created but the ad still points at ${group.creative_id}: ${errorMessage(err)}. Retry with ads_update_ad { ad_id: "${adId}", creative_id: "${newCreativeId}" }.`,
+                new_creative_id: newCreativeId,
+              });
+            }
+          }
+        }
+      }
+
+      const report = {
+        dry_run,
+        requested_url_tags: requestedTags,
+        planned,
+        updated,
+        skipped,
+        failed,
+      };
+
+      const lines: string[] = dry_run
+        ? [
+            `Dry run — no changes made. ${planned.length} ad(s) would get url_tags "${requestedTags || "(removed)"}".`,
+            ...planned.map(
+              (p) =>
+                `• Ad ${p.ad_id}: clone creative ${p.old_creative_id} (${p.strategy === "reuse_post" ? "reusing the existing post" : "cloning the creative spec"})`,
+            ),
+          ]
+        : [
+            `Updated ${updated.length} ad(s), skipped ${skipped.length}, failed ${failed.length}.`,
+            ...updated.map(
+              (u) => `• Ad ${u.ad_id}: creative ${u.old_creative_id} → ${u.new_creative_id}`,
+            ),
+          ];
+
+      if (skipped.length > 0) {
+        lines.push("", "Skipped:", ...skipped.map((s) => `• Ad ${s.ad_id}: ${s.reason}`));
+      }
+      if (failed.length > 0) {
+        lines.push("", "Failed:", ...failed.map((f) => `• Ad ${f.ad_id}: ${f.error}`));
+      }
+      if (!dry_run && updated.length > 0) {
+        lines.push(
+          "",
+          "⚠️ Updated ads re-enter Meta review and may pause delivery briefly. The previous creatives still exist and are unchanged.",
+        );
+      }
+
+      return {
+        content: [
+          { type: "text", text: lines.join("\n") },
+          { type: "text", text: JSON.stringify(report, null, 2) },
         ],
       };
     },

--- a/src/tools/ads.ts
+++ b/src/tools/ads.ts
@@ -10,7 +10,7 @@ import { READ, CREATE, UPDATE, DELETE, WRITE_WARNING } from "./_register.js";
 const statusEnum = z.enum(["ACTIVE", "PAUSED", "DELETED", "ARCHIVED"]);
 
 const CREATIVE_REBUILD_FIELDS =
-  "id,name,object_story_spec,asset_feed_spec,effective_object_story_id,url_tags,instagram_user_id,source_instagram_media_id,effective_instagram_media_id,link_url,degrees_of_freedom_spec";
+  "id,name,object_story_spec,asset_feed_spec,effective_object_story_id,url_tags,instagram_user_id,source_instagram_media_id,effective_instagram_media_id,link_url,degrees_of_freedom_spec,call_to_action_type,adlabels";
 
 type RebuildStrategy = "reuse_post" | "clone_spec" | "reuse_instagram_media";
 
@@ -77,6 +77,15 @@ function planRebuild(creative: AdCreative): RebuildStrategy | { reason: string }
   return { reason: "creative has no reusable post, object_story_spec or Instagram media to rebuild from" };
 }
 
+async function readCreativeIdAfterFailedRepoint(adId: string): Promise<string | undefined> {
+  try {
+    const ad = await metaApiClient.get<Ad>(`/${adId}`, { fields: "creative{id}" });
+    return ad.creative?.id;
+  } catch {
+    return undefined;
+  }
+}
+
 function describeStrategy(strategy: RebuildStrategy): string {
   if (strategy === "reuse_post") return "reusing the existing post";
   if (strategy === "reuse_instagram_media") return "reusing the Instagram post";
@@ -100,6 +109,15 @@ function buildReplacementCreativeBody(
     body.source_instagram_media_id =
       (creative.source_instagram_media_id ?? creative.effective_instagram_media_id) as string;
     if (instagramUserId) body.instagram_user_id = instagramUserId;
+    // Unlike a page post, an Instagram-media creative stores its CTA on the
+    // creative itself (see ads_create_ad_creative), so it has to be rebuilt or
+    // the replacement loses the button.
+    if (creative.call_to_action_type) {
+      body.call_to_action = JSON.stringify({
+        type: creative.call_to_action_type,
+        value: creative.link_url ? { link: creative.link_url } : undefined,
+      });
+    }
   } else {
     body.object_story_spec = JSON.stringify(creative.object_story_spec);
   }
@@ -113,6 +131,12 @@ function buildReplacementCreativeBody(
   if (creative.degrees_of_freedom_spec) {
     body.degrees_of_freedom_spec = JSON.stringify(creative.degrees_of_freedom_spec);
   }
+  // Agencies key reporting and automations off ad labels; a replacement without
+  // them drops out of those views silently.
+  const adlabels = (creative.adlabels ?? [])
+    .map((label) => (label.id ? { id: label.id } : label.name ? { name: label.name } : undefined))
+    .filter((label): label is { id: string } | { name: string } => label !== undefined);
+  if (adlabels.length > 0) body.adlabels = JSON.stringify(adlabels);
 
   if (urlTags !== "") body.url_tags = urlTags;
 
@@ -295,7 +319,7 @@ export function registerAdTools(server: McpServer): void {
   server.registerTool(
     "ads_update_ad_url_tags",
     {
-      description: `${WRITE_WARNING}Change the UTM parameters (url_tags) of one or more live ads. Meta creatives are immutable, so each ad's creative is cloned with the new url_tags and the ad is repointed at the clone. The clone re-references the source wholesale — the existing Facebook post, the creative spec, or the Instagram post — so media, copy, destination link and CTA are preserved, along with the post's likes and comments. Side effect: every updated ad re-enters Meta review. Ads whose url_tags already match are skipped, so re-running is safe. Dynamic creatives (asset_feed_spec) are reported as skipped. Use dry_run to preview.`,
+      description: `${WRITE_WARNING}Change the UTM parameters (url_tags) of one or more live ads. Meta creatives are immutable, so each ad's creative is cloned with the new url_tags and the ad is repointed at the clone. The clone re-references the source wholesale — the existing Facebook post, the creative spec, or the Instagram post — so media, copy, destination link and CTA are preserved, along with the post's likes and comments. Side effect: every updated ad re-enters Meta review. Ads whose url_tags already match are skipped, so re-running converges — though an ad whose write failed mid-flight gets its own replacement creative on retry, leaving the earlier one unused (the response reports its id). Do not run two batches over the same ads concurrently. Dynamic creatives (asset_feed_spec) are reported as skipped. Use dry_run to preview.`,
       inputSchema: {
         ad_ids: z
           .array(z.string())
@@ -318,6 +342,7 @@ export function registerAdTools(server: McpServer): void {
       const skipped: SkippedAd[] = [];
       const failed: FailedAd[] = [];
       const planned: PlannedRebuild[] = [];
+      const warnings: string[] = [];
 
       const groups = new Map<string, CreativeGroup>();
       for (const rawAdId of new Set(ad_ids)) {
@@ -418,9 +443,29 @@ export function registerAdTools(server: McpServer): void {
                 new_creative_id: newCreativeId,
               });
             } catch (err) {
+              // The write may have reached Meta with only its response lost, so
+              // read the ad back before claiming it was left untouched.
+              const outcome = await readCreativeIdAfterFailedRepoint(adId);
+
+              if (outcome === newCreativeId) {
+                updated.push({
+                  ad_id: adId,
+                  old_creative_id: group.creative_id,
+                  new_creative_id: newCreativeId,
+                });
+                warnings.push(
+                  `Ad ${adId} reported an error (${errorMessage(err)}) but is confirmed to point at creative ${newCreativeId}.`,
+                );
+                continue;
+              }
+
+              const state =
+                outcome === undefined
+                  ? `the ad's creative could not be read back, so its state is unknown`
+                  : `the ad still points at ${outcome}`;
               failed.push({
                 ad_id: adId,
-                error: `Creative ${newCreativeId} was created but the ad still points at ${group.creative_id}: ${errorMessage(err)}. Retry with ads_update_ad { ad_id: "${adId}", creative_id: "${newCreativeId}" }.`,
+                error: `Creative ${newCreativeId} was created but ${state}: ${errorMessage(err)}. Retry with ads_update_ad { ad_id: "${adId}", creative_id: "${newCreativeId}" }.`,
                 new_creative_id: newCreativeId,
               });
             }
@@ -435,6 +480,7 @@ export function registerAdTools(server: McpServer): void {
         updated,
         skipped,
         failed,
+        warnings,
       };
 
       const lines: string[] = dry_run

--- a/src/tools/ads.ts
+++ b/src/tools/ads.ts
@@ -10,9 +10,9 @@ import { READ, CREATE, UPDATE, DELETE, WRITE_WARNING } from "./_register.js";
 const statusEnum = z.enum(["ACTIVE", "PAUSED", "DELETED", "ARCHIVED"]);
 
 const CREATIVE_REBUILD_FIELDS =
-  "id,name,object_story_spec,asset_feed_spec,effective_object_story_id,url_tags,instagram_user_id";
+  "id,name,object_story_spec,asset_feed_spec,effective_object_story_id,url_tags,instagram_user_id,source_instagram_media_id,effective_instagram_media_id,link_url,degrees_of_freedom_spec";
 
-type RebuildStrategy = "reuse_post" | "clone_spec";
+type RebuildStrategy = "reuse_post" | "clone_spec" | "reuse_instagram_media";
 
 interface CreativeGroup {
   creative_id: string;
@@ -58,8 +58,11 @@ function resolveInstagramUserId(creative: AdCreative): string | undefined {
 }
 
 // Meta creatives are immutable except for name/status/adlabels, so changing
-// url_tags means minting a replacement. Reusing the existing post keeps the
-// ad's social proof (likes/comments); cloning the spec is the fallback.
+// url_tags means minting a replacement. Every strategy here re-references the
+// source wholesale (post, spec or Instagram media) rather than reconstructing
+// its parts, because a creative's destination link and CTA are not always
+// readable back — rebuilding them field by field could silently drop them.
+// Reusing the post also keeps the ad's social proof (likes/comments).
 function planRebuild(creative: AdCreative): RebuildStrategy | { reason: string } {
   if (creative.asset_feed_spec) {
     return {
@@ -68,7 +71,16 @@ function planRebuild(creative: AdCreative): RebuildStrategy | { reason: string }
   }
   if (creative.effective_object_story_id) return "reuse_post";
   if (asRecord(creative.object_story_spec)) return "clone_spec";
-  return { reason: "creative has no reusable post or object_story_spec to rebuild from" };
+  if (creative.source_instagram_media_id || creative.effective_instagram_media_id) {
+    return "reuse_instagram_media";
+  }
+  return { reason: "creative has no reusable post, object_story_spec or Instagram media to rebuild from" };
+}
+
+function describeStrategy(strategy: RebuildStrategy): string {
+  if (strategy === "reuse_post") return "reusing the existing post";
+  if (strategy === "reuse_instagram_media") return "reusing the Instagram post";
+  return "cloning the creative spec";
 }
 
 function buildReplacementCreativeBody(
@@ -79,12 +91,27 @@ function buildReplacementCreativeBody(
   const body: Record<string, string | number | boolean> = {};
   if (creative.name) body.name = creative.name;
 
+  const instagramUserId = resolveInstagramUserId(creative);
+
   if (strategy === "reuse_post") {
     body.object_story_id = creative.effective_object_story_id as string;
-    const instagramUserId = resolveInstagramUserId(creative);
+    if (instagramUserId) body.instagram_user_id = instagramUserId;
+  } else if (strategy === "reuse_instagram_media") {
+    body.source_instagram_media_id =
+      (creative.source_instagram_media_id ?? creative.effective_instagram_media_id) as string;
     if (instagramUserId) body.instagram_user_id = instagramUserId;
   } else {
     body.object_story_spec = JSON.stringify(creative.object_story_spec);
+  }
+
+  // Carried across because they live beside the story/spec rather than inside
+  // it: link_url is a creatable destination override, and dropping
+  // degrees_of_freedom_spec would silently reset the ad's Advantage+ creative
+  // enhancements. call_to_action_type is readable but not creatable, so the
+  // CTA can only travel with the source it is attached to.
+  if (creative.link_url) body.link_url = creative.link_url;
+  if (creative.degrees_of_freedom_spec) {
+    body.degrees_of_freedom_spec = JSON.stringify(creative.degrees_of_freedom_spec);
   }
 
   if (urlTags !== "") body.url_tags = urlTags;
@@ -268,7 +295,7 @@ export function registerAdTools(server: McpServer): void {
   server.registerTool(
     "ads_update_ad_url_tags",
     {
-      description: `${WRITE_WARNING}Change the UTM parameters (url_tags) of one or more live ads. Meta creatives are immutable, so each ad's creative is cloned with the new url_tags and the ad is repointed at the clone — the existing post is reused when possible, preserving likes and comments. Side effect: every updated ad re-enters Meta review. Ads whose url_tags already match are skipped, so re-running is safe. Dynamic creatives (asset_feed_spec) are reported as skipped. Use dry_run to preview.`,
+      description: `${WRITE_WARNING}Change the UTM parameters (url_tags) of one or more live ads. Meta creatives are immutable, so each ad's creative is cloned with the new url_tags and the ad is repointed at the clone. The clone re-references the source wholesale — the existing Facebook post, the creative spec, or the Instagram post — so media, copy, destination link and CTA are preserved, along with the post's likes and comments. Side effect: every updated ad re-enters Meta review. Ads whose url_tags already match are skipped, so re-running is safe. Dynamic creatives (asset_feed_spec) are reported as skipped. Use dry_run to preview.`,
       inputSchema: {
         ad_ids: z
           .array(z.string())
@@ -293,7 +320,7 @@ export function registerAdTools(server: McpServer): void {
       const planned: PlannedRebuild[] = [];
 
       const groups = new Map<string, CreativeGroup>();
-      for (const rawAdId of ad_ids) {
+      for (const rawAdId of new Set(ad_ids)) {
         try {
           const adId = validateMetaId(rawAdId, "ad");
           const ad = await metaApiClient.get<Ad & { account_id?: string }>(`/${adId}`, {
@@ -414,8 +441,7 @@ export function registerAdTools(server: McpServer): void {
         ? [
             `Dry run — no changes made. ${planned.length} ad(s) would get url_tags "${requestedTags || "(removed)"}".`,
             ...planned.map(
-              (p) =>
-                `• Ad ${p.ad_id}: clone creative ${p.old_creative_id} (${p.strategy === "reuse_post" ? "reusing the existing post" : "cloning the creative spec"})`,
+              (p) => `• Ad ${p.ad_id}: clone creative ${p.old_creative_id} (${describeStrategy(p.strategy)})`,
             ),
           ]
         : [

--- a/src/tools/creatives.ts
+++ b/src/tools/creatives.ts
@@ -3,7 +3,11 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { metaApiClient } from "../meta/client.js";
 import { normalizeAccountId, validateMetaId } from "../utils/format.js";
 import { buildFieldsParam } from "../utils/validation.js";
-import { CREATIVE_DEFAULT_FIELDS } from "../meta/types/creative.js";
+import {
+  CREATIVE_DEFAULT_FIELDS,
+  EFFECTIVE_LINK_URL_SOURCE_FIELDS,
+  SYNTHETIC_CREATIVE_FIELDS,
+} from "../meta/types/creative.js";
 import { IMAGE_DEFAULT_FIELDS } from "../meta/types/image.js";
 import { VIDEO_DEFAULT_FIELDS, VIDEO_DETAIL_FIELDS } from "../meta/types/video.js";
 import type { AdCreative, AdImage, AdVideo, MetaApiResponse } from "../meta/types/index.js";
@@ -75,21 +79,50 @@ function extractEffectiveLinkUrl(creative: AdCreative): string | undefined {
   );
 }
 
+// Clients read effective_link_url off our responses and echo it back in `fields`.
+// It is derived here, not stored by Meta, so forwarding it would fail with #100:
+// strip it and request the fields it is derived from instead.
+function buildCreativeFieldsParam(fields?: string[]): string {
+  if (!fields || fields.length === 0) {
+    return buildFieldsParam(undefined, [...CREATIVE_DEFAULT_FIELDS]);
+  }
+
+  const synthetic = new Set<string>(SYNTHETIC_CREATIVE_FIELDS);
+  const requested = fields.filter((field) => !synthetic.has(field));
+
+  const expanded = fields.includes("effective_link_url")
+    ? [...new Set([...requested, ...EFFECTIVE_LINK_URL_SOURCE_FIELDS])]
+    : requested;
+
+  return buildFieldsParam(expanded, [...CREATIVE_DEFAULT_FIELDS]);
+}
+
+function withDerivedEffectiveLinkUrl(creative: AdCreative): AdCreative {
+  const effectiveLinkUrl = extractEffectiveLinkUrl(creative);
+  return effectiveLinkUrl && !creative.effective_link_url
+    ? { ...creative, effective_link_url: effectiveLinkUrl }
+    : creative;
+}
+
 export function registerCreativeTools(server: McpServer): void {
   // ─── Get Ad Creatives ────────────────────────────────────────
   server.registerTool(
     "ads_get_ad_creatives",
     {
-      description: "Get creative details for an ad or list creatives for an ad account.",
+      description: "Get creative details for an ad or list creatives for an ad account. Returns url_tags (UTM parameters) by default, so a single call can audit tracking across an account.",
       inputSchema: {
         ad_id: z.string().optional().describe("Ad ID to get creatives for"),
         account_id: z.string().optional().describe("Account ID to list all creatives"),
         limit: z.number().min(1).max(100).default(25),
+        fields: z
+          .array(z.string())
+          .optional()
+          .describe("Creative fields to request. 'effective_link_url' is a virtual field derived by this server (never sent to Meta) — requesting it fetches link_url, object_story_spec and asset_feed_spec instead."),
       },
       annotations: { ...READ },
     },
-    async ({ ad_id, account_id, limit }) => {
-      const fieldsParam = buildFieldsParam(undefined, [...CREATIVE_DEFAULT_FIELDS]);
+    async ({ ad_id, account_id, limit, fields }) => {
+      const fieldsParam = buildCreativeFieldsParam(fields);
 
       let path: string;
       if (ad_id) {
@@ -104,7 +137,7 @@ export function registerCreativeTools(server: McpServer): void {
         path,
         { fields: fieldsParam, limit },
       );
-      const creatives = response.data ?? [];
+      const creatives = (response.data ?? []).map(withDerivedEffectiveLinkUrl);
 
       const text =
         creatives.length === 0
@@ -112,7 +145,7 @@ export function registerCreativeTools(server: McpServer): void {
           : creatives
               .map(
                 (c) =>
-                  `• ${c.name ?? "Unnamed"} (${c.id}) — CTA: ${c.call_to_action_type ?? "N/A"} — Image: ${c.image_url ? "Yes" : "No"}`,
+                  `• ${c.name ?? "Unnamed"} (${c.id}) — CTA: ${c.call_to_action_type ?? "N/A"} — Image: ${c.image_url ? "Yes" : "No"} — UTMs: ${c.url_tags ?? "N/A"}`,
               )
               .join("\n");
 
@@ -129,30 +162,30 @@ export function registerCreativeTools(server: McpServer): void {
   server.registerTool(
     "ads_get_creative_details",
     {
-      description: "Get detailed information about a specific creative.",
+      description: "Get detailed information about a specific creative. 'effective_link_url' is a virtual field this server derives from link_url / object_story_spec / asset_feed_spec — it is accepted in `fields` but never forwarded to Meta.",
       inputSchema: {
         creative_id: z.string().describe("Creative ID"),
-        fields: z.array(z.string()).optional(),
+        fields: z
+          .array(z.string())
+          .optional()
+          .describe("Creative fields to request. 'effective_link_url' is a virtual field derived by this server (never sent to Meta) — requesting it fetches link_url, object_story_spec and asset_feed_spec instead."),
       },
       annotations: { ...READ },
     },
     async ({ creative_id, fields }) => {
       const id = validateMetaId(creative_id, "creative");
-      const fieldsParam = buildFieldsParam(fields, [...CREATIVE_DEFAULT_FIELDS]);
+      const fieldsParam = buildCreativeFieldsParam(fields);
       const creative = await metaApiClient.get<AdCreative>(`/${id}`, {
         fields: fieldsParam,
       });
-      const effectiveLinkUrl = extractEffectiveLinkUrl(creative);
-      const responseCreative =
-        effectiveLinkUrl && !creative.effective_link_url
-          ? { ...creative, effective_link_url: effectiveLinkUrl }
-          : creative;
+      const responseCreative = withDerivedEffectiveLinkUrl(creative);
 
       const lines: string[] = [
         `Creative: ${creative.name ?? "Unnamed"} (${creative.id})`,
         `Status: ${creative.status ?? "N/A"}`,
         `CTA: ${creative.call_to_action_type ?? "N/A"}`,
-        `Link URL: ${effectiveLinkUrl ?? "N/A"}`,
+        `Link URL: ${responseCreative.effective_link_url ?? "N/A"}`,
+        `UTMs (url_tags): ${creative.url_tags ?? "N/A"}`,
         `Post ID: ${creative.effective_object_story_id ?? "N/A"}`,
       ];
 
@@ -313,7 +346,7 @@ export function registerCreativeTools(server: McpServer): void {
   server.registerTool(
     "ads_update_ad_creative",
     {
-      description: `${WRITE_WARNING}Update an existing creative's name. Note: most creative fields are immutable after creation.`,
+      description: `${WRITE_WARNING}Update an existing creative's name. Every other creative field (content, links, url_tags) is immutable after creation — to change an ad's UTM parameters use ads_update_ad_url_tags, which clones the creative and repoints the ad.`,
       inputSchema: {
         creative_id: z.string().describe("Creative ID to update"),
         name: z.string().optional().describe("New name for the creative"),
@@ -321,6 +354,12 @@ export function registerCreativeTools(server: McpServer): void {
       annotations: { ...UPDATE },
     },
     async ({ creative_id, name }) => {
+      if (name === undefined) {
+        throw new Error(
+          "Nothing to update: name is the only mutable creative field. Content, links and url_tags are immutable after creation — use ads_update_ad_url_tags to change UTM parameters (it clones the creative and repoints the ad).",
+        );
+      }
+
       const id = validateMetaId(creative_id, "creative");
       const body: Record<string, string | number | boolean> = {};
       if (name !== undefined) body.name = name;

--- a/src/tools/creatives.ts
+++ b/src/tools/creatives.ts
@@ -81,10 +81,27 @@ function extractEffectiveLinkUrl(creative: AdCreative): string | undefined {
 
 // Callers sometimes pass Graph-style comma-joined lists as a single array
 // entry. Split those so a synthetic field hidden inside one cannot slip
-// through, but leave nested selectors like `object_story_spec{link_data,name}`
-// intact — their commas are part of the expression.
+// through, but only on top-level commas: the ones inside a nested selector
+// like `object_story_spec{link_data,name}` are part of the expression.
 function splitFieldEntry(entry: string): string[] {
-  return entry.includes("{") ? [entry] : entry.split(",");
+  const parts: string[] = [];
+  let depth = 0;
+  let current = "";
+
+  for (const char of entry) {
+    if (char === "{") depth++;
+    else if (char === "}") depth = Math.max(0, depth - 1);
+
+    if (char === "," && depth === 0) {
+      parts.push(current);
+      current = "";
+      continue;
+    }
+    current += char;
+  }
+  parts.push(current);
+
+  return parts;
 }
 
 // Clients read effective_link_url off our responses and echo it back in `fields`.

--- a/src/tools/creatives.ts
+++ b/src/tools/creatives.ts
@@ -79,6 +79,14 @@ function extractEffectiveLinkUrl(creative: AdCreative): string | undefined {
   );
 }
 
+// Callers sometimes pass Graph-style comma-joined lists as a single array
+// entry. Split those so a synthetic field hidden inside one cannot slip
+// through, but leave nested selectors like `object_story_spec{link_data,name}`
+// intact — their commas are part of the expression.
+function splitFieldEntry(entry: string): string[] {
+  return entry.includes("{") ? [entry] : entry.split(",");
+}
+
 // Clients read effective_link_url off our responses and echo it back in `fields`.
 // It is derived here, not stored by Meta, so forwarding it would fail with #100:
 // strip it and request the fields it is derived from instead.
@@ -87,10 +95,11 @@ function buildCreativeFieldsParam(fields?: string[]): string {
     return buildFieldsParam(undefined, [...CREATIVE_DEFAULT_FIELDS]);
   }
 
+  const tokens = fields.flatMap(splitFieldEntry).map((field) => field.trim()).filter(Boolean);
   const synthetic = new Set<string>(SYNTHETIC_CREATIVE_FIELDS);
-  const requested = fields.filter((field) => !synthetic.has(field));
+  const requested = tokens.filter((field) => !synthetic.has(field));
 
-  const expanded = fields.includes("effective_link_url")
+  const expanded = tokens.includes("effective_link_url")
     ? [...new Set([...requested, ...EFFECTIVE_LINK_URL_SOURCE_FIELDS])]
     : requested;
 

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -43,7 +43,7 @@ export function registerAllTools(server: McpServer): void {
   registerAccountTools(server);      // 3 tools
   registerCampaignTools(server);     // 5 tools
   registerAdSetTools(server);        // 6 tools
-  registerAdTools(server);           // 5 tools
+  registerAdTools(server);           // 6 tools
   registerCreativeTools(server);     // 9 tools
   registerEntityTools(server);       // 3 tools — generic helpers (get_ad_entities, update_entity, activate_entity)
   registerInsightsTools(server);     // 1 tool  — power-tool ads_get_insights
@@ -82,5 +82,5 @@ export function registerAllTools(server: McpServer): void {
   // ─── Token Management ────────────────────────────────────
   registerTokenTools(server);        // 4 tools — list / set-active / register / delete
 
-  // Total: 124 tools (79 renamed + 14 new in v3 + 3 audience-sharing + 1 invoices + 27 WhatsApp)
+  // Total: 125 tools (79 renamed + 14 new in v3 + 3 audience-sharing + 1 invoices + 27 WhatsApp + 1 url-tags)
 }

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -29,3 +29,12 @@ export function buildFieldsParam(
 ): string {
   return (fields && fields.length > 0 ? fields : defaults).join(",");
 }
+
+/**
+ * Normalize a url_tags value: Meta stores it without the leading "?", and
+ * keeping it would produce "??utm_source=..." in the final click URL.
+ */
+export function normalizeUrlTags(value: string): string {
+  const trimmed = value.trim();
+  return trimmed.startsWith("?") ? trimmed.slice(1) : trimmed;
+}

--- a/tests/tools/ads.test.ts
+++ b/tests/tools/ads.test.ts
@@ -1,0 +1,465 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { registerAdTools } from "../../src/tools/ads.js";
+import { metaApiClient } from "../../src/meta/client.js";
+import {
+  createMockMcpServer,
+  setupTestToken,
+  cleanupTestToken,
+  mockFetchResponse,
+} from "../setup.js";
+
+type ToolResult = { content: Array<{ type: string; text: string }> };
+
+const UPDATE_AD = 3;
+const UPDATE_URL_TAGS = 4;
+
+function bodyOf(callIndex: number): URLSearchParams {
+  const call = vi.mocked(fetch).mock.calls[callIndex];
+  return new URLSearchParams(call[1]?.body as string);
+}
+
+function pathOf(callIndex: number): string {
+  return new URL(vi.mocked(fetch).mock.calls[callIndex][0] as string).pathname;
+}
+
+function methods(): Array<string | undefined> {
+  return vi.mocked(fetch).mock.calls.map((c) => c[1]?.method);
+}
+
+function adResponse(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "3001",
+    account_id: "123",
+    creative: { id: "4001" },
+    ...overrides,
+  };
+}
+
+function specCreative(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "4001",
+    name: "Creative A",
+    object_story_spec: {
+      page_id: "6001",
+      link_data: { link: "https://byads.co", image_hash: "h1" },
+    },
+    ...overrides,
+  };
+}
+
+describe("registerAdTools", () => {
+  beforeEach(() => {
+    setupTestToken();
+    metaApiClient.resetForTests();
+  });
+
+  afterEach(() => {
+    cleanupTestToken();
+    metaApiClient.resetForTests();
+    vi.restoreAllMocks();
+  });
+
+  it("registers exactly 6 tools", () => {
+    const server = createMockMcpServer();
+    registerAdTools(server as never);
+    expect(server.registerTool).toHaveBeenCalledTimes(6);
+  });
+
+  it("registers tools with expected names", () => {
+    const server = createMockMcpServer();
+    registerAdTools(server as never);
+
+    expect(server._registeredTools.map((t) => t.name)).toEqual([
+      "ads_get_ads",
+      "ads_get_ad_details",
+      "ads_create_ad",
+      "ads_update_ad",
+      "ads_update_ad_url_tags",
+      "ads_delete_ad",
+    ]);
+  });
+
+  describe("ads_update_ad handler", () => {
+    it("updates name and status with a single request", async () => {
+      const server = createMockMcpServer();
+      registerAdTools(server as never);
+      vi.stubGlobal("fetch", vi.fn().mockResolvedValue(mockFetchResponse({ success: true })));
+
+      const handler = server._registeredTools[UPDATE_AD].handler;
+      const result = await handler({
+        ad_id: "3001",
+        name: "Renamed",
+        status: "PAUSED",
+        creative_id: undefined,
+      }) as ToolResult;
+
+      expect(vi.mocked(fetch)).toHaveBeenCalledTimes(1);
+      expect(pathOf(0)).toMatch(/\/3001$/);
+      expect(methods()[0]).toBe("POST");
+      expect(bodyOf(0).get("name")).toBe("Renamed");
+      expect(bodyOf(0).get("status")).toBe("PAUSED");
+      expect(bodyOf(0).has("creative")).toBe(false);
+      expect(result.content[0].text).toContain("updated successfully");
+    });
+
+    it("refuses an empty update instead of reporting a false success", async () => {
+      const server = createMockMcpServer();
+      registerAdTools(server as never);
+      vi.stubGlobal("fetch", vi.fn());
+
+      const handler = server._registeredTools[UPDATE_AD].handler;
+      await expect(handler({
+        ad_id: "3001",
+        name: undefined,
+        status: undefined,
+        creative_id: undefined,
+      })).rejects.toThrow(/at least one/i);
+
+      expect(vi.mocked(fetch)).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("ads_update_ad_url_tags handler", () => {
+    it("reuses the existing post when the creative has one", async () => {
+      const server = createMockMcpServer();
+      registerAdTools(server as never);
+      vi.stubGlobal("fetch", vi.fn()
+        .mockResolvedValueOnce(mockFetchResponse(adResponse()))
+        .mockResolvedValueOnce(mockFetchResponse(specCreative({
+          effective_object_story_id: "6001_777",
+          url_tags: "utm_source=old",
+        })))
+        .mockResolvedValueOnce(mockFetchResponse({ id: "4100" }))
+        .mockResolvedValueOnce(mockFetchResponse({ success: true })));
+
+      const handler = server._registeredTools[UPDATE_URL_TAGS].handler;
+      const result = await handler({
+        ad_ids: ["3001"],
+        url_tags: "utm_source=meta&utm_medium=paid",
+        dry_run: false,
+      }) as ToolResult;
+
+      const creativeFields = new URL(vi.mocked(fetch).mock.calls[1][0] as string)
+        .searchParams.get("fields");
+      expect(creativeFields).toBe(
+        "id,name,object_story_spec,asset_feed_spec,effective_object_story_id,url_tags,instagram_user_id",
+      );
+      expect(creativeFields).not.toContain("effective_link_url");
+
+      expect(pathOf(2)).toContain("/act_123/adcreatives");
+      expect(bodyOf(2).get("object_story_id")).toBe("6001_777");
+      expect(bodyOf(2).get("url_tags")).toBe("utm_source=meta&utm_medium=paid");
+      expect(bodyOf(2).get("name")).toBe("Creative A");
+      expect(bodyOf(2).has("object_story_spec")).toBe(false);
+
+      expect(pathOf(3)).toMatch(/\/3001$/);
+      expect(JSON.parse(bodyOf(3).get("creative") ?? "{}")).toEqual({ creative_id: "4100" });
+
+      expect(result.content[0].text).toContain("4001");
+      expect(result.content[0].text).toContain("4100");
+      expect(result.content[0].text).toMatch(/review/i);
+    });
+
+    it("clones object_story_spec when there is no reusable post", async () => {
+      const server = createMockMcpServer();
+      registerAdTools(server as never);
+      vi.stubGlobal("fetch", vi.fn()
+        .mockResolvedValueOnce(mockFetchResponse(adResponse()))
+        .mockResolvedValueOnce(mockFetchResponse(specCreative()))
+        .mockResolvedValueOnce(mockFetchResponse({ id: "4100" }))
+        .mockResolvedValueOnce(mockFetchResponse({ success: true })));
+
+      const handler = server._registeredTools[UPDATE_URL_TAGS].handler;
+      await handler({ ad_ids: ["3001"], url_tags: "utm_source=meta", dry_run: false });
+
+      expect(bodyOf(2).has("object_story_id")).toBe(false);
+      expect(JSON.parse(bodyOf(2).get("object_story_spec") ?? "{}")).toEqual({
+        page_id: "6001",
+        link_data: { link: "https://byads.co", image_hash: "h1" },
+      });
+      expect(bodyOf(2).get("url_tags")).toBe("utm_source=meta");
+    });
+
+    it("carries the Instagram identity from the creative", async () => {
+      const server = createMockMcpServer();
+      registerAdTools(server as never);
+      vi.stubGlobal("fetch", vi.fn()
+        .mockResolvedValueOnce(mockFetchResponse(adResponse()))
+        .mockResolvedValueOnce(mockFetchResponse(specCreative({
+          effective_object_story_id: "6001_777",
+          instagram_user_id: "9001",
+        })))
+        .mockResolvedValueOnce(mockFetchResponse({ id: "4100" }))
+        .mockResolvedValueOnce(mockFetchResponse({ success: true })));
+
+      const handler = server._registeredTools[UPDATE_URL_TAGS].handler;
+      await handler({ ad_ids: ["3001"], url_tags: "utm_source=meta", dry_run: false });
+
+      expect(bodyOf(2).get("instagram_user_id")).toBe("9001");
+    });
+
+    it("carries a spec-embedded Instagram identity", async () => {
+      const server = createMockMcpServer();
+      registerAdTools(server as never);
+      vi.stubGlobal("fetch", vi.fn()
+        .mockResolvedValueOnce(mockFetchResponse(adResponse()))
+        .mockResolvedValueOnce(mockFetchResponse({
+          id: "4001",
+          name: "Creative A",
+          effective_object_story_id: "6001_777",
+          object_story_spec: { page_id: "6001", instagram_user_id: "9002", link_data: { link: "https://byads.co" } },
+        }))
+        .mockResolvedValueOnce(mockFetchResponse({ id: "4100" }))
+        .mockResolvedValueOnce(mockFetchResponse({ success: true })));
+
+      const handler = server._registeredTools[UPDATE_URL_TAGS].handler;
+      await handler({ ad_ids: ["3001"], url_tags: "utm_source=meta", dry_run: false });
+
+      expect(bodyOf(2).get("instagram_user_id")).toBe("9002");
+    });
+
+    it("creates one creative for ads that share it", async () => {
+      const server = createMockMcpServer();
+      registerAdTools(server as never);
+      vi.stubGlobal("fetch", vi.fn()
+        .mockResolvedValueOnce(mockFetchResponse(adResponse({ id: "3001" })))
+        .mockResolvedValueOnce(mockFetchResponse(adResponse({ id: "3002" })))
+        .mockResolvedValueOnce(mockFetchResponse(specCreative()))
+        .mockResolvedValueOnce(mockFetchResponse({ id: "4100" }))
+        .mockResolvedValueOnce(mockFetchResponse({ success: true }))
+        .mockResolvedValueOnce(mockFetchResponse({ success: true })));
+
+      const handler = server._registeredTools[UPDATE_URL_TAGS].handler;
+      const result = await handler({
+        ad_ids: ["3001", "3002"],
+        url_tags: "utm_source=meta",
+        dry_run: false,
+      }) as ToolResult;
+
+      const creativeCreations = vi.mocked(fetch).mock.calls.filter(
+        (c) => (c[0] as string).includes("/adcreatives"),
+      );
+      expect(creativeCreations).toHaveLength(1);
+      expect(JSON.parse(bodyOf(4).get("creative") ?? "{}")).toEqual({ creative_id: "4100" });
+      expect(JSON.parse(bodyOf(5).get("creative") ?? "{}")).toEqual({ creative_id: "4100" });
+
+      const report = JSON.parse(result.content[1].text) as { updated: unknown[] };
+      expect(report.updated).toHaveLength(2);
+    });
+
+    it("skips ads whose url_tags already match", async () => {
+      const server = createMockMcpServer();
+      registerAdTools(server as never);
+      vi.stubGlobal("fetch", vi.fn()
+        .mockResolvedValueOnce(mockFetchResponse(adResponse()))
+        .mockResolvedValueOnce(mockFetchResponse(specCreative({ url_tags: "utm_source=meta" }))));
+
+      const handler = server._registeredTools[UPDATE_URL_TAGS].handler;
+      const result = await handler({
+        ad_ids: ["3001"],
+        url_tags: "utm_source=meta",
+        dry_run: false,
+      }) as ToolResult;
+
+      expect(methods()).toEqual(["GET", "GET"]);
+      const report = JSON.parse(result.content[1].text) as { skipped: Array<{ reason: string }> };
+      expect(report.skipped[0].reason).toMatch(/already/i);
+    });
+
+    it("treats a leading question mark as equivalent", async () => {
+      const server = createMockMcpServer();
+      registerAdTools(server as never);
+      vi.stubGlobal("fetch", vi.fn()
+        .mockResolvedValueOnce(mockFetchResponse(adResponse()))
+        .mockResolvedValueOnce(mockFetchResponse(specCreative({ url_tags: "utm_source=meta" }))));
+
+      const handler = server._registeredTools[UPDATE_URL_TAGS].handler;
+      await handler({ ad_ids: ["3001"], url_tags: "?utm_source=meta", dry_run: false });
+
+      expect(methods()).toEqual(["GET", "GET"]);
+    });
+
+    it("strips a leading question mark from the value it writes", async () => {
+      const server = createMockMcpServer();
+      registerAdTools(server as never);
+      vi.stubGlobal("fetch", vi.fn()
+        .mockResolvedValueOnce(mockFetchResponse(adResponse()))
+        .mockResolvedValueOnce(mockFetchResponse(specCreative({ url_tags: "utm_source=old" })))
+        .mockResolvedValueOnce(mockFetchResponse({ id: "4100" }))
+        .mockResolvedValueOnce(mockFetchResponse({ success: true })));
+
+      const handler = server._registeredTools[UPDATE_URL_TAGS].handler;
+      await handler({ ad_ids: ["3001"], url_tags: "?utm_source=meta", dry_run: false });
+
+      expect(bodyOf(2).get("url_tags")).toBe("utm_source=meta");
+    });
+
+    it("removes url_tags when passed an empty string", async () => {
+      const server = createMockMcpServer();
+      registerAdTools(server as never);
+      vi.stubGlobal("fetch", vi.fn()
+        .mockResolvedValueOnce(mockFetchResponse(adResponse()))
+        .mockResolvedValueOnce(mockFetchResponse(specCreative({ url_tags: "utm_source=old" })))
+        .mockResolvedValueOnce(mockFetchResponse({ id: "4100" }))
+        .mockResolvedValueOnce(mockFetchResponse({ success: true })));
+
+      const handler = server._registeredTools[UPDATE_URL_TAGS].handler;
+      await handler({ ad_ids: ["3001"], url_tags: "", dry_run: false });
+
+      expect(bodyOf(2).has("url_tags")).toBe(false);
+      expect(JSON.parse(bodyOf(3).get("creative") ?? "{}")).toEqual({ creative_id: "4100" });
+    });
+
+    it("skips removal when the creative has no url_tags", async () => {
+      const server = createMockMcpServer();
+      registerAdTools(server as never);
+      vi.stubGlobal("fetch", vi.fn()
+        .mockResolvedValueOnce(mockFetchResponse(adResponse()))
+        .mockResolvedValueOnce(mockFetchResponse(specCreative())));
+
+      const handler = server._registeredTools[UPDATE_URL_TAGS].handler;
+      await handler({ ad_ids: ["3001"], url_tags: "", dry_run: false });
+
+      expect(methods()).toEqual(["GET", "GET"]);
+    });
+
+    it("skips dynamic creatives and keeps processing the rest of the batch", async () => {
+      const server = createMockMcpServer();
+      registerAdTools(server as never);
+      vi.stubGlobal("fetch", vi.fn()
+        .mockResolvedValueOnce(mockFetchResponse(adResponse({ id: "3001", creative: { id: "4001" } })))
+        .mockResolvedValueOnce(mockFetchResponse(adResponse({ id: "3002", creative: { id: "4002" } })))
+        .mockResolvedValueOnce(mockFetchResponse({
+          id: "4001",
+          name: "Dynamic",
+          asset_feed_spec: { link_urls: [{ website_url: "https://byads.co" }] },
+        }))
+        .mockResolvedValueOnce(mockFetchResponse(specCreative({ id: "4002" })))
+        .mockResolvedValueOnce(mockFetchResponse({ id: "4100" }))
+        .mockResolvedValueOnce(mockFetchResponse({ success: true })));
+
+      const handler = server._registeredTools[UPDATE_URL_TAGS].handler;
+      const result = await handler({
+        ad_ids: ["3001", "3002"],
+        url_tags: "utm_source=meta",
+        dry_run: false,
+      }) as ToolResult;
+
+      const report = JSON.parse(result.content[1].text) as {
+        updated: Array<{ ad_id: string }>;
+        skipped: Array<{ ad_id: string; reason: string }>;
+      };
+      expect(report.skipped).toHaveLength(1);
+      expect(report.skipped[0].ad_id).toBe("3001");
+      expect(report.skipped[0].reason).toMatch(/asset_feed_spec|dynamic/i);
+      expect(report.updated.map((u) => u.ad_id)).toEqual(["3002"]);
+    });
+
+    it("reports ads without a creative as failed without aborting", async () => {
+      const server = createMockMcpServer();
+      registerAdTools(server as never);
+      vi.stubGlobal("fetch", vi.fn()
+        .mockResolvedValueOnce(mockFetchResponse({ id: "3001", account_id: "123" }))
+        .mockResolvedValueOnce(mockFetchResponse(adResponse({ id: "3002" })))
+        .mockResolvedValueOnce(mockFetchResponse(specCreative()))
+        .mockResolvedValueOnce(mockFetchResponse({ id: "4100" }))
+        .mockResolvedValueOnce(mockFetchResponse({ success: true })));
+
+      const handler = server._registeredTools[UPDATE_URL_TAGS].handler;
+      const result = await handler({
+        ad_ids: ["3001", "3002"],
+        url_tags: "utm_source=meta",
+        dry_run: false,
+      }) as ToolResult;
+
+      const report = JSON.parse(result.content[1].text) as {
+        updated: Array<{ ad_id: string }>;
+        failed: Array<{ ad_id: string; error: string }>;
+      };
+      expect(report.failed[0].ad_id).toBe("3001");
+      expect(report.failed[0].error).toMatch(/creative/i);
+      expect(report.updated.map((u) => u.ad_id)).toEqual(["3002"]);
+    });
+
+    it("writes nothing in dry_run mode", async () => {
+      const server = createMockMcpServer();
+      registerAdTools(server as never);
+      vi.stubGlobal("fetch", vi.fn()
+        .mockResolvedValueOnce(mockFetchResponse(adResponse()))
+        .mockResolvedValueOnce(mockFetchResponse(specCreative({
+          effective_object_story_id: "6001_777",
+          url_tags: "utm_source=old",
+        }))));
+
+      const handler = server._registeredTools[UPDATE_URL_TAGS].handler;
+      const result = await handler({
+        ad_ids: ["3001"],
+        url_tags: "utm_source=meta",
+        dry_run: true,
+      }) as ToolResult;
+
+      expect(methods()).toEqual(["GET", "GET"]);
+      const report = JSON.parse(result.content[1].text) as {
+        dry_run: boolean;
+        planned: Array<{ ad_id: string; strategy: string; old_creative_id: string }>;
+      };
+      expect(report.dry_run).toBe(true);
+      expect(report.planned[0]).toMatchObject({ ad_id: "3001", old_creative_id: "4001" });
+      expect(report.planned[0].strategy).toMatch(/post/i);
+    });
+
+    it("reports a failed repoint with the orphaned creative id", async () => {
+      const server = createMockMcpServer();
+      registerAdTools(server as never);
+      vi.stubGlobal("fetch", vi.fn()
+        .mockResolvedValueOnce(mockFetchResponse(adResponse({ id: "3001" })))
+        .mockResolvedValueOnce(mockFetchResponse(adResponse({ id: "3002" })))
+        .mockResolvedValueOnce(mockFetchResponse(specCreative()))
+        .mockResolvedValueOnce(mockFetchResponse({ id: "4100" }))
+        .mockResolvedValueOnce(mockFetchResponse({ success: true }))
+        .mockResolvedValueOnce(mockFetchResponse(
+          { error: { message: "(#100) invalid ad", type: "OAuthException", code: 100 } },
+          { status: 400 },
+        )));
+
+      const handler = server._registeredTools[UPDATE_URL_TAGS].handler;
+      const result = await handler({
+        ad_ids: ["3001", "3002"],
+        url_tags: "utm_source=meta",
+        dry_run: false,
+      }) as ToolResult;
+
+      const report = JSON.parse(result.content[1].text) as {
+        updated: Array<{ ad_id: string }>;
+        failed: Array<{ ad_id: string; error: string; new_creative_id?: string }>;
+      };
+      expect(report.updated.map((u) => u.ad_id)).toEqual(["3001"]);
+      expect(report.failed[0].ad_id).toBe("3002");
+      expect(report.failed[0].new_creative_id).toBe("4100");
+    });
+
+    it("fails the whole group when the creative cannot be read", async () => {
+      const server = createMockMcpServer();
+      registerAdTools(server as never);
+      vi.stubGlobal("fetch", vi.fn()
+        .mockResolvedValueOnce(mockFetchResponse(adResponse()))
+        .mockResolvedValueOnce(mockFetchResponse(
+          { error: { message: "(#100) missing", type: "OAuthException", code: 100 } },
+          { status: 400 },
+        )));
+
+      const handler = server._registeredTools[UPDATE_URL_TAGS].handler;
+      const result = await handler({
+        ad_ids: ["3001"],
+        url_tags: "utm_source=meta",
+        dry_run: false,
+      }) as ToolResult;
+
+      expect(methods()).toEqual(["GET", "GET"]);
+      const report = JSON.parse(result.content[1].text) as {
+        failed: Array<{ ad_id: string; error: string }>;
+      };
+      expect(report.failed[0].ad_id).toBe("3001");
+    });
+  });
+});

--- a/tests/tools/ads.test.ts
+++ b/tests/tools/ads.test.ts
@@ -142,7 +142,7 @@ describe("registerAdTools", () => {
       const creativeFields = new URL(vi.mocked(fetch).mock.calls[1][0] as string)
         .searchParams.get("fields");
       expect(creativeFields).toBe(
-        "id,name,object_story_spec,asset_feed_spec,effective_object_story_id,url_tags,instagram_user_id,source_instagram_media_id,effective_instagram_media_id,link_url,degrees_of_freedom_spec",
+        "id,name,object_story_spec,asset_feed_spec,effective_object_story_id,url_tags,instagram_user_id,source_instagram_media_id,effective_instagram_media_id,link_url,degrees_of_freedom_spec,call_to_action_type,adlabels",
       );
       expect(creativeFields).not.toContain("effective_link_url");
 
@@ -242,6 +242,109 @@ describe("registerAdTools", () => {
       expect(bodyOf(2).get("url_tags")).toBe("utm_source=meta");
       expect(bodyOf(2).has("object_story_id")).toBe(false);
       expect(bodyOf(2).has("object_story_spec")).toBe(false);
+    });
+
+    it("rebuilds the CTA of an Instagram creative, which stores it on the creative", async () => {
+      const server = createMockMcpServer();
+      registerAdTools(server as never);
+      vi.stubGlobal("fetch", vi.fn()
+        .mockResolvedValueOnce(mockFetchResponse(adResponse()))
+        .mockResolvedValueOnce(mockFetchResponse({
+          id: "4001",
+          name: "IG Post Creative",
+          source_instagram_media_id: "7001",
+          call_to_action_type: "SHOP_NOW",
+          link_url: "https://byads.co/shop",
+          url_tags: "utm_source=old",
+        }))
+        .mockResolvedValueOnce(mockFetchResponse({ id: "4100" }))
+        .mockResolvedValueOnce(mockFetchResponse({ success: true })));
+
+      const handler = server._registeredTools[UPDATE_URL_TAGS].handler;
+      await handler({ ad_ids: ["3001"], url_tags: "utm_source=meta", dry_run: false });
+
+      expect(JSON.parse(bodyOf(2).get("call_to_action") ?? "{}")).toEqual({
+        type: "SHOP_NOW",
+        value: { link: "https://byads.co/shop" },
+      });
+    });
+
+    it("carries ad labels to the replacement creative", async () => {
+      const server = createMockMcpServer();
+      registerAdTools(server as never);
+      vi.stubGlobal("fetch", vi.fn()
+        .mockResolvedValueOnce(mockFetchResponse(adResponse()))
+        .mockResolvedValueOnce(mockFetchResponse(specCreative({
+          adlabels: [{ id: "5001", name: "Q3" }, { name: "Brand" }],
+        })))
+        .mockResolvedValueOnce(mockFetchResponse({ id: "4100" }))
+        .mockResolvedValueOnce(mockFetchResponse({ success: true })));
+
+      const handler = server._registeredTools[UPDATE_URL_TAGS].handler;
+      await handler({ ad_ids: ["3001"], url_tags: "utm_source=meta", dry_run: false });
+
+      expect(JSON.parse(bodyOf(2).get("adlabels") ?? "[]")).toEqual([{ id: "5001" }, { name: "Brand" }]);
+    });
+
+    it("counts a repoint as updated when the ad is confirmed to have moved", async () => {
+      const server = createMockMcpServer();
+      registerAdTools(server as never);
+      vi.stubGlobal("fetch", vi.fn()
+        .mockResolvedValueOnce(mockFetchResponse(adResponse()))
+        .mockResolvedValueOnce(mockFetchResponse(specCreative()))
+        .mockResolvedValueOnce(mockFetchResponse({ id: "4100" }))
+        .mockResolvedValueOnce(mockFetchResponse(
+          { error: { message: "(#100) lost response", type: "OAuthException", code: 100 } },
+          { status: 400 },
+        ))
+        .mockResolvedValueOnce(mockFetchResponse({ id: "3001", creative: { id: "4100" } })));
+
+      const handler = server._registeredTools[UPDATE_URL_TAGS].handler;
+      const result = await handler({
+        ad_ids: ["3001"],
+        url_tags: "utm_source=meta",
+        dry_run: false,
+      }) as ToolResult;
+
+      const report = JSON.parse(result.content[1].text) as {
+        updated: Array<{ ad_id: string }>;
+        failed: unknown[];
+        warnings: string[];
+      };
+      expect(report.updated.map((u) => u.ad_id)).toEqual(["3001"]);
+      expect(report.failed).toHaveLength(0);
+      expect(report.warnings[0]).toContain("4100");
+    });
+
+    it("reports an unknown state when the ad cannot be read back", async () => {
+      const server = createMockMcpServer();
+      registerAdTools(server as never);
+      vi.stubGlobal("fetch", vi.fn()
+        .mockResolvedValueOnce(mockFetchResponse(adResponse()))
+        .mockResolvedValueOnce(mockFetchResponse(specCreative()))
+        .mockResolvedValueOnce(mockFetchResponse({ id: "4100" }))
+        .mockResolvedValueOnce(mockFetchResponse(
+          { error: { message: "(#100) boom", type: "OAuthException", code: 100 } },
+          { status: 400 },
+        ))
+        .mockResolvedValueOnce(mockFetchResponse(
+          { error: { message: "(#100) unreadable", type: "OAuthException", code: 100 } },
+          { status: 400 },
+        )));
+
+      const handler = server._registeredTools[UPDATE_URL_TAGS].handler;
+      const result = await handler({
+        ad_ids: ["3001"],
+        url_tags: "utm_source=meta",
+        dry_run: false,
+      }) as ToolResult;
+
+      const report = JSON.parse(result.content[1].text) as {
+        failed: Array<{ ad_id: string; error: string; new_creative_id?: string }>;
+      };
+      expect(report.failed[0].ad_id).toBe("3001");
+      expect(report.failed[0].error).toMatch(/state is unknown/i);
+      expect(report.failed[0].new_creative_id).toBe("4100");
     });
 
     it("prefers the existing post over the Instagram media when both are present", async () => {
@@ -512,7 +615,8 @@ describe("registerAdTools", () => {
         .mockResolvedValueOnce(mockFetchResponse(
           { error: { message: "(#100) invalid ad", type: "OAuthException", code: 100 } },
           { status: 400 },
-        )));
+        ))
+        .mockResolvedValueOnce(mockFetchResponse({ id: "3002", creative: { id: "4001" } })));
 
       const handler = server._registeredTools[UPDATE_URL_TAGS].handler;
       const result = await handler({

--- a/tests/tools/ads.test.ts
+++ b/tests/tools/ads.test.ts
@@ -142,7 +142,7 @@ describe("registerAdTools", () => {
       const creativeFields = new URL(vi.mocked(fetch).mock.calls[1][0] as string)
         .searchParams.get("fields");
       expect(creativeFields).toBe(
-        "id,name,object_story_spec,asset_feed_spec,effective_object_story_id,url_tags,instagram_user_id",
+        "id,name,object_story_spec,asset_feed_spec,effective_object_story_id,url_tags,instagram_user_id,source_instagram_media_id,effective_instagram_media_id,link_url,degrees_of_freedom_spec",
       );
       expect(creativeFields).not.toContain("effective_link_url");
 
@@ -218,6 +218,56 @@ describe("registerAdTools", () => {
       expect(bodyOf(2).get("instagram_user_id")).toBe("9002");
     });
 
+    it("reuses the Instagram media when the creative has no post or spec", async () => {
+      const server = createMockMcpServer();
+      registerAdTools(server as never);
+      vi.stubGlobal("fetch", vi.fn()
+        .mockResolvedValueOnce(mockFetchResponse(adResponse()))
+        .mockResolvedValueOnce(mockFetchResponse({
+          id: "4001",
+          name: "IG Post Creative",
+          source_instagram_media_id: "7001",
+          effective_instagram_media_id: "7002",
+          instagram_user_id: "9003",
+          url_tags: "utm_source=old",
+        }))
+        .mockResolvedValueOnce(mockFetchResponse({ id: "4100" }))
+        .mockResolvedValueOnce(mockFetchResponse({ success: true })));
+
+      const handler = server._registeredTools[UPDATE_URL_TAGS].handler;
+      await handler({ ad_ids: ["3001"], url_tags: "utm_source=meta", dry_run: false });
+
+      expect(bodyOf(2).get("source_instagram_media_id")).toBe("7001");
+      expect(bodyOf(2).get("instagram_user_id")).toBe("9003");
+      expect(bodyOf(2).get("url_tags")).toBe("utm_source=meta");
+      expect(bodyOf(2).has("object_story_id")).toBe(false);
+      expect(bodyOf(2).has("object_story_spec")).toBe(false);
+    });
+
+    it("prefers the existing post over the Instagram media when both are present", async () => {
+      const server = createMockMcpServer();
+      registerAdTools(server as never);
+      vi.stubGlobal("fetch", vi.fn()
+        .mockResolvedValueOnce(mockFetchResponse(adResponse()))
+        .mockResolvedValueOnce(mockFetchResponse({
+          id: "4001",
+          name: "IG Post Creative",
+          effective_object_story_id: "6001_7777",
+          source_instagram_media_id: "7001",
+          instagram_user_id: "9003",
+          url_tags: "utm_source=old",
+        }))
+        .mockResolvedValueOnce(mockFetchResponse({ id: "4100" }))
+        .mockResolvedValueOnce(mockFetchResponse({ success: true })));
+
+      const handler = server._registeredTools[UPDATE_URL_TAGS].handler;
+      await handler({ ad_ids: ["3001"], url_tags: "utm_source=meta", dry_run: false });
+
+      expect(bodyOf(2).get("object_story_id")).toBe("6001_7777");
+      expect(bodyOf(2).has("source_instagram_media_id")).toBe(false);
+      expect(bodyOf(2).get("instagram_user_id")).toBe("9003");
+    });
+
     it("creates one creative for ads that share it", async () => {
       const server = createMockMcpServer();
       registerAdTools(server as never);
@@ -242,9 +292,51 @@ describe("registerAdTools", () => {
       expect(creativeCreations).toHaveLength(1);
       expect(JSON.parse(bodyOf(4).get("creative") ?? "{}")).toEqual({ creative_id: "4100" });
       expect(JSON.parse(bodyOf(5).get("creative") ?? "{}")).toEqual({ creative_id: "4100" });
+      expect([pathOf(4), pathOf(5)].map((p) => p.split("/").pop()).sort()).toEqual(["3001", "3002"]);
 
+      const report = JSON.parse(result.content[1].text) as { updated: Array<{ ad_id: string }> };
+      expect(report.updated.map((u) => u.ad_id).sort()).toEqual(["3001", "3002"]);
+    });
+
+    it("reads each ad once when an id is repeated", async () => {
+      const server = createMockMcpServer();
+      registerAdTools(server as never);
+      vi.stubGlobal("fetch", vi.fn()
+        .mockResolvedValueOnce(mockFetchResponse(adResponse()))
+        .mockResolvedValueOnce(mockFetchResponse(specCreative()))
+        .mockResolvedValueOnce(mockFetchResponse({ id: "4100" }))
+        .mockResolvedValueOnce(mockFetchResponse({ success: true })));
+
+      const handler = server._registeredTools[UPDATE_URL_TAGS].handler;
+      const result = await handler({
+        ad_ids: ["3001", "3001"],
+        url_tags: "utm_source=meta",
+        dry_run: false,
+      }) as ToolResult;
+
+      expect(vi.mocked(fetch)).toHaveBeenCalledTimes(4);
       const report = JSON.parse(result.content[1].text) as { updated: unknown[] };
-      expect(report.updated).toHaveLength(2);
+      expect(report.updated).toHaveLength(1);
+    });
+
+    it("carries the destination override and Advantage+ enhancement settings", async () => {
+      const server = createMockMcpServer();
+      registerAdTools(server as never);
+      const dof = { creative_features_spec: { standard_enhancements: { enroll_status: "OPT_IN" } } };
+      vi.stubGlobal("fetch", vi.fn()
+        .mockResolvedValueOnce(mockFetchResponse(adResponse()))
+        .mockResolvedValueOnce(mockFetchResponse(specCreative({
+          link_url: "https://byads.co/landing",
+          degrees_of_freedom_spec: dof,
+        })))
+        .mockResolvedValueOnce(mockFetchResponse({ id: "4100" }))
+        .mockResolvedValueOnce(mockFetchResponse({ success: true })));
+
+      const handler = server._registeredTools[UPDATE_URL_TAGS].handler;
+      await handler({ ad_ids: ["3001"], url_tags: "utm_source=meta", dry_run: false });
+
+      expect(bodyOf(2).get("link_url")).toBe("https://byads.co/landing");
+      expect(JSON.parse(bodyOf(2).get("degrees_of_freedom_spec") ?? "{}")).toEqual(dof);
     });
 
     it("skips ads whose url_tags already match", async () => {

--- a/tests/tools/creatives.test.ts
+++ b/tests/tools/creatives.test.ts
@@ -1,6 +1,9 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { registerCreativeTools } from "../../src/tools/creatives.js";
-import { CREATIVE_DEFAULT_FIELDS } from "../../src/meta/types/creative.js";
+import {
+  CREATIVE_DEFAULT_FIELDS,
+  SYNTHETIC_CREATIVE_FIELDS,
+} from "../../src/meta/types/creative.js";
 import {
   createMockMcpServer,
   setupTestToken,
@@ -18,8 +21,10 @@ describe("registerCreativeTools", () => {
     vi.restoreAllMocks();
   });
 
-  it("never requests effective_link_url — not a real Meta AdCreative field (Graph API rejects it with #100)", () => {
-    expect(CREATIVE_DEFAULT_FIELDS).not.toContain("effective_link_url");
+  it("never requests a synthetic field from Meta — the Graph API rejects them with #100", () => {
+    for (const synthetic of SYNTHETIC_CREATIVE_FIELDS) {
+      expect(CREATIVE_DEFAULT_FIELDS).not.toContain(synthetic);
+    }
   });
 
   it("registers exactly 9 tools", () => {
@@ -75,7 +80,7 @@ describe("registerCreativeTools", () => {
       const url = new URL(vi.mocked(fetch).mock.calls[0][0] as string);
       expect(url.pathname).toContain("/40123");
       expect(url.searchParams.get("fields")).toBe(
-        "id,name,title,body,image_hash,image_url,thumbnail_url,object_story_spec,asset_feed_spec,call_to_action_type,link_url,effective_object_story_id,status",
+        "id,name,title,body,image_hash,image_url,thumbnail_url,object_story_spec,asset_feed_spec,call_to_action_type,link_url,effective_object_story_id,status,url_tags",
       );
     });
 
@@ -127,6 +132,160 @@ describe("registerCreativeTools", () => {
 
       expect(result.content[0].text).toContain("Link URL: https://ugc.byads.co/chile");
       expect(result.content[1].text).toContain("\"effective_link_url\": \"https://ugc.byads.co/chile\"");
+    });
+
+    it("accepts effective_link_url in fields by requesting its sources instead", async () => {
+      const server = createMockMcpServer();
+      registerCreativeTools(server as never);
+
+      vi.stubGlobal("fetch", vi.fn().mockResolvedValue(mockFetchResponse({
+        id: "40777",
+        name: "Virtual Field Creative",
+        link_url: "https://byads.co/landing",
+      })));
+
+      const handler = server._registeredTools[1].handler;
+      const result = await handler({
+        creative_id: "40777",
+        fields: ["name", "effective_link_url"],
+      }) as { content: Array<{ type: string; text: string }> };
+
+      const fieldsParam = new URL(vi.mocked(fetch).mock.calls[0][0] as string)
+        .searchParams.get("fields");
+      expect(fieldsParam).toBe("name,link_url,object_story_spec,asset_feed_spec");
+      expect(fieldsParam).not.toContain("effective_link_url");
+      expect(result.content[1].text).toContain("\"effective_link_url\": \"https://byads.co/landing\"");
+    });
+
+    it("derives effective_link_url when it is the only requested field", async () => {
+      const server = createMockMcpServer();
+      registerCreativeTools(server as never);
+
+      vi.stubGlobal("fetch", vi.fn().mockResolvedValue(mockFetchResponse({
+        id: "40778",
+        name: "Link Data Creative",
+        object_story_spec: {
+          page_id: "6001",
+          link_data: { link: "https://byads.co/promo" },
+        },
+      })));
+
+      const handler = server._registeredTools[1].handler;
+      const result = await handler({
+        creative_id: "40778",
+        fields: ["effective_link_url"],
+      }) as { content: Array<{ type: string; text: string }> };
+
+      const fieldsParam = new URL(vi.mocked(fetch).mock.calls[0][0] as string)
+        .searchParams.get("fields");
+      expect(fieldsParam).toBe("link_url,object_story_spec,asset_feed_spec");
+      expect(result.content[0].text).toContain("Link URL: https://byads.co/promo");
+    });
+
+    it("does not duplicate source fields already requested by the caller", async () => {
+      const server = createMockMcpServer();
+      registerCreativeTools(server as never);
+
+      vi.stubGlobal("fetch", vi.fn().mockResolvedValue(mockFetchResponse({ id: "40779" })));
+
+      const handler = server._registeredTools[1].handler;
+      await handler({
+        creative_id: "40779",
+        fields: ["link_url", "effective_link_url"],
+      });
+
+      expect(new URL(vi.mocked(fetch).mock.calls[0][0] as string).searchParams.get("fields"))
+        .toBe("link_url,object_story_spec,asset_feed_spec");
+    });
+  });
+
+  describe("ads_get_ad_creatives handler", () => {
+    it("requests url_tags by default and reports them per creative", async () => {
+      const server = createMockMcpServer();
+      registerCreativeTools(server as never);
+
+      vi.stubGlobal("fetch", vi.fn().mockResolvedValue(mockFetchResponse({
+        data: [{ id: "4001", name: "C1", url_tags: "utm_source=meta" }],
+      })));
+
+      const handler = server._registeredTools[0].handler;
+      const result = await handler({
+        ad_id: undefined,
+        account_id: "act_123",
+        limit: 25,
+        fields: undefined,
+      }) as { content: Array<{ type: string; text: string }> };
+
+      expect(new URL(vi.mocked(fetch).mock.calls[0][0] as string).searchParams.get("fields"))
+        .toContain("url_tags");
+      expect(result.content[0].text).toContain("utm_source=meta");
+    });
+
+    it("strips effective_link_url from caller fields and derives it per creative", async () => {
+      const server = createMockMcpServer();
+      registerCreativeTools(server as never);
+
+      vi.stubGlobal("fetch", vi.fn().mockResolvedValue(mockFetchResponse({
+        data: [{
+          id: "4002",
+          name: "C2",
+          object_story_spec: {
+            page_id: "6001",
+            video_data: {
+              video_id: "8001",
+              call_to_action: { type: "SHOP_NOW", value: { link: "https://byads.co/shop" } },
+            },
+          },
+        }],
+      })));
+
+      const handler = server._registeredTools[0].handler;
+      const result = await handler({
+        ad_id: undefined,
+        account_id: "act_123",
+        limit: 25,
+        fields: ["id", "effective_link_url"],
+      }) as { content: Array<{ type: string; text: string }> };
+
+      expect(new URL(vi.mocked(fetch).mock.calls[0][0] as string).searchParams.get("fields"))
+        .toBe("id,link_url,object_story_spec,asset_feed_spec");
+      expect(result.content[1].text).toContain("\"effective_link_url\": \"https://byads.co/shop\"");
+    });
+  });
+
+  describe("ads_update_ad_creative handler", () => {
+    it("refuses an empty update instead of reporting a false success", async () => {
+      const server = createMockMcpServer();
+      registerCreativeTools(server as never);
+
+      vi.stubGlobal("fetch", vi.fn());
+
+      const handler = server._registeredTools[3].handler;
+      await expect(handler({ creative_id: "4001", name: undefined }))
+        .rejects.toThrow(/immutable/i);
+      await expect(handler({ creative_id: "4001", name: undefined }))
+        .rejects.toThrow(/ads_update_ad_url_tags/);
+
+      expect(vi.mocked(fetch)).not.toHaveBeenCalled();
+    });
+
+    it("updates the creative name", async () => {
+      const server = createMockMcpServer();
+      registerCreativeTools(server as never);
+
+      vi.stubGlobal("fetch", vi.fn().mockResolvedValue(mockFetchResponse({ success: true })));
+
+      const handler = server._registeredTools[3].handler;
+      const result = await handler({
+        creative_id: "4001",
+        name: "Renamed Creative",
+      }) as { content: Array<{ type: string; text: string }> };
+
+      const call = vi.mocked(fetch).mock.calls[0];
+      expect(new URL(call[0] as string).pathname).toMatch(/\/4001$/);
+      expect(call[1]?.method).toBe("POST");
+      expect(new URLSearchParams(call[1]?.body as string).get("name")).toBe("Renamed Creative");
+      expect(result.content[0].text).toContain("updated successfully");
     });
   });
 

--- a/tests/tools/creatives.test.ts
+++ b/tests/tools/creatives.test.ts
@@ -200,6 +200,25 @@ describe("registerCreativeTools", () => {
       expect(fieldsParam).not.toContain("effective_link_url");
     });
 
+    it("strips a synthetic field from an entry that also carries a nested selector", async () => {
+      const server = createMockMcpServer();
+      registerCreativeTools(server as never);
+
+      vi.stubGlobal("fetch", vi.fn().mockResolvedValue(mockFetchResponse({ id: "40782" })));
+
+      const handler = server._registeredTools[1].handler;
+      await handler({
+        creative_id: "40782",
+        fields: ["id,effective_link_url,object_story_spec{link_data,name}"],
+      });
+
+      const fieldsParam = new URL(vi.mocked(fetch).mock.calls[0][0] as string)
+        .searchParams.get("fields");
+      expect(fieldsParam).not.toContain("effective_link_url");
+      expect(fieldsParam).toContain("object_story_spec{link_data,name}");
+      expect(fieldsParam).toContain("link_url");
+    });
+
     it("keeps nested field selectors intact", async () => {
       const server = createMockMcpServer();
       registerCreativeTools(server as never);

--- a/tests/tools/creatives.test.ts
+++ b/tests/tools/creatives.test.ts
@@ -182,6 +182,40 @@ describe("registerCreativeTools", () => {
       expect(result.content[0].text).toContain("Link URL: https://byads.co/promo");
     });
 
+    it("strips a synthetic field hidden inside a comma-joined entry", async () => {
+      const server = createMockMcpServer();
+      registerCreativeTools(server as never);
+
+      vi.stubGlobal("fetch", vi.fn().mockResolvedValue(mockFetchResponse({ id: "40780" })));
+
+      const handler = server._registeredTools[1].handler;
+      await handler({
+        creative_id: "40780",
+        fields: ["id,name,effective_link_url"],
+      });
+
+      const fieldsParam = new URL(vi.mocked(fetch).mock.calls[0][0] as string)
+        .searchParams.get("fields");
+      expect(fieldsParam).toBe("id,name,link_url,object_story_spec,asset_feed_spec");
+      expect(fieldsParam).not.toContain("effective_link_url");
+    });
+
+    it("keeps nested field selectors intact", async () => {
+      const server = createMockMcpServer();
+      registerCreativeTools(server as never);
+
+      vi.stubGlobal("fetch", vi.fn().mockResolvedValue(mockFetchResponse({ id: "40781" })));
+
+      const handler = server._registeredTools[1].handler;
+      await handler({
+        creative_id: "40781",
+        fields: ["object_story_spec{link_data,video_data}", "name"],
+      });
+
+      expect(new URL(vi.mocked(fetch).mock.calls[0][0] as string).searchParams.get("fields"))
+        .toBe("object_story_spec{link_data,video_data},name");
+    });
+
     it("does not duplicate source fields already requested by the caller", async () => {
       const server = createMockMcpServer();
       registerCreativeTools(server as never);

--- a/tests/tools/registration.test.ts
+++ b/tests/tools/registration.test.ts
@@ -3,14 +3,15 @@ import { registerAllTools } from "../../src/tools/index.js";
 import { createMockMcpServer } from "../setup.js";
 
 describe("registerAllTools", () => {
-  it("registers exactly 124 tools total", () => {
+  it("registers exactly 125 tools total", () => {
     // 79 v2 tools renamed (with account_insights removed → 79) + 14 new in v3 +
     //   3 audience-sharing tools (share / unshare / get-shared-accounts) +
     //   1 invoices tool (ads_get_invoices) +
-    //   27 WhatsApp Business tools (whatsapp_*).
+    //   27 WhatsApp Business tools (whatsapp_*) +
+    //   1 UTM editing tool (ads_update_ad_url_tags).
     const server = createMockMcpServer();
     registerAllTools(server as never);
-    expect(server.registerTool).toHaveBeenCalledTimes(124);
+    expect(server.registerTool).toHaveBeenCalledTimes(125);
   });
 
   it("registers all tools with unique names", () => {
@@ -100,6 +101,7 @@ describe("registerAllTools", () => {
     expect(names).toContain("ads_create_campaign");
     expect(names).toContain("ads_get_insights");
     expect(names).toContain("ads_get_creative_details");
+    expect(names).toContain("ads_update_ad_url_tags");
     expect(names).toContain("ads_clone_ad_set_bundle");
 
     // Token management tools

--- a/tests/utils/validation.test.ts
+++ b/tests/utils/validation.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { requireOneOf, buildFieldsParam } from "../../src/utils/validation.js";
+import { requireOneOf, buildFieldsParam, normalizeUrlTags } from "../../src/utils/validation.js";
 
 describe("requireOneOf", () => {
   it("does not throw when at least one field is present", () => {
@@ -62,5 +62,33 @@ describe("buildFieldsParam", () => {
 
   it("handles single field", () => {
     expect(buildFieldsParam(["id"], ["id", "name"])).toBe("id");
+  });
+});
+
+describe("normalizeUrlTags", () => {
+  it("leaves a plain query string untouched", () => {
+    expect(normalizeUrlTags("utm_source=meta&utm_medium=paid")).toBe(
+      "utm_source=meta&utm_medium=paid",
+    );
+  });
+
+  it("strips a single leading question mark", () => {
+    expect(normalizeUrlTags("?utm_source=meta")).toBe("utm_source=meta");
+  });
+
+  it("strips only one question mark", () => {
+    expect(normalizeUrlTags("??utm_source=meta")).toBe("?utm_source=meta");
+  });
+
+  it("trims surrounding whitespace before stripping", () => {
+    expect(normalizeUrlTags("  ?utm_source=meta  ")).toBe("utm_source=meta");
+  });
+
+  it("returns an empty string unchanged", () => {
+    expect(normalizeUrlTags("")).toBe("");
+  });
+
+  it("returns an empty string for whitespace only", () => {
+    expect(normalizeUrlTags("   ")).toBe("");
   });
 });


### PR DESCRIPTION
## Why

A client auditing UTMs across ~66 creatives hit this on every call:

```
ads_get_creative_details { fields: ["id","name","url_tags","effective_link_url"] }
→ MCP error -32602: Invalid parameter: (#100) Tried accessing nonexisting field (effective_link_url)
```

**Root cause:** `effective_link_url` is not a Graph API field. This server derives it locally (`extractEffectiveLinkUrl`) and injects it into creative responses — so clients learn the name from our own output, ask for it back, and `buildFieldsParam` forwards it verbatim to Meta. The server was teaching a field it then refused to accept. (PR #91 removed it from `CREATIVE_DEFAULT_FIELDS`; the caller-supplied path stayed open.)

Editing UTMs had no path at all. Verified against Meta's docs: `POST /{creative_id}` only updates `account_id/adlabels/name/status`, and the Ad object has no `url_tags` field. In-place editing is therefore copy-on-write — the same thing Ads Manager does under the hood, which is why the ad re-enters review.

## What changed

**`effective_link_url` is now a virtual field.** Both creative read tools strip it from the Graph request, request its sources (`link_url`, `object_story_spec`, `asset_feed_spec`) instead, and still return the derived value. The call that used to fail now works.

**`ads_update_ad_url_tags`** (new, 1–50 ads per call). Clones each ad's creative with the new `url_tags` and repoints the ad. Every strategy re-references the source **wholesale** rather than rebuilding it field by field — reading real creatives showed a destination link that is not readable back at all, so reconstruction would have produced ads pointing nowhere:

- **Facebook post** (`object_story_id`) — preserves likes and comments
- **Creative spec** (`object_story_spec`)
- **Instagram post** (`source_instagram_media_id`)

Fields living beside the story are carried explicitly: `link_url`, `degrees_of_freedom_spec` (dropping it would silently reset Advantage+ creative enhancements), `adlabels`, and a rebuilt `call_to_action` for Instagram creatives, which store their CTA on the creative rather than the post.

Ads sharing a creative mint one replacement. Matching tags are skipped, so re-running converges. `url_tags: ""` removes tags, a leading `?` is stripped, `dry_run: true` previews. Dynamic (`asset_feed_spec`) creatives are reported as skipped, never silently altered. The response reports every ad as updated / skipped / failed and warns about re-review.

**Empty updates no longer report false success** — `ads_update_ad_creative` without `name` and `ads_update_ad` with no updatable field used to POST an empty body and answer "updated successfully".

**Reads surface UTMs** — `url_tags` in the creative defaults and a `fields` param on `ads_get_ad_creatives`, so an account-wide UTM audit is one call.

## Review

Two independent adversarial reviews ran before this PR; both returned findings, all addressed:

- **CTA erased on Instagram creatives** — `call_to_action_type` is readable but not creatable; the `call_to_action` *object* is what Meta accepts. Now rebuilt.
- **Synthetic field still leaked** — an entry like `"id,effective_link_url,object_story_spec{link_data,name}"` contains braces, so it was kept whole and reached Meta, reproducing the same #100. Splitting now tracks brace depth.
- **Ad labels dropped**, pulling creatives out of agency reporting views. Now carried.
- **Repoint false negatives** — a lost response was reported as failure while the ad may have moved. The ad is now read back to separate confirmed / failed / unknown.
- Weak assertions strengthened; repeated `ad_ids` deduped.

**Deliberately not adopted:** a persisted idempotency key for creative creation. The clone-bundle tool needs one because a replay duplicates *ads*, which spend; here a replay leaves an unused creative that never delivers and whose id is reported. The limitation and a concurrency caveat are documented on the tool instead.

## Verification

`npm run lint`, `npm run typecheck`, `npm test` (480 passing), `npm run build` — all green. `gitleaks` clean across all 3 commits. No new tools beyond the one (124 → 125, counters updated in `src/tools/index.ts`, README and `registration.test.ts`). No version bump — that belongs to the release commit.

Mocks pin request shape, not Meta's semantics, so after deploy: (a) `ads_get_creative_details` with `fields:["effective_link_url"]`; (b) `ads_update_ad_url_tags` with `dry_run: true` over a few real ads; (c) one paused ad end-to-end, confirming re-review and the new UTMs on the click URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)