### PR TITLE
chore: version the pre-deploy guard in the repo and close its blind spots

### DIFF
--- a/.github/pre-deploy-guard/README.md
+++ b/.github/pre-deploy-guard/README.md
@@ -1,0 +1,66 @@
+# pre-deploy-guard
+
+Local validation that runs before a commit, push or deploy leaves your machine.
+
+This repo is public and a push to `main` deploys to Cloud Run, so a leaked token is permanent and a broken commit ships. [CI](../workflows/ci.yml) catches both server-side; this guard catches them seconds earlier, before anything is published.
+
+## Run it without Claude Code
+
+The scripts are plain bash and need no agent:
+
+```bash
+bash .github/pre-deploy-guard/scripts/quick-checks.sh   # before a commit  (~10s)
+bash .github/pre-deploy-guard/scripts/run-checks.sh     # before a push    (1-5 min)
+```
+
+Both exit non-zero on any finding and print a `PASS / FAIL / SKIP` summary naming each failure.
+
+| Check | quick | full |
+|---|:--:|:--:|
+| Prohibited files staged (`.env`, `*.key`, `*.pem`, service accounts) | ● | ● |
+| `.gitignore` covers those paths | | ● |
+| Custom regex secret scan ([scan-secrets.sh](scripts/scan-secrets.sh)) | ● | ● |
+| gitleaks on the staged diff | ● | ● |
+| `npm run lint` / `typecheck` / `test` / `build` | typecheck only | ● |
+
+Requires [gitleaks](https://github.com/gitleaks/gitleaks) (`brew install gitleaks`); the step is skipped with a warning if it is absent.
+
+## Install the Claude Code integration
+
+```bash
+cp -r .github/pre-deploy-guard ~/.claude/skills/
+cp .github/pre-deploy-guard/agent.md ~/.claude/agents/pre-deploy-guard.md
+```
+
+Then register the hook in `~/.claude/settings.json`:
+
+```json
+"hooks": {
+  "PreToolUse": [
+    {
+      "matcher": "Bash",
+      "hooks": [
+        { "type": "command", "command": "/Users/<you>/.claude/skills/pre-deploy-guard/scripts/hook-gate.sh" }
+      ]
+    }
+  ]
+}
+```
+
+[hook-gate.sh](scripts/hook-gate.sh) intercepts `git commit -m`, `git push`, `gcloud run deploy`, `docker push` and `npm publish`, runs the matching mode, and denies the call with the failure output when anything fails. It also refuses any guarded command carrying `--no-verify`.
+
+**Opt-in is per repo**, via the marker file `.github/pre-deploy-guard.enabled`. That file is committed here, so the hook is active in this repo and silently inert everywhere else — installing it will not interfere with your other projects.
+
+## What it looks for
+
+[references/sensitive-patterns.md](references/sensitive-patterns.md) documents every pattern: what it identifies, the blast radius if it leaks, and a rotation playbook. Read it when a finding lands — rotation order matters, and for `TOKEN_ENCRYPTION_KEY` a re-encryption migration has to run before the new key is deployed.
+
+Two independent layers scan for secrets, deliberately: gitleaks with the repo [.gitleaks.toml](../../.gitleaks.toml) (`EAA` tokens from 40 chars, to stay quiet on test fixtures) and the custom scanner (from 20 chars, tighter). A finding from either one blocks.
+
+## If the guard fails
+
+Fix the cause. Never `--no-verify`, never `git push -f` over a finding.
+
+A secret finding means the value is **already compromised**, even if the commit never lands — local environments leak through swap, IDE indexes and container logs. Rotate at the source first, then remove the value from the working tree, then re-stage and re-run.
+
+For a genuine false positive, add a precise rule to the `.gitleaks.toml` allowlist or to the `ALLOWLIST` array in [scan-secrets.sh](scripts/scan-secrets.sh), and include that change in the same review so it gets scrutiny.

--- a/.github/pre-deploy-guard/SKILL.md
+++ b/.github/pre-deploy-guard/SKILL.md
@@ -1,0 +1,136 @@
+---
+name: pre-deploy-guard
+description: Use BEFORE running git commit, git push, gcloud run deploy, docker push, or npm publish on a public/open-source repo. Verifies lint, typecheck, tests and build pass AND that no sensitive data (API keys, tokens, .env files, credentials, private keys) is being committed. ALWAYS invoke this skill when the user mentions committing, pushing, deploying, releasing, or shipping code on this repo (meta-ads-mcp) or any repo that has `.github/pre-deploy-guard.enabled`. Critical safety check; do not skip even for "small" or "doc-only" changes — secrets routinely leak through README edits, debug logs, or test fixtures.
+---
+
+# Pre-deploy Guard
+
+This skill protects public open-source repositories from two preventable disasters:
+
+1. **Secret leakage** — once a token, API key or credential is pushed to a public branch, treat it as compromised forever. Rotation is mandatory; deletion of history is best-effort.
+2. **Broken main** — for `meta-ads-mcp` specifically, a push to `main` triggers a Cloud Run deploy. There is no PR gate by default, so a broken commit ships to production.
+
+The skill works in concert with three other pieces; understand the picture before touching them:
+
+| Layer | What it does | Where it lives |
+|---|---|---|
+| `CLAUDE.md` rule | Stating the policy so any agent reading the repo follows it | committed in repo root |
+| **This skill** | The playbook for *how* to validate when about to commit/push/deploy | `~/.claude/skills/pre-deploy-guard/` |
+| `pre-deploy-guard` agent | A subagent that runs the same audit and returns a structured report | `~/.claude/agents/pre-deploy-guard.md` |
+| Hook (`hook-gate.sh`) | PreToolUse hook that *blocks* offending Bash calls | `~/.claude/settings.json` |
+| `ci.yml` workflow | Server-side defense that runs on every PR/push | `.github/workflows/ci.yml` |
+
+## When to activate
+
+Activate this skill **before** Claude executes any of the following Bash patterns:
+
+- `git commit -m …`, `git commit -am …`, `git commit --message …`
+- `git push …` (any remote)
+- `gcloud run deploy …`, `gcloud run services replace …`
+- `docker push …`
+- `npm publish`, `pnpm publish`, `yarn publish`
+- `gh pr merge …` (publishing the work)
+
+The hook will *also* try to block these calls automatically — but the skill exists so Claude understands *why* the block happened, *what* to do, and how to handle false positives without bypassing safety.
+
+If the user says things like "commit and push", "ship it", "deploy", "release", "merge to main": activate this skill **before** you start running git/deploy commands.
+
+## Two modes
+
+| Mode | When | Script | What it runs |
+|---|---|---|---|
+| **quick** | before `git commit -m` | `scripts/quick-checks.sh` | file guard, custom regex secret scan, gitleaks --staged, typecheck. Target <10s. |
+| **full** | before `git push`, `gcloud run deploy`, `docker push`, `npm publish` | `scripts/run-checks.sh` | quick checks **plus** lint, full test suite, build. Can take 1-5 min. |
+
+Default to **quick** for commits and **full** for pushes/deploys. If the diff being committed is large (>500 LOC) or touches `src/auth/`, `src/transport/security-config.ts`, or other security surface, escalate to **full** even on commit.
+
+## Procedure
+
+1. **Identify mode** from the user intent (commit → quick; push/deploy/publish → full).
+2. **Run the script** from the repo root:
+
+   ```bash
+   bash ~/.claude/skills/pre-deploy-guard/scripts/quick-checks.sh
+   # or
+   bash ~/.claude/skills/pre-deploy-guard/scripts/run-checks.sh
+   ```
+
+   These scripts auto-detect git repo, package.json, and tsconfig presence. They're safe to run on any project (no-op outside git repos).
+
+3. **Read the summary block at the bottom** (`PASS / FAIL / SKIP` counts plus a `Blocking failures` list when applicable). Each failure is named so you can map it back to a fix.
+
+4. **If exit code is 0** → report briefly to the user ("pre-deploy-guard: all checks passed (mode=quick)") and proceed with the original git/deploy command.
+
+5. **If exit code is non-zero** → STOP. Do **not** attempt to bypass with `--no-verify`, `git push -f`, or any other escape hatch. Report the failures to the user. Then:
+
+   - **If failure is `prohibited files staged`** (e.g. `.env`, `*.key`): the user almost certainly added it by mistake. Suggest `git restore --staged <file>` and ensure it's covered by `.gitignore`. Do **not** delete the file from disk without confirming.
+   - **If failure is a secret detection** (`gitleaks reported findings` or `custom regex scanner found secrets`): treat the secret as **already compromised** even if the commit hasn't landed yet — local environments leak through swap, IDE indexes, container logs. Tell the user to:
+     1. Rotate the credential at the source (Meta App console, OAuth provider, GCP IAM, etc.).
+     2. Then remove the value from the working tree (use a placeholder or load from `.env`).
+     3. Then re-stage and re-run the guard.
+     The skill `references/sensitive-patterns.md` has rotation playbooks per credential type.
+   - **If failure is `npm run lint` / `typecheck` / `test` / `build`**: it's a regular CI failure. Investigate, fix the underlying issue, re-run the guard.
+
+6. **For false positives** (gitleaks flags a value that genuinely isn't a secret): edit `.gitleaks.toml` `[allowlist]` and add a precise pattern or path-level exclusion. Commit that change as part of the same review. **Never** add `--no-verify` or globally disable a rule.
+
+## When to delegate to the agent
+
+If the diff is large (rough rule of thumb: >500 added lines, or touches >15 files), invoke the `pre-deploy-guard` subagent with the Agent tool instead of running the script in the foreground:
+
+```
+Agent({
+  description: "Pre-deploy audit",
+  subagent_type: "pre-deploy-guard",
+  prompt: "Audit the staged changes on branch <name> in <path-to>/meta-ads-mcp. Run the full validation. Report PASS/FAIL with findings."
+})
+```
+
+The subagent runs in its own context window, so its output (which can be very long for big diffs) doesn't pollute the main conversation. The subagent returns a single structured report you can relay to the user.
+
+## Patterns watched
+
+The custom regex scanner (`scripts/scan-secrets.sh`) watches for these in the staged diff. Full descriptions in `references/sensitive-patterns.md`.
+
+| Name | Matches | Why it matters |
+|---|---|---|
+| `META_APP_SECRET=` | Meta app secret assignment | Lets attacker impersonate the app, mint OAuth tokens for any user. |
+| `EAA[A-Za-z0-9]{20,}` | Meta long-lived access token | Reads/writes ad accounts on the user's behalf. |
+| `OAUTH_SECRET=` | This server's JWT signing key | Attacker can mint MCP session tokens for any user. |
+| `TOKEN_ENCRYPTION_KEY=` (64 hex) | AES-256-GCM key for tokens-at-rest | Decrypts every Meta token in Firestore. |
+| `SESSION_COOKIE_SECRET=` | Cookie signing secret | Forge user sessions. |
+| `MCP_API_KEY=` | Service-to-service key | Bypass OAuth entirely. |
+| `META_TOKENS` (JSON map of `EAA…` tokens) | Multi-tenant token map | Mass compromise. |
+| `ya29\....` | Google OAuth access token | GCP API access. |
+| `AIza[A-Za-z0-9_-]{35}` | Google API key | GCP/Firebase API access. |
+| `-----BEGIN … PRIVATE KEY-----` | Any private key block | Service account, RSA, EC keys. |
+| `gh[pousr]_` | GitHub PAT/app token | Repo write/admin. |
+| `AKIA[0-9A-Z]{16}` | AWS access key | Cloud account access. |
+
+Plus everything `gitleaks` default ruleset catches (Stripe, Slack, Twilio, Datadog, etc.).
+
+The custom scanner skips `.env.example`, lock files, `.gitleaks.toml` and itself by path, and skips any line containing `fixture`, `placeholder`, `YOUR_` or `gitleaks:allow`. There is no blanket `tests/**` exemption — a realistic-looking fixture must carry one of those markers. gitleaks honours the `.gitleaks.toml` allowlist.
+
+## Why this matters (so you can explain to the user)
+
+`meta-ads-mcp` is a public OSS server that holds Meta API tokens for many advertisers. The threat model is clear:
+
+- **`META_APP_SECRET` leak**: Meta forces app re-auth, every user must reconnect. Ops nightmare.
+- **`OAUTH_SECRET` leak**: every issued MCP session token is forgeable. All users must be invalidated.
+- **`TOKEN_ENCRYPTION_KEY` leak**: Firestore is now plaintext. Every advertiser's tokens are exposed. Catastrophic.
+- **GCP service account leak**: attacker can deploy malicious revisions to Cloud Run, read Firestore directly, escalate via IAM.
+
+These aren't hypothetical: credential leaks through public repositories are common enough that GitHub runs secret scanning by default. Treat the guard as the last line of defense between Claude and a postmortem.
+
+## Files in this skill
+
+```
+~/.claude/skills/pre-deploy-guard/
+├── SKILL.md                            # this file
+├── scripts/
+│   ├── run-checks.sh                   # full audit
+│   ├── quick-checks.sh                 # fast pre-commit audit
+│   ├── scan-secrets.sh                 # custom regex scanner
+│   └── hook-gate.sh                    # PreToolUse hook entrypoint
+└── references/
+    └── sensitive-patterns.md           # detail per pattern + rotation playbooks
+```

--- a/.github/pre-deploy-guard/agent.md
+++ b/.github/pre-deploy-guard/agent.md
@@ -1,0 +1,91 @@
+---
+name: pre-deploy-guard
+description: Specialist for thorough pre-deploy / pre-commit auditing of public OSS repos. Verifies build/test/lint/typecheck pass, scans for leaked secrets (gitleaks + custom regex), checks staged files against a prohibited list, and validates .gitignore coverage. Use PROACTIVELY before any git push, gcloud run deploy, docker push, or npm publish on a public/open-source repository — particularly meta-ads-mcp.
+tools: Read, Bash, Grep
+model: sonnet
+---
+
+You are a pre-deploy safety auditor for public open-source repositories. Your job is to determine, with high confidence, whether the current working tree is safe to commit, push, or deploy.
+
+## What you check
+
+Run `~/.claude/skills/pre-deploy-guard/scripts/run-checks.sh` from the repo root. The script covers:
+
+1. **File guard** — no `.env`, `*.key`, `*.pem`, `credentials.json`, `service-account*.json`, or SSH private keys in the staging area.
+2. **`.gitignore` guard** — required ignore entries are present.
+3. **`npm run lint`** (if defined).
+4. **`npm run typecheck`** (if defined).
+5. **`npm test`** (if defined; runs with `CI=1`).
+6. **`npm run build`** (if defined).
+7. **Custom regex secret scan** on the staged diff via `scripts/scan-secrets.sh` — covers Meta tokens (`META_APP_SECRET`, `META_ACCESS_TOKEN` / `EAA…`, `META_TOKENS`), OAuth (`OAUTH_SECRET`, `OAUTH_APPROVAL_PIN`, `SESSION_COOKIE_SECRET`), encryption (`TOKEN_ENCRYPTION_KEY`), service keys (`MCP_API_KEY`), Google (`AIza…`, `ya29.…`, GCP service accounts), GitHub PATs, AWS keys, generic private key blocks.
+8. **gitleaks** with `.gitleaks.toml` config when present, default rules otherwise.
+
+## Operating rules
+
+- **Read-only audit by default.** Do **not** edit code, do **not** run `git commit`/`push`/`deploy`. You exist to report.
+- The user prompt may explicitly grant you scope to fix trivial things (e.g. "add the missing .gitignore entry"). Only do that when explicitly instructed.
+- If the repo doesn't have one of the npm scripts, that step is `[SKIP]` and is **not** a failure.
+- If `gitleaks` isn't installed and `npx` isn't available, that step is `[SKIP]`. Report this to the user — they should install gitleaks for full coverage. Do not treat the skip as a pass.
+- **Never** suggest `--no-verify`, `git push -f` over a finding, or disabling rules globally. False positives are handled via a precise `.gitleaks.toml` allowlist or a fix to the underlying code.
+
+## How to invoke the validation
+
+```bash
+cd "$REPO_ROOT"
+bash ~/.claude/skills/pre-deploy-guard/scripts/run-checks.sh
+```
+
+Capture stdout+stderr together. The script prints `[OK] / [FAIL] / [SKIP]` per step and a summary. Exit code 0 means everything that ran passed; non-zero means at least one blocking failure.
+
+For git diff stats (to size up the change before running), use:
+```bash
+git diff --cached --stat
+git diff --cached --name-only --diff-filter=ACMR
+```
+
+## Required output structure
+
+Always emit a report that follows this exact shape so the calling agent can parse it consistently:
+
+```
+## Status: PASS | FAIL
+
+## Steps
+| Step                          | Result | Notes              |
+|-------------------------------|--------|--------------------|
+| File guard                    | OK     |                    |
+| .gitignore guard              | OK     |                    |
+| npm run lint                  | OK     |                    |
+| npm run typecheck             | OK     |                    |
+| npm test                      | OK     | 47 tests, 0 fail   |
+| npm run build                 | OK     |                    |
+| Custom regex secret scan      | OK     |                    |
+| gitleaks                      | OK     |                    |
+
+## Findings
+(Empty when PASS. When FAIL, one entry per finding:)
+- **<step name>** — <file:line> — <short reason>
+  Detail: <copy the relevant excerpt of the script output, redacted if it contains a secret>
+  Suggested fix: <concrete next step — e.g. "remove .env.test from staging via `git restore --staged .env.test`" or "rotate META_APP_SECRET and replace with a placeholder">
+
+## Next actions
+- (When PASS) "Safe to proceed with `git push origin <branch>`."
+- (When FAIL) Numbered list of fix steps in execution order.
+- Mention any [SKIP] steps the user should be aware of (e.g. "gitleaks was skipped — install via brew or run with npx for stronger coverage").
+```
+
+## Edge cases
+
+- **Empty staged tree** — the script reports `nothing to commit`. Treat as PASS with a note ("no staged changes; nothing to validate").
+- **Detached HEAD or rebase in progress** — note it but still run the audit. Mention it in `Next actions` so the user knows to finish the rebase first.
+- **Massive diff (>1000 LOC, multi-package)** — the run can take minutes. Tell the user up front via your first text output that you're running the full suite and approximately how long it'll take. Don't try to short-circuit.
+- **Repeated false positives** for the same string across multiple files — recommend updating `.gitleaks.toml` allowlist with a single rule rather than adding many path exclusions.
+
+## What you specifically know about meta-ads-mcp
+
+The canonical repo this guard was built for is `<path-to>/meta-ads-mcp`. It's:
+- A Node 20+ TypeScript MCP server that brokers Meta Ads API access via OAuth.
+- Deployed to Cloud Run; encrypted Meta tokens live in Firestore.
+- Public on GitHub. **Anything sensitive in a commit is a real incident.**
+
+Sensitive variables (per `.env.example`): `META_APP_SECRET`, `META_ACCESS_TOKEN`, `META_TOKENS`, `OAUTH_SECRET`, `OAUTH_APPROVAL_PIN`, `SESSION_COOKIE_SECRET`, `TOKEN_ENCRYPTION_KEY`, `MCP_API_KEY`. The `.github/pre-deploy-guard/references/sensitive-patterns.md` file has full descriptions and rotation steps — read it if a finding lands on one of these and the user needs guidance.

--- a/.github/pre-deploy-guard/references/sensitive-patterns.md
+++ b/.github/pre-deploy-guard/references/sensitive-patterns.md
@@ -1,0 +1,118 @@
+# Sensitive patterns reference
+
+Detail for each pattern the guard watches: what it identifies, blast radius if leaked, and a rotation playbook. Use this when you need to explain to the user *why* a finding matters and *how* to recover.
+
+## Meta / Facebook
+
+### `META_APP_SECRET`
+- **Regex**: `(?i)META_APP_SECRET\s*=\s*["']?[A-Za-z0-9]{16,}`
+- **What**: The Facebook App Secret used in OAuth flows and to verify Meta webhook signatures.
+- **Blast radius**: An attacker with `META_APP_ID` + `META_APP_SECRET` can impersonate the application, exchange short-lived tokens, and request user-scoped tokens for anyone who has authorized the app — effectively reading/writing ad accounts on their behalf.
+- **Rotation**:
+  1. developers.facebook.com → App → Settings → Basic → Reset App Secret.
+  2. Update Cloud Run env var (`OAUTH_SECRET` is **different** — don't confuse them).
+  3. Notify users that re-auth may be required if you change the OAuth flow at the same time.
+
+### `META_ACCESS_TOKEN` / Long-lived user tokens (`EAA…`)
+- **Regex**: `EAA[A-Za-z0-9]{20,}`
+- **What**: Meta access tokens. The `EAA` prefix is the Graph API token format.
+- **Blast radius**: Direct API access on behalf of the token's owner — read/write campaigns, fetch private insights, post on owned pages.
+- **Rotation**: Revoke at developers.facebook.com → Tools → Access Token Debugger → Revoke. The user must re-authorize.
+
+### `META_TOKENS` (multi-tenant map)
+- **Regex**: `META_TOKENS\s*=\s*["']?\{[^}]*EAA`
+- **What**: JSON map of `{ "agency_a": "EAA...", ... }` for the legacy multi-tenant fallback.
+- **Blast radius**: Mass compromise of every advertiser whose token is in the map. Worst-case scenario.
+- **Rotation**: Revoke each token individually. Never store this as JSON in code; use Firestore.
+
+## OAuth / session
+
+### `OAUTH_SECRET`
+- **Regex**: `(?i)OAUTH_SECRET\s*=\s*["']?[A-Za-z0-9+/=]{32,}`
+- **What**: This server's secret for signing MCP OAuth JWTs (`src/auth/oauth-provider.ts`).
+- **Blast radius**: An attacker who has this secret can mint valid MCP session tokens for any user the server knows about. Total compromise of the auth boundary.
+- **Rotation**:
+  1. Generate a new value: `openssl rand -hex 32`.
+  2. Set in Cloud Run env var.
+  3. **All existing sessions become invalid** — users must re-authorize. Communicate this in advance.
+
+### `OAUTH_APPROVAL_PIN`
+- **Regex**: `(?i)OAUTH_APPROVAL_PIN\s*=\s*["']?[A-Za-z0-9]{6,}`
+- **What**: Out-of-band approval PIN gating new OAuth client registrations.
+- **Blast radius**: Attacker can register arbitrary OAuth clients against the server, increasing attack surface.
+- **Rotation**: Generate new random value, update Cloud Run env, communicate to admins via secure channel.
+
+### `SESSION_COOKIE_SECRET`
+- **Regex**: `(?i)SESSION_COOKIE_SECRET\s*=\s*["']?[A-Za-z0-9+/=]{32,}`
+- **What**: Secret for signing browser session cookies during the Meta OAuth flow.
+- **Blast radius**: Forge user sessions during OAuth handshake — can impersonate any in-flight authenticating user.
+- **Rotation**: `openssl rand -base64 32` → Cloud Run env. Existing flows in progress will fail and users will need to retry.
+
+## Encryption
+
+### `TOKEN_ENCRYPTION_KEY`
+- **Regex**: `(?i)TOKEN_ENCRYPTION_KEY\s*=\s*["']?[A-Fa-f0-9]{64}`
+- **What**: AES-256-GCM key encrypting Meta tokens at rest in Firestore (`src/auth/crypto.ts`, `src/auth/token-store.ts`).
+- **Blast radius**: **Catastrophic.** With this key, anyone with read access to Firestore can decrypt every advertiser's Meta token. Even if Firestore itself is locked down, the value being public means a future Firestore read (e.g. via a different vulnerability) becomes a token theft.
+- **Rotation**:
+  1. Generate new key: `openssl rand -hex 32`.
+  2. Implement (or use existing) re-encryption migration: read every doc, decrypt with old key, encrypt with new key, write back.
+  3. Roll out new key as Cloud Run env var **after** migration completes.
+  4. Until the migration runs, treat all existing tokens as compromised — ideally force re-auth.
+
+## Internal API
+
+### `MCP_API_KEY`
+- **Regex**: `(?i)MCP_API_KEY\s*=\s*["']?[A-Za-z0-9]{20,}`
+- **What**: Service-to-service API key that bypasses OAuth entirely.
+- **Blast radius**: Direct access to the MCP tool surface as a fully-authenticated client. No user consent required.
+- **Rotation**: Generate new value. Update both server and any client services calling with the old key. Old key invalidated immediately.
+
+## Google Cloud
+
+### `ya29...` OAuth access tokens
+- **Regex**: `ya29\.[0-9A-Za-z_-]{30,}`
+- **What**: Short-lived Google OAuth access tokens.
+- **Blast radius**: Whatever scopes the token had. Often used for `gcloud` CLI tokens — could include project admin access.
+- **Rotation**: Tokens expire in 1 hour, but during that hour they're fully valid. Revoke via `gcloud auth revoke` or the OAuth playground. Investigate how it leaked.
+
+### `AIza...` API keys
+- **Regex**: `AIza[0-9A-Za-z_-]{35}`
+- **What**: Google API keys — Firebase, Maps, generic GCP API access.
+- **Blast radius**: Depends on key restrictions. If unrestricted, potentially any GCP API. If restricted, just the allowed APIs but with the project's quota and billing.
+- **Rotation**: GCP Console → APIs & Services → Credentials → Regenerate or delete the key. Update consuming code.
+
+### Service account JSON / private keys
+- **Regex**: `"private_key":\s*"-----BEGIN` and `-----BEGIN(\s+(RSA|EC|DSA|OPENSSH|PGP))?\s+PRIVATE KEY-----`
+- **What**: Any JSON service-account file or raw PEM private key.
+- **Blast radius**: Full IAM-bound access to whatever the SA can do. For this project, that includes Firestore (read all tokens), Cloud Run (deploy malicious code), Artifact Registry (push poisoned images).
+- **Rotation**: GCP Console → IAM → Service Accounts → revoke the key. Investigate whether it was used. Audit logs in Cloud Logging.
+
+## Other vendor tokens
+
+### GitHub Personal Access Tokens
+- **Regex**: `gh[pousr]_[A-Za-z0-9]{36,}` (`ghp_`, `gho_`, `ghu_`, `ghs_`, `ghr_`)
+- **Blast radius**: Whatever scopes the token has. Often `repo:*` which means write access to all repos the user can access.
+- **Rotation**: github.com → Settings → Developer settings → Personal access tokens → Revoke. Investigate.
+
+### AWS access keys
+- **Regex**: `AKIA[0-9A-Z]{16}`
+- **Blast radius**: Whatever IAM policy is attached to the user/role.
+- **Rotation**: IAM Console → Users → Security credentials → Delete the access key. Audit CloudTrail.
+
+## Generic indicators
+
+### `.env` files in staging
+Any path matching `(^|/)\.env($|\.)` (excluding `.env.example`) is rejected unconditionally. There is no legitimate reason to commit these.
+
+### Private key blocks
+Any line containing `-----BEGIN ... PRIVATE KEY-----` is rejected. Keys belong in secret managers (GCP Secret Manager, AWS Secrets Manager, Vault), not in repos.
+
+---
+
+## After any rotation: post-incident checklist
+
+1. Document the leak in an internal incident report (date, value type, exposure window, suspected/confirmed access).
+2. Audit logs for the affected service for the exposure window. Look for unusual access patterns from unfamiliar IPs/UAs.
+3. If the value was committed (even to a feature branch that wasn't merged), the value is in `git reflog` and any clone. Force-pushing over the commit is *not* sufficient. Consider the value compromised forever.
+4. Update `.gitleaks.toml` and `.github/pre-deploy-guard/scripts/scan-secrets.sh` if the regex didn't catch the leak — file an issue or PR.

--- a/.github/pre-deploy-guard/scripts/hook-gate.sh
+++ b/.github/pre-deploy-guard/scripts/hook-gate.sh
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+# hook-gate.sh — PreToolUse hook entrypoint for Claude Code.
+#
+# Reads the tool-invocation JSON from stdin. If the call is a Bash command
+# performing `git commit` (with -m/--message/-am), `git push`, or one of a
+# few deploy commands *inside an opted-in repo*, this script runs the
+# pre-deploy validation suite. If anything fails, it emits a JSON
+# `permissionDecision: "deny"` so Claude cannot run the action.
+#
+# Opt-in mechanism (any of):
+#   - the repo contains a marker file `.github/pre-deploy-guard.enabled`
+#
+# Anywhere else: silently allow (exit 0 with empty JSON).
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RUN_FULL="$SCRIPT_DIR/run-checks.sh"
+RUN_QUICK="$SCRIPT_DIR/quick-checks.sh"
+
+allow_silent() {
+  printf '{}\n'
+  exit 0
+}
+
+# Emits a deny-decision JSON. The reason text comes from $REASON_FILE so we
+# don't have to escape it for the shell.
+deny_with_reason_file() {
+  local reason_file="$1"
+  REASON_FILE="$reason_file" python3 - <<'PY'
+import json, os, sys
+path = os.environ.get("REASON_FILE", "")
+try:
+    with open(path, "r") as f:
+        reason = f.read()[:3500]
+except Exception:
+    reason = "pre-deploy-guard blocked the command (reason file unavailable)."
+print(json.dumps({
+    "hookSpecificOutput": {
+        "hookEventName": "PreToolUse",
+        "permissionDecision": "deny",
+        "permissionDecisionReason": reason,
+    }
+}))
+PY
+  exit 0
+}
+
+deny_with_text() {
+  local text="$1"
+  local f
+  f="$(mktemp -t pdg-reason.XXXXXX)" || {
+    printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"pre-deploy-guard blocked this command and could not write the reason file."}}\n'
+    exit 0
+  }
+  printf '%s' "$text" > "$f"
+  trap 'rm -f "$f"' EXIT
+  deny_with_reason_file "$f"
+}
+
+# ── 1. Read tool input ──────────────────────────────────────────────
+if [ -t 0 ]; then
+  allow_silent
+fi
+
+INPUT="$(cat)"
+[ -z "$INPUT" ] && allow_silent
+
+# Parse tool_name and tool_input.command via python. We write the result to a
+# temp file with a header line for the tool name and the rest of the file as
+# the verbatim command (preserves any newlines).
+PARSE_OUT="$(mktemp -t pdg-parse.XXXXXX)" || deny_with_text \
+  "pre-deploy-guard: could not create a temp file to inspect this command. Refusing to allow it unvalidated; free some disk/TMPDIR space and retry."
+printf '%s' "$INPUT" | python3 -c '
+import json, sys
+try:
+    data = json.load(sys.stdin)
+except Exception:
+    sys.exit(0)
+tool = (data.get("tool_name") or "").strip()
+cmd  = ""
+ti   = data.get("tool_input")
+if isinstance(ti, dict):
+    cmd = ti.get("command") or ""
+with open(sys.argv[1], "w") as f:
+    f.write(tool + "\n")
+    f.write(cmd)
+' "$PARSE_OUT" 2>/dev/null
+
+if [ ! -s "$PARSE_OUT" ]; then
+  rm -f "$PARSE_OUT"
+  allow_silent
+fi
+
+TOOL_NAME="$(head -n 1 "$PARSE_OUT")"
+COMMAND="$(tail -n +2 "$PARSE_OUT")"
+rm -f "$PARSE_OUT"
+
+[ "$TOOL_NAME" = "Bash" ] || allow_silent
+[ -z "$COMMAND" ] && allow_silent
+
+# ── 2. Decide which gate to run based on the command ────────────────
+MODE=""
+case "$COMMAND" in
+  *"git commit"*"-m"*|*"git commit"*"--message"*|*"git commit"*"-am"*|*"git commit"*"-a -m"*)
+    MODE="quick" ;;
+  *"git push"*)
+    MODE="full" ;;
+  *"gcloud run deploy"*|*"gcloud run services replace"*|*"gcloud run services update"*"--image"*)
+    MODE="full" ;;
+  *"docker push"*)
+    MODE="full" ;;
+  *"npm publish"*|*"pnpm publish"*|*"yarn publish"*)
+    MODE="full" ;;
+  *)
+    allow_silent ;;
+esac
+
+# ── 3. Determine if cwd opted in ────────────────────────────────────
+ROOT="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+[ -z "$ROOT" ] && allow_silent
+
+if [ ! -f "$ROOT/.github/pre-deploy-guard.enabled" ]; then
+  allow_silent
+fi
+
+# Only after opt-in: blocking this globally would make the hook anything but
+# inert in the user's other repositories.
+case "$COMMAND" in
+  *"--no-verify"*)
+    deny_with_text "pre-deploy-guard: refusing to run a git command with --no-verify in this repo. It bypasses local validation and can leak secrets. Re-run without --no-verify and let the guard finish its checks." ;;
+esac
+
+# ── 4. Run the gate ─────────────────────────────────────────────────
+cd "$ROOT" || allow_silent
+OUT="$(mktemp -t pdg-out.XXXXXX)" || deny_with_text \
+  "pre-deploy-guard: could not create a temp file for the validation output. Refusing to allow this command unvalidated."
+trap 'rm -f "$OUT"' EXIT
+
+if [ "$MODE" = "quick" ]; then
+  bash "$RUN_QUICK" >"$OUT" 2>&1
+  RC=$?
+else
+  bash "$RUN_FULL" >"$OUT" 2>&1
+  RC=$?
+fi
+
+if [ "$RC" -eq 0 ]; then
+  allow_silent
+fi
+
+REASON_FILE="$(mktemp -t pdg-reason.XXXXXX)" || deny_with_text \
+  "pre-deploy-guard blocked this command; the validation output could not be written to a temp file."
+{
+  printf 'pre-deploy-guard blocked this command (mode=%s) in %s.\n\n' "$MODE" "$ROOT"
+  printf 'This repo is public; nothing should ship until validation passes.\n\n'
+  printf 'Validation output (tail):\n\n'
+  tail -c 2400 "$OUT"
+  printf '\n\nResolve the failures above. Do NOT bypass with --no-verify; if a finding is a false positive, update .gitleaks.toml allowlist or the underlying code. To re-run manually:\n'
+  printf '  bash %s    # quick (pre-commit)\n' "$RUN_QUICK"
+  printf '  bash %s    # full (pre-push / pre-deploy)\n' "$RUN_FULL"
+} > "$REASON_FILE"
+
+trap 'rm -f "$OUT" "$REASON_FILE"' EXIT
+deny_with_reason_file "$REASON_FILE"

--- a/.github/pre-deploy-guard/scripts/quick-checks.sh
+++ b/.github/pre-deploy-guard/scripts/quick-checks.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# quick-checks.sh — Fast pre-commit validation (<10s target).
+# Skips full test suite and full build. Runs:
+#   1. File guard (staged paths blacklist)
+#   2. Custom regex secret scan on staged diff
+#   3. gitleaks --staged (fast)
+#   4. typecheck (TypeScript projects only)
+#
+# Exits 0 on success, 1 on any blocking failure.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCAN_SECRETS="$SCRIPT_DIR/scan-secrets.sh"
+
+ROOT="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+if [ -z "$ROOT" ]; then
+  echo "[SKIP] Not in a git repository — pre-deploy-guard quick mode does nothing here."
+  exit 0
+fi
+cd "$ROOT"
+
+PASS=0
+FAIL=0
+SKIP=0
+FAILURES=()
+LOG="$(mktemp -t pre-deploy-guard-quick.XXXXXX)"
+trap 'rm -f "$LOG"' EXIT
+
+mark_ok()    { echo "[OK]   $1"; PASS=$((PASS+1)); }
+mark_fail()  { echo "[FAIL] $1"; FAIL=$((FAIL+1)); FAILURES+=("$1"); }
+mark_skip()  { echo "[SKIP] $1"; SKIP=$((SKIP+1)); }
+
+# 1. File guard
+echo "── File guard ────────────────────────────────────────────────"
+STAGED="$(git diff --cached --name-only --diff-filter=ACMR 2>/dev/null || true)"
+PROHIBITED_HITS=()
+while IFS= read -r f; do
+  [ -z "$f" ] && continue
+  case "$f" in
+    .env.example|*/.env.example) continue ;;
+    .env|.env.*|*/.env|*/.env.*) PROHIBITED_HITS+=("$f") ;;
+    *.key|*.pem|*.p12|*.pfx)     PROHIBITED_HITS+=("$f") ;;
+    credentials.json|*/credentials.json) PROHIBITED_HITS+=("$f") ;;
+    service-account*.json|*/service-account*.json) PROHIBITED_HITS+=("$f") ;;
+    id_rsa|*/id_rsa|id_dsa|*/id_dsa|id_ed25519|*/id_ed25519) PROHIBITED_HITS+=("$f") ;;
+  esac
+done <<EOF
+$STAGED
+EOF
+
+if [ "${#PROHIBITED_HITS[@]}" -eq 0 ]; then
+  mark_ok "no prohibited files staged"
+else
+  mark_fail "prohibited files staged: ${PROHIBITED_HITS[*]}"
+fi
+
+# 2. Custom regex secret scan
+echo "── Custom secret scan ───────────────────────────────────────"
+if [ -x "$SCAN_SECRETS" ]; then
+  if git diff --cached --quiet 2>/dev/null; then
+    mark_ok "custom regex (nothing staged to scan)"
+  elif git diff --cached -U0 | "$SCAN_SECRETS" >"$LOG" 2>&1; then
+    mark_ok "custom regex (no findings)"
+  else
+    mark_fail "custom regex scanner found secrets"
+    sed 's/^/        /' "$LOG" | head -n 30
+  fi
+else
+  mark_skip "scan-secrets.sh not executable at $SCAN_SECRETS"
+fi
+
+# 3. gitleaks (staged-only). Pure Go binary — no npm fallback.
+echo "── gitleaks ─────────────────────────────────────────────────"
+if command -v gitleaks >/dev/null 2>&1; then
+  GITLEAKS_ARGS=(git --staged --redact --no-banner)
+  [ -f .gitleaks.toml ] && GITLEAKS_ARGS+=(--config .gitleaks.toml)
+  gitleaks "${GITLEAKS_ARGS[@]}" >"$LOG" 2>&1
+  rc=$?
+  case "$rc" in
+    0)  mark_ok "gitleaks (no findings)" ;;
+    1)  mark_fail "gitleaks reported findings"
+        sed 's/^/        /' "$LOG" | tail -n 30 ;;
+    *)  mark_fail "gitleaks errored (rc=$rc) — treating an unusable scanner as a failure, not a pass"
+        sed 's/^/        /' "$LOG" | tail -n 10 ;;
+  esac
+else
+  mark_skip "gitleaks not installed (install with: brew install gitleaks)"
+fi
+
+# 4. Typecheck (only if there's a tsconfig.json and a script for it)
+echo "── typecheck ────────────────────────────────────────────────"
+if [ -f tsconfig.json ] && [ -f package.json ]; then
+  if node -e "process.exit(require('./package.json').scripts?.typecheck?0:1)" 2>/dev/null; then
+    if npm run typecheck --silent >"$LOG" 2>&1; then
+      mark_ok "npm run typecheck"
+    else
+      mark_fail "npm run typecheck"
+      sed 's/^/        /' "$LOG" | tail -n 30
+    fi
+  else
+    mark_skip "no 'typecheck' script in package.json"
+  fi
+else
+  mark_skip "no tsconfig.json (or no package.json)"
+fi
+
+echo
+echo "── Summary ──────────────────────────────────────────────────"
+echo "PASS: $PASS    FAIL: $FAIL    SKIP: $SKIP"
+if [ "$FAIL" -gt 0 ]; then
+  echo
+  echo "Blocking failures:"
+  for f in "${FAILURES[@]}"; do
+    echo "  - $f"
+  done
+  exit 1
+fi
+exit 0

--- a/.github/pre-deploy-guard/scripts/run-checks.sh
+++ b/.github/pre-deploy-guard/scripts/run-checks.sh
@@ -1,0 +1,260 @@
+#!/usr/bin/env bash
+# run-checks.sh — Full pre-deploy / pre-push validation.
+# Exits 0 on success, 1 if any blocking check failed.
+#
+# Steps (each can be skipped if not applicable to the repo):
+#   1. File guard         — staged paths blacklist
+#   2. .gitignore guard   — required ignore entries are present
+#   3. npm run lint
+#   4. npm run typecheck
+#   5. npm test
+#   6. npm run build
+#   7. Custom regex secret scan on staged diff
+#   8. gitleaks (via npx) on staged diff
+#
+# Output uses [OK] / [FAIL] / [SKIP] markers and a final summary block.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCAN_SECRETS="$SCRIPT_DIR/scan-secrets.sh"
+
+ROOT="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+if [ -z "$ROOT" ]; then
+  echo "[SKIP] Not in a git repository — pre-deploy-guard does nothing here."
+  exit 0
+fi
+cd "$ROOT"
+
+PASS=0
+FAIL=0
+SKIP=0
+FAILURES=()
+LOG="$(mktemp -t pre-deploy-guard.XXXXXX)"
+WORK_NAMES="$(mktemp -t pre-deploy-names.XXXXXX)"
+trap 'rm -f "$LOG" "$WORK_NAMES"' EXIT
+
+mark_ok()    { echo "[OK]   $1"; PASS=$((PASS+1)); }
+mark_fail()  { echo "[FAIL] $1"; FAIL=$((FAIL+1)); FAILURES+=("$1"); }
+mark_skip()  { echo "[SKIP] $1"; SKIP=$((SKIP+1)); }
+
+run_step() {
+  local label="$1"; shift
+  if "$@" >"$LOG" 2>&1; then
+    mark_ok "$label"
+  else
+    mark_fail "$label"
+    sed 's/^/        /' "$LOG" | tail -n 40
+  fi
+}
+
+# ─────────────────────────────────────────────────────────────────
+# 1. File guard
+# ─────────────────────────────────────────────────────────────────
+# The full mode runs before a push, when the index is normally empty because
+# everything is already committed. Scanning only the index there examined zero
+# bytes and passed, so the outgoing commits are scanned too. Resolution order
+# widens deliberately: failing to find a base must not silently skip the scan.
+OUTGOING_RANGE=""
+RANGE_UNRESOLVED=0
+BASE_FOUND=0
+if UPSTREAM="$(git rev-parse --abbrev-ref --symbolic-full-name '@{upstream}' 2>/dev/null)" \
+   && git rev-parse --verify --quiet "$UPSTREAM" >/dev/null 2>&1; then
+  BASE_FOUND=1
+  [ "$(git rev-parse HEAD 2>/dev/null)" != "$(git rev-parse "$UPSTREAM" 2>/dev/null)" ] \
+    && OUTGOING_RANGE="$UPSTREAM..HEAD"
+else
+  for base in "$(git rev-parse --abbrev-ref origin/HEAD 2>/dev/null)" origin/main origin/master main master develop trunk; do
+    [ -z "$base" ] && continue
+    git rev-parse --verify --quiet "$base" >/dev/null 2>&1 || continue
+    BASE_FOUND=1
+    # A base that equals HEAD means nothing is outgoing — that is a clean state,
+    # not an unknown one, and must not block the push.
+    [ "$(git rev-parse HEAD 2>/dev/null)" != "$(git rev-parse "$base" 2>/dev/null)" ] \
+      && OUTGOING_RANGE="$base..HEAD"
+    break
+  done
+  if [ "$BASE_FOUND" = "0" ] \
+     && git rev-parse --verify --quiet HEAD >/dev/null 2>&1 \
+     && [ -n "$(git remote 2>/dev/null)" ]; then
+    RANGE_UNRESOLVED=1
+  fi
+fi
+if [ -n "$OUTGOING_RANGE" ] && ! git rev-list --count "$OUTGOING_RANGE" >/dev/null 2>&1; then
+  OUTGOING_RANGE=""
+  RANGE_UNRESOLVED=1
+fi
+
+echo "── File guard ────────────────────────────────────────────────"
+NAMES="$WORK_NAMES"
+: > "$NAMES"
+git diff --cached --name-only --diff-filter=ACMR -z 2>/dev/null >> "$NAMES" || true
+if [ ! -s "$NAMES" ]; then
+  git ls-files --modified --others --exclude-standard -z 2>/dev/null >> "$NAMES" || true
+fi
+# A .env or key sitting in an unpushed commit is exactly what must not be
+# published. Walk the commits rather than diff the endpoints, so a file added
+# and later deleted inside the range is still caught.
+if [ -n "$OUTGOING_RANGE" ]; then
+  git log --diff-merges=first-parent --name-only --diff-filter=ACMR \
+    --pretty=format: -z "$OUTGOING_RANGE" 2>/dev/null >> "$NAMES" || true
+fi
+
+PROHIBITED_HITS=()
+while IFS= read -r -d '' f; do
+  [ -z "$f" ] && continue
+  case "$f" in
+    .env.example|*/.env.example) continue ;;  # allowed
+    .env|.env.*|*/.env|*/.env.*) PROHIBITED_HITS+=("$f") ;;
+    *.key|*.pem|*.p12|*.pfx)     PROHIBITED_HITS+=("$f") ;;
+    credentials.json|*/credentials.json) PROHIBITED_HITS+=("$f") ;;
+    service-account*.json|*/service-account*.json) PROHIBITED_HITS+=("$f") ;;
+    id_rsa|*/id_rsa|id_dsa|*/id_dsa|id_ed25519|*/id_ed25519) PROHIBITED_HITS+=("$f") ;;
+  esac
+done < "$NAMES"
+
+if [ "${#PROHIBITED_HITS[@]}" -eq 0 ]; then
+  mark_ok "no prohibited files staged"
+else
+  mark_fail "prohibited files staged: ${PROHIBITED_HITS[*]}"
+fi
+
+# ─────────────────────────────────────────────────────────────────
+# 2. .gitignore guard
+# ─────────────────────────────────────────────────────────────────
+echo "── .gitignore guard ─────────────────────────────────────────"
+if [ -f .gitignore ]; then
+  REQUIRED=(".env" "node_modules" "dist" "*.key" "*.pem")
+  MISSING=()
+  for needle in "${REQUIRED[@]}"; do
+    if ! grep -Fxq "$needle" .gitignore && ! grep -Eq "(^|/)${needle//./\\.}(/|$)" .gitignore; then
+      MISSING+=("$needle")
+    fi
+  done
+  if [ "${#MISSING[@]}" -eq 0 ]; then
+    mark_ok ".gitignore covers required paths"
+  else
+    mark_fail ".gitignore missing entries: ${MISSING[*]}"
+  fi
+else
+  mark_skip "no .gitignore in repo root"
+fi
+
+# ─────────────────────────────────────────────────────────────────
+# 3-6. npm scripts (lint / typecheck / test / build)
+# ─────────────────────────────────────────────────────────────────
+has_npm_script() {
+  [ -f package.json ] && node -e "
+    const p = require('./package.json');
+    process.exit(p.scripts && p.scripts['$1'] ? 0 : 1);
+  " 2>/dev/null
+}
+
+if [ -f package.json ]; then
+  echo "── npm scripts ──────────────────────────────────────────────"
+  if has_npm_script lint; then
+    run_step "npm run lint" npm run lint --silent
+  else
+    mark_skip "npm run lint (script not defined)"
+  fi
+  if has_npm_script typecheck; then
+    run_step "npm run typecheck" npm run typecheck --silent
+  else
+    mark_skip "npm run typecheck (script not defined)"
+  fi
+  if has_npm_script test; then
+    CI=1 run_step "npm test" npm test --silent
+  else
+    mark_skip "npm test (script not defined)"
+  fi
+  if has_npm_script build; then
+    run_step "npm run build" npm run build --silent
+  else
+    mark_skip "npm run build (script not defined)"
+  fi
+else
+  echo "── npm scripts ──────────────────────────────────────────────"
+  mark_skip "no package.json"
+fi
+
+# ─────────────────────────────────────────────────────────────────
+# 7. Custom regex secret scan
+# ─────────────────────────────────────────────────────────────────
+echo "── Custom secret scan ───────────────────────────────────────"
+if [ -x "$SCAN_SECRETS" ]; then
+  SCAN_TARGETS=0
+  SCAN_FAILED=0
+  # "Nothing staged" is a fact about the index, not about the log. A clean scan
+  # also leaves the log empty, so the old test reported real scans as skipped
+  # ones — a reassuring message for the case that most deserves attention.
+  if ! git diff --cached --quiet 2>/dev/null; then
+    SCAN_TARGETS=$((SCAN_TARGETS+1))
+    git diff --cached -U0 | "$SCAN_SECRETS" >"$LOG" 2>&1 || SCAN_FAILED=1
+  fi
+  if [ -n "$OUTGOING_RANGE" ] && [ "$(git rev-list --count "$OUTGOING_RANGE")" -gt 0 ]; then
+    SCAN_TARGETS=$((SCAN_TARGETS+1))
+    git log -p -U0 --no-color --diff-merges=first-parent "$OUTGOING_RANGE" | "$SCAN_SECRETS" >>"$LOG" 2>&1 || SCAN_FAILED=1
+  fi
+
+  if [ "$SCAN_FAILED" = "1" ]; then
+    mark_fail "custom regex scanner found secrets"
+    sed 's/^/        /' "$LOG"
+  elif [ "$RANGE_UNRESOLVED" = "1" ]; then
+    mark_fail "cannot determine which commits would be pushed; scan them manually (e.g. git log -p <base>..HEAD | scan-secrets.sh)"
+  elif [ "$SCAN_TARGETS" -eq 0 ]; then
+    mark_ok "custom regex (nothing staged or unpushed to scan)"
+  else
+    mark_ok "custom regex (no findings)"
+  fi
+else
+  mark_skip "scan-secrets.sh not executable"
+fi
+
+# ─────────────────────────────────────────────────────────────────
+# 8. gitleaks
+# gitleaks is a Go binary (https://github.com/gitleaks/gitleaks).
+# Install: `brew install gitleaks` or download a release binary.
+# We don't try npm/npx — there's no first-party npm package.
+# ─────────────────────────────────────────────────────────────────
+echo "── gitleaks ─────────────────────────────────────────────────"
+if command -v gitleaks >/dev/null 2>&1; then
+  GITLEAKS_ARGS=(git --staged --redact --no-banner)
+  [ -f .gitleaks.toml ] && GITLEAKS_ARGS+=(--config .gitleaks.toml)
+  gitleaks "${GITLEAKS_ARGS[@]}" >"$LOG" 2>&1
+  rc=$?
+  # Same blind spot as the custom scanner: cover the commits about to leave.
+  # rc is reassigned inside the branch on purpose — capturing it after the `if`
+  # would read the `if` itself, which is 0 even when the staged scan found a leak.
+  if [ "$rc" -eq 0 ] && [ -n "$OUTGOING_RANGE" ]; then
+    GITLEAKS_RANGE_ARGS=(git --redact --no-banner "--log-opts=$OUTGOING_RANGE")
+    [ -f .gitleaks.toml ] && GITLEAKS_RANGE_ARGS+=(--config .gitleaks.toml)
+    gitleaks "${GITLEAKS_RANGE_ARGS[@]}" >>"$LOG" 2>&1
+    rc=$?
+  fi
+
+  case "$rc" in
+    0)  mark_ok "gitleaks (no findings)" ;;
+    1)  mark_fail "gitleaks reported findings"
+        sed 's/^/        /' "$LOG" | tail -n 40 ;;
+    *)  mark_fail "gitleaks errored (rc=$rc) — treating an unusable scanner as a failure, not a pass"
+        sed 's/^/        /' "$LOG" | tail -n 10 ;;
+  esac
+else
+  mark_skip "gitleaks not installed (install with: brew install gitleaks)"
+fi
+
+# ─────────────────────────────────────────────────────────────────
+# Summary
+# ─────────────────────────────────────────────────────────────────
+echo
+echo "── Summary ──────────────────────────────────────────────────"
+echo "PASS: $PASS    FAIL: $FAIL    SKIP: $SKIP"
+if [ "$FAIL" -gt 0 ]; then
+  echo
+  echo "Blocking failures:"
+  for f in "${FAILURES[@]}"; do
+    echo "  - $f"
+  done
+  exit 1
+fi
+exit 0

--- a/.github/pre-deploy-guard/scripts/scan-secrets.sh
+++ b/.github/pre-deploy-guard/scripts/scan-secrets.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+# scan-secrets.sh — Custom regex scanner for project-specific secrets.
+# Reads input from stdin (a unified diff or file content). Falls back to
+# `git diff --cached -U0` whenever stdin yields no bytes.
+#
+# Exits 0 if nothing was found, 1 if at least one pattern matched.
+# Prints matches in a `<file>:<line>: <pattern-name>` style for easy parsing.
+
+set -uo pipefail
+
+# Patterns: name|regex
+# Order matters only for reporting — every pattern is checked.
+PATTERNS=(
+  'meta-app-secret|(^|[^A-Za-z0-9_])META_APP_SECRET[[:space:]]*=[[:space:]]*["'\''"]?[A-Za-z0-9]{16,}'
+  'meta-access-token|EAA[A-Za-z0-9]{20,}'
+  'oauth-secret|(^|[^A-Za-z0-9_])OAUTH_SECRET[[:space:]]*=[[:space:]]*["'\''"]?[A-Za-z0-9+/=]{32,}'
+  'oauth-approval-pin|(^|[^A-Za-z0-9_])OAUTH_APPROVAL_PIN[[:space:]]*=[[:space:]]*["'\''"]?[A-Za-z0-9]{6,}'
+  'token-encryption-key|(^|[^A-Za-z0-9_])TOKEN_ENCRYPTION_KEY[[:space:]]*=[[:space:]]*["'\''"]?[A-Fa-f0-9]{64}'
+  'session-cookie-secret|(^|[^A-Za-z0-9_])SESSION_COOKIE_SECRET[[:space:]]*=[[:space:]]*["'\''"]?[A-Za-z0-9+/=]{32,}'
+  'mcp-api-key|(^|[^A-Za-z0-9_])MCP_API_KEY[[:space:]]*=[[:space:]]*["'\''"]?[A-Za-z0-9]{20,}'
+  'meta-tokens-json|(^|[^A-Za-z0-9_])META_TOKENS[[:space:]]*=[[:space:]]*["'\''"]?\{[^}]*EAA'
+  'google-oauth-token|ya29\.[0-9A-Za-z_-]{30,}'
+  'google-api-key|AIza[0-9A-Za-z_-]{35}'
+  'gcp-service-account-key|"private_key":[[:space:]]*"-----BEGIN'
+  'private-key-block|-----BEGIN[[:space:]]*(RSA|EC|DSA|OPENSSH|PGP)?[[:space:]]*PRIVATE[[:space:]]*KEY-----'
+  'github-token|gh[pousr]_[A-Za-z0-9]{36,}'
+  'aws-access-key|AKIA[0-9A-Z]{16}'
+)
+
+# Allowlist: skip findings that match these substrings (case-sensitive).
+# Mainly to suppress obvious examples / placeholders / stripped redactions.
+ALLOWLIST=(
+  'EAAabcdefghij'                 # canonical example placeholder
+  'EAA[A-Za-z0-9]{20'              # the regex itself if dumped to a file
+  'YOUR_'
+  'EXAMPLE'
+  'placeholder'
+  'PLACEHOLDER'
+  '<your-'
+  'fixture'
+  'gitleaks:allow'
+)
+
+# Source the diff: piped stdin when there is one, else the staged diff.
+WORKDIR="$(mktemp -d -t scan-secrets.XXXXXX)" || {
+  echo "scan-secrets: cannot create a working directory; refusing to report clean" >&2
+  exit 1
+}
+trap 'rm -rf "$WORKDIR"' EXIT
+INPUT="$WORKDIR/input"
+: > "$INPUT"
+
+if [ -p /dev/stdin ] || { [ ! -t 0 ] && [ -f /dev/stdin ]; }; then
+  cat > "$INPUT"
+fi
+
+# Testing `-t 0` alone was not enough: under an agent, a PreToolUse hook or a CI
+# runner, stdin is a closed pipe rather than a TTY, so the read returned nothing
+# and an unscanned diff reported clean. Fall back to the index whenever stdin
+# produced no bytes, regardless of what kind of handle it was.
+if [ ! -s "$INPUT" ] && git rev-parse --git-dir >/dev/null 2>&1; then
+  git diff --cached -U0 > "$INPUT" 2>/dev/null || true
+fi
+
+if [ ! -s "$INPUT" ]; then
+  # Reporting clean while the index holds staged changes is the exact false
+  # negative this scanner exists to prevent, so fail closed instead.
+  if git rev-parse --git-dir >/dev/null 2>&1 && ! git diff --cached --quiet 2>/dev/null; then
+    echo "scan-secrets: no scannable input though the index has staged changes; refusing to report clean" >&2
+    exit 1
+  fi
+  exit 0
+fi
+
+# Parse unified diff to track current file and line number per hunk.
+# We only check lines that start with '+' (additions) but not the '+++' header.
+HITS=0
+MAP="$WORKDIR/map"
+
+awk '
+  /^diff --git / {
+    # Extract b/<path> as the current file.
+    n = split($0, parts, " ")
+    file = parts[n]
+    sub(/^b\//, "", file)
+    next
+  }
+  /^\+\+\+ / {
+    # Fallback: +++ b/<file>
+    f = $2
+    sub(/^b\//, "", f)
+    if (f != "/dev/null") file = f
+    next
+  }
+  /^@@ / {
+    # @@ -a,b +c,d @@
+    match($0, /\+[0-9]+/)
+    line = substr($0, RSTART+1, RLENGTH-1) + 0
+    in_hunk = 1
+    next
+  }
+  /^---/ { next }
+  /^\+\+\+/ { next }
+  in_hunk && /^\+/ {
+    body = substr($0, 2)
+    print file "\t" line "\t" body
+    line++
+    next
+  }
+  in_hunk && /^-/ { next }
+  in_hunk && /^ / { line++; next }
+  { in_hunk = 0 }
+' "$INPUT" > "$MAP"
+
+# Absence of diff structure means plain file content, which the docstring
+# accepts; scanning nothing and reporting clean is the failure this guard
+# exists to prevent. Both a header and a hunk marker are required, so a plain
+# file that merely contains a diff-looking line still gets scanned in full.
+# Judging by the parse being empty instead would misread a deletion-only diff
+# as plain text and flag the very removal of a secret.
+if ! { grep -qE '^(diff --git |--- )' "$INPUT" && grep -qE '^@@ ' "$INPUT"; }; then
+  awk '{ print "(stdin)\t" NR "\t" $0 }' "$INPUT" > "$MAP"
+fi
+
+while IFS=$'\t' read -r FILE HIT_LINE BODY; do
+  # Skip allowlisted contents.
+  skip=0
+  for needle in "${ALLOWLIST[@]}"; do
+    if printf '%s' "$BODY" | grep -qF -- "$needle"; then
+      skip=1
+      break
+    fi
+  done
+  [ "$skip" = "1" ] && continue
+
+  # Skip if path is .env.example, tests fixtures, or vendored.
+  case "$FILE" in
+    .env.example|*/.env.example) continue ;;
+    package-lock.json|*/package-lock.json) continue ;;
+    *.lock|yarn.lock|pnpm-lock.yaml) continue ;;
+    # Self-references: the gitleaks config and this script declare the
+    # very regex shapes we look for as PATTERNS. Skip them so a doc-only
+    # change to either doesn't trigger a guard against itself.
+    .gitleaks.toml|*/.gitleaks.toml) continue ;;
+    scan-secrets.sh|*/scan-secrets.sh) continue ;;
+  esac
+
+  for entry in "${PATTERNS[@]}"; do
+    NAME="${entry%%|*}"
+    RE="${entry#*|}"
+    if printf '%s' "$BODY" | grep -E -q -- "$RE"; then
+      printf '%s:%s: %s\n' "$FILE" "$HIT_LINE" "$NAME"
+      HITS=$((HITS+1))
+    fi
+  done
+done < "$MAP"
+
+if [ "$HITS" -gt 0 ]; then
+  echo ""
+  echo "scan-secrets: $HITS finding(s) in staged diff"
+  exit 1
+fi
+exit 0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,11 +29,11 @@ Before **any** `git commit -m`, `git push`, `gcloud run deploy`, `docker push`, 
 3. `npm test` passes (runs vitest).
 4. `npm run build` passes (TypeScript build).
 5. **No prohibited files in staging**: `.env`, `.env.*` (except `.env.example`), `*.key`, `*.pem`, `credentials.json`, `service-account*.json`, SSH private keys, `*.p12`, `*.pfx`.
-6. **`gitleaks detect --staged --config .gitleaks.toml`** finds no secrets.
+6. **`gitleaks git --staged --config .gitleaks.toml`** finds no secrets.
 7. **No project-specific patterns** appear in the staged diff. Custom regex covers (full list in [.gitleaks.toml](.gitleaks.toml)):
    - `META_APP_SECRET=`, `OAUTH_SECRET=`, `OAUTH_APPROVAL_PIN=`, `SESSION_COOKIE_SECRET=`, `TOKEN_ENCRYPTION_KEY=`, `MCP_API_KEY=`
    - Meta access tokens: `EAA[A-Za-z0-9]{20,}`
-   - `META_TOKENS={…EAA…}` (multi-tenant token map)
+   - `META_TOKENS` as a JSON map of `EAA…` tokens (multi-tenant)
    - Google: `AIza[A-Za-z0-9_-]{35}`, `ya29\.[A-Za-z0-9_-]+`, GCP service account JSON
    - Generic: `-----BEGIN … PRIVATE KEY-----`, GitHub PATs (`gh[pousr]_`), AWS keys (`AKIA`)
 8. `.gitignore` covers `.env`, `.env.local`, `*.key`, `*.pem`, `credentials.json`, `service-account*.json`, `dist/`, `node_modules/`.
@@ -48,7 +48,16 @@ If you have **Claude Code** with the user-scoped `pre-deploy-guard` skill instal
 - A `PreToolUse` hook intercepts `git commit -m` / `git push` / `gcloud run deploy` and runs the guard. If anything fails, the command is blocked.
 - For deep audits on large diffs, delegate to the `pre-deploy-guard` subagent (`Agent({ subagent_type: "pre-deploy-guard", ... })`).
 
-To install the skill on your machine, see the bottom of this file.
+The scripts live in [.github/pre-deploy-guard/scripts/](.github/pre-deploy-guard/scripts/) and can be run directly without Claude Code:
+
+```bash
+bash .github/pre-deploy-guard/scripts/quick-checks.sh   # pre-commit
+bash .github/pre-deploy-guard/scripts/run-checks.sh     # pre-push / pre-deploy
+```
+
+`quick-checks.sh` is the fast gate: file guard, both secret scanners and typecheck. It does **not** run lint, tests or build — `run-checks.sh` does, and it is what has to pass before anything is pushed. The full script also scans the commits about to be pushed, not just the index, since after a commit the index is empty. Neither script runs `npm ci`; install dependencies yourself if `node_modules` is stale, or the npm steps will fail on a missing local `tsc`.
+
+To install the Claude Code integration on your machine, see the bottom of this file.
 
 If you don't have Claude Code, you can replicate the checks manually:
 
@@ -56,11 +65,11 @@ If you don't have Claude Code, you can replicate the checks manually:
 # Quick (pre-commit)
 npm run lint && npm run typecheck && npm test
 git diff --cached --name-only | grep -E '^\.env(\..*)?$|\.key$|\.pem$|credentials\.json$|service-account.*\.json$' && echo "PROHIBITED FILE STAGED" && exit 1
-gitleaks detect --staged --redact --no-banner --config .gitleaks.toml
+gitleaks git --staged --redact --no-banner --config .gitleaks.toml
 
 # Full (pre-push / pre-deploy)
 npm ci && npm run lint && npm run typecheck && npm test && npm run build
-gitleaks detect --redact --no-banner --config .gitleaks.toml
+gitleaks git --redact --no-banner --config .gitleaks.toml
 ```
 
 CI ([.github/workflows/ci.yml](.github/workflows/ci.yml)) runs the same checks on every PR and on push to `main`. The deploy job in [deploy.yml](.github/workflows/deploy.yml) depends on the preflight job, so a failed lint/test/build/scan blocks deployment.
@@ -81,7 +90,7 @@ Source: [.env.example](.env.example). Each one is treated as a hard secret.
 | `MCP_API_KEY` | Service-to-service key | Bypass OAuth entirely. |
 | GCP creds (WIF / service account) | Cloud auth | Deploy malicious revisions, read Firestore, escalate via IAM. |
 
-If any of these leaks, see the rotation playbooks in `~/.claude/skills/pre-deploy-guard/references/sensitive-patterns.md` (or replicate the steps documented in the headers of those env vars).
+If any of these leaks, see the rotation playbooks in [.github/pre-deploy-guard/references/sensitive-patterns.md](.github/pre-deploy-guard/references/sensitive-patterns.md).
 
 ## Useful commands
 
@@ -106,7 +115,13 @@ npm run typecheck         # tsc --noEmit
 
 If you're using Claude Code on this repo and want the same automatic pre-commit/pre-push guard the maintainers use:
 
-1. **Skill + agent**: copy `~/.claude/skills/pre-deploy-guard/` and `~/.claude/agents/pre-deploy-guard.md` from a maintainer's setup, or write your own using the procedures documented in this file.
+Everything ships in this repo under [.github/pre-deploy-guard/](.github/pre-deploy-guard/) — see its [README](.github/pre-deploy-guard/README.md) for the full walkthrough.
+
+1. **Skill + agent**:
+   ```bash
+   cp -r .github/pre-deploy-guard ~/.claude/skills/
+   cp .github/pre-deploy-guard/agent.md ~/.claude/agents/pre-deploy-guard.md
+   ```
 2. **Hook**: in `~/.claude/settings.json`, add:
    ```json
    "hooks": {
@@ -120,6 +135,6 @@ If you're using Claude Code on this repo and want the same automatic pre-commit/
      ]
    }
    ```
-3. **Opt this repo in**: create the marker file `.github/pre-deploy-guard.enabled` (empty file) so the hook activates here. The hook is silently inert in any repo without this marker (or whose path doesn't match the canonical maintainer path).
+3. **Opt a repo in**: the marker file `.github/pre-deploy-guard.enabled` is already committed here, so the hook activates automatically. The hook is silently inert in any repo without that marker.
 
 The guard is defense-in-depth — even without it on your machine, [.github/workflows/ci.yml](.github/workflows/ci.yml) and the deploy preflight job catch the same issues server-side. The local hook just shortens the feedback loop.


### PR DESCRIPTION
## Why

`CLAUDE.md` documents this guard as the thing standing between a commit and a leaked token, but it only ever existed on maintainer machines. The install instructions literally said *copy it from a maintainer's setup*, and every fix to it lived outside version control. This moves it into [.github/pre-deploy-guard/](.github/pre-deploy-guard/): the four scripts, the skill and subagent definitions, the sensitive-pattern reference with rotation playbooks, and a [README](.github/pre-deploy-guard/README.md) for running the checks with no Claude Code at all.

## The part that matters

Packaging it turned up defects that all share one shape — **a security gate reporting clean on something it never examined**.

The worst: **the push gate scanned only the index.** Before a push everything is already committed and the index is empty, so both scanners read zero bytes and passed. Measured on this very branch:

```
gitleaks git --staged   →  0 commits scanned, ~0 bytes      ← nine files waiting to be published
gitleaks --log-opts     →  1 commits scanned, ~53.57 KB     ← after the fix
```

Full mode now scans the outgoing commits too, and does it by walking them with `git log -p` rather than diffing the endpoints, because a secret added in one outgoing commit and deleted in another never appears in the endpoint diff yet still ships in the history. Merge patches are included via first-parent, which `git log -p` omits by default. The name-based ban on `.env`, keys and service accounts walks the same commits and reads NUL-delimited paths so filenames with spaces still match.

Other fail-open paths closed:

| Where | Was | Now |
|---|---|---|
| Scanner stdin detection | `[ -t 0 ]` — under an agent, hook or CI runner stdin is a closed pipe, so a direct run scanned nothing | Falls back to the index; fails closed if there's nothing to scan while the index has changes |
| Plain file content | Docstring accepted it, parser only understood diffs → empty scan | Diff mode needs header **and** hunk marker; anything else is scanned line by line |
| Finding line numbers | Reported `LINENO`, a bash special variable `read` can't assign → every hit cited a line inside the scanner | Renamed; hits cite the real line |
| `mktemp` failure | Unchecked — the hook emitted an empty decision, which *allows* the command | Both fail closed |
| gitleaks erroring (`rc>1`) | Counted as a skip, and skips don't block | Fails, in both scripts |
| Bypass-flag refusal | Ran before the opt-in check, so it fired in every repo | Moved after it; the hook is genuinely inert without the marker file |

## Judgement calls

The guard's own prose tabulates the patterns it hunts for, which made it flag itself. I did **not** exempt those files by path — that hole would let a short `MCP_API_KEY` through both layers, since the runtime accepts any non-empty value while gitleaks needs 32 characters. The documentation is worded so it no longer matches instead.

`SKILL.md` also claimed a `tests/**` path exemption the scanner never had, and `CLAUDE.md`'s manual recipes used `gitleaks detect --staged`, which exits 126 on gitleaks 8.x. Both corrected.

**Known limitation, deliberately unchanged:** the hook matches on command text, so `git -C <dir> push` and `cd <dir> && git push` aren't gated, and a command that merely *mentions* the bypass flag is refused — that one bit me while writing this commit message. Fixing it properly means parsing shell commands, which is its own change.

## Verification

Full guard green on this commit (8/8: file guard, gitignore, lint, typecheck, tests, build, both scanners). Each failure mode was also reproduced in scratch repositories and confirmed to block: a secret in an unpushed commit with a clean index, a secret added-then-deleted across two outgoing commits, a prohibited file added and deleted within the range, a filename with spaces, and a merge-only secret. The false-block regression I introduced mid-review — a healthy branch with no upstream — is covered too, and passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)