### PR TITLE
feat: ads_get_creative_media — creative media as inline MCP image blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,22 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 
+- **`ads_get_creative_media` — see the actual creative, not just its URLs.**
+  Given an `ad_id` or `creative_id`, the tool walks the creative
+  (`image_url`/`image_hash`, `object_story_spec` link/video data including
+  carousel `child_attachments`, `asset_feed_spec` assets, and the upsized
+  `thumbnail_url` fallback for boosted posts), resolves image hashes through a
+  single batched `adimages` lookup, downloads each image through the existing
+  SSRF-hardened downloader, and returns them as inline MCP `image` content
+  blocks that a multimodal model (Claude, Gemini) can analyze directly. Videos
+  cannot be embedded as MCP blocks, so each one returns its best thumbnail as
+  an image block plus a signed short-lived `source` URL (and a ready-to-use
+  download hint) in the JSON metadata for external download or video-capable
+  models. Response size is bounded by a `max_images` cap (default 5), an 8 MB
+  per-image limit and a 20 MB cumulative budget; `image_size: "small"` swaps in
+  128px previews to save context. Partial failures (an expired CDN URL, an
+  unresolvable hash) are reported per-asset without failing the call.
+
 - **`ads_update_ad_url_tags` — edit the UTM parameters of live ads (1-50 per
   call).** Meta creatives are immutable (`POST /{creative_id}` only accepts
   `name` / `status` / `adlabels`), so the tool clones each ad's creative with

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 - [Who is this for?](#who-is-this-for)
 - [Aligned with Meta's official MCP](#aligned-with-metas-official-mcp)
 - [Features](#features)
-- [Tools (126 total)](#tools-126-total)
+- [Tools (127 total)](#tools-127-total)
 - [Quick start](#quick-start)
 - [Authentication — three modes](#authentication--three-modes)
 - [Setting up Sign in with Meta](#setting-up-sign-in-with-meta)
@@ -78,7 +78,7 @@ When to use which:
 
 ## Features
 
-- **126 tools** covering campaign management, creatives, targeting, audiences, reporting, comments, billing, invoices, tokens, Instagram workflows, WhatsApp Business management, rate-limit observability, semantic insight views, diagnostics, help-center search, and agency-tier cross-account macros.
+- **127 tools** covering campaign management, creatives, targeting, audiences, reporting, comments, billing, invoices, tokens, Instagram workflows, WhatsApp Business management, rate-limit observability, semantic insight views, diagnostics, help-center search, and agency-tier cross-account macros.
 - **Aligned vocabulary** with Meta's official MCP server so agents transfer cleanly between both.
 - **Sign in with Meta (Facebook Login)** — replaces shared PINs. Each user lands their own long-lived (60-day) Meta token.
 - **System User token registry** — for tokens that don't expire, register them per user from the consent UI.
@@ -94,7 +94,7 @@ When to use which:
 - **Async reports with safe polling** — `ads_run_report_and_wait` one-shot with 5 s-min / 60 s-max backoff, proper `Job Failed` / `Job Skipped` handling.
 - **Retry logic** — exponential backoff on truly transient errors only (never on throttled requests).
 
-## Tools (126 total)
+## Tools (127 total)
 
 Ads tools use the `ads_*` naming convention, aligned with Meta's official MCP server; WhatsApp Business tools use `whatsapp_*`. Read tools declare `readOnlyHint: true`; mutating tools declare `destructiveHint` / `idempotentHint` and prefix descriptions with a `⚠️` warning.
 
@@ -105,6 +105,7 @@ Ads tools use the `ads_*` naming convention, aligned with Meta's official MCP se
 | Ad Sets | 6 | CRUD + clone bundle (native ad-copy, 100% creative-type coverage incl. dynamic/Advantage+) |
 | Ads | 6 | CRUD with creative assignment, UTM (`url_tags`) editing |
 | Creatives | 9 | List, details, create/update, image/video library and uploads |
+| Creative media | 1 | `ads_get_creative_media` — downloads an ad's images (incl. carousel cards and video thumbnails) and returns them as inline MCP image blocks for visual analysis; videos come with a signed source URL for external download |
 | Generic entity helpers | 3 | `ads_get_ad_entities`, `ads_update_entity`, `ads_activate_entity` (mirror official MCP) |
 | Insights — power tool | 1 | `ads_get_insights` — full control over breakdowns, attribution, time series |
 | Insights views | 5 | `performance_trend`, `anomaly_signal`, `auction_ranking_benchmarks`, `industry_benchmark`, `advertiser_context` |

--- a/src/meta/types/creative.ts
+++ b/src/meta/types/creative.ts
@@ -18,6 +18,7 @@ export type CallToActionType =
 export interface AdCreative {
   id: string;
   name: string;
+  account_id?: string;
   title?: string;
   body?: string;
   image_hash?: string;

--- a/src/tools/creative-media.ts
+++ b/src/tools/creative-media.ts
@@ -1,0 +1,508 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { metaApiClient } from "../meta/client.js";
+import { normalizeAccountId, validateMetaId } from "../utils/format.js";
+import { CREATIVE_DEFAULT_FIELDS } from "../meta/types/creative.js";
+import { IMAGE_DEFAULT_FIELDS } from "../meta/types/image.js";
+import { VIDEO_DETAIL_FIELDS } from "../meta/types/video.js";
+import type { AdCreative, AdImage, AdVideo, MetaApiResponse } from "../meta/types/index.js";
+import { downloadSafePublicImage } from "../utils/safe-download.js";
+import { logger } from "../utils/logger.js";
+import { asRecord, getString } from "./creatives.js";
+import { READ } from "./_register.js";
+
+const MAX_IMAGE_BYTES = 8 * 1024 * 1024;
+const TOTAL_BYTES_BUDGET = 20 * 1024 * 1024;
+const MISSING_ACCOUNT_HINT =
+  "Image hash could not be resolved to a URL — pass account_id so the adimages lookup can run.";
+const VIDEO_EXPIRY_WARNING =
+  "Video source URLs are signed, short-lived CDN links — download them promptly. If one has expired, call this tool again to get a fresh URL.";
+
+export type MediaRole =
+  | "primary"
+  | "carousel_child"
+  | "asset_feed_image"
+  | "video_thumbnail"
+  | "thumbnail_fallback";
+
+export interface ImageRef {
+  role: MediaRole;
+  url?: string;
+  hash?: string;
+  carouselIndex?: number;
+}
+
+export interface VideoRef {
+  videoId: string;
+  specThumbnailUrl?: string;
+  specThumbnailHash?: string;
+}
+
+type ToolContentBlock =
+  | { type: "text"; text: string }
+  | { type: "image"; data: string; mimeType: string };
+
+interface ImageAssetMeta {
+  block_index?: number;
+  role: MediaRole;
+  carousel_index?: number;
+  image_hash?: string;
+  width?: number;
+  height?: number;
+  permalink_url?: string;
+  source_url?: string;
+  mime_type?: string;
+  bytes?: number;
+  downloaded: boolean;
+  error?: string;
+  skipped?: "max_images" | "size_budget";
+}
+
+interface VideoAssetMeta {
+  video_id: string;
+  title?: string;
+  length_seconds?: number;
+  source_url?: string;
+  thumbnail_block_index?: number;
+  download_hint?: string;
+  error?: string;
+}
+
+export function collectCreativeMedia(creative: AdCreative): { images: ImageRef[]; videos: VideoRef[] } {
+  const images: ImageRef[] = [];
+  const videos: VideoRef[] = [];
+  const imagesByKey = new Map<string, ImageRef>();
+  const seenVideos = new Set<string>();
+
+  const addImage = (ref: ImageRef): void => {
+    const keys = [ref.hash, ref.url].filter((key): key is string => Boolean(key));
+    if (keys.length === 0) return;
+    // A ref carrying both identifiers can connect two previously separate
+    // entries (one hash-only, one url-only) — merge them into one asset so the
+    // same image is never downloaded twice.
+    const existingRefs = [...new Set(keys.map((key) => imagesByKey.get(key)).filter((r): r is ImageRef => Boolean(r)))];
+    if (existingRefs.length > 0) {
+      const target = existingRefs[0];
+      for (const other of existingRefs.slice(1)) {
+        target.hash ??= other.hash;
+        target.url ??= other.url;
+        const index = images.indexOf(other);
+        if (index >= 0) images.splice(index, 1);
+        for (const [key, value] of imagesByKey) {
+          if (value === other) imagesByKey.set(key, target);
+        }
+      }
+      target.hash ??= ref.hash;
+      target.url ??= ref.url;
+      for (const key of keys) imagesByKey.set(key, target);
+      return;
+    }
+    images.push(ref);
+    for (const key of keys) imagesByKey.set(key, ref);
+  };
+  const addVideo = (ref: VideoRef): void => {
+    if (seenVideos.has(ref.videoId)) return;
+    seenVideos.add(ref.videoId);
+    videos.push(ref);
+  };
+
+  addImage({ role: "primary", url: creative.image_url, hash: creative.image_hash });
+
+  const objectStorySpec = asRecord(creative.object_story_spec);
+  const linkData = asRecord(objectStorySpec?.["link_data"]);
+  if (linkData) {
+    addImage({
+      role: "primary",
+      hash: getString(linkData, "image_hash"),
+      url: getString(linkData, "picture"),
+    });
+    const children = Array.isArray(linkData["child_attachments"]) ? linkData["child_attachments"] : [];
+    children.forEach((child, index) => {
+      const record = asRecord(child);
+      if (!record) return;
+      const videoId = getString(record, "video_id");
+      if (videoId) {
+        addVideo({
+          videoId,
+          specThumbnailUrl: getString(record, "picture"),
+          specThumbnailHash: getString(record, "image_hash"),
+        });
+        return;
+      }
+      addImage({
+        role: "carousel_child",
+        carouselIndex: index,
+        hash: getString(record, "image_hash"),
+        url: getString(record, "picture"),
+      });
+    });
+  }
+
+  const videoData = asRecord(objectStorySpec?.["video_data"]);
+  const videoId = getString(videoData, "video_id");
+  if (videoId) {
+    addVideo({
+      videoId,
+      specThumbnailUrl: getString(videoData, "image_url"),
+      specThumbnailHash: getString(videoData, "image_hash"),
+    });
+  }
+
+  const assetFeedSpec = asRecord(creative.asset_feed_spec);
+  const feedImages = Array.isArray(assetFeedSpec?.["images"]) ? assetFeedSpec["images"] : [];
+  for (const entry of feedImages) {
+    const record = asRecord(entry);
+    if (!record) continue;
+    addImage({
+      role: "asset_feed_image",
+      hash: getString(record, "hash"),
+      url: getString(record, "url"),
+    });
+  }
+  const feedVideos = Array.isArray(assetFeedSpec?.["videos"]) ? assetFeedSpec["videos"] : [];
+  for (const entry of feedVideos) {
+    const record = asRecord(entry);
+    const feedVideoId = getString(record, "video_id");
+    if (!feedVideoId) continue;
+    addVideo({
+      videoId: feedVideoId,
+      specThumbnailUrl: getString(record, "thumbnail_url"),
+      specThumbnailHash: getString(record, "thumbnail_hash"),
+    });
+  }
+
+  if (images.length === 0 && videos.length === 0 && creative.thumbnail_url) {
+    addImage({ role: "thumbnail_fallback", url: creative.thumbnail_url });
+  }
+
+  return { images, videos };
+}
+
+export function pickVideoThumbnailUrl(video: AdVideo, size: "full" | "small"): string | undefined {
+  const thumbs = video.thumbnails?.data ?? [];
+  const largest = thumbs.length > 0
+    ? [...thumbs].sort((a, b) => (b.width ?? 0) - (a.width ?? 0))[0]
+    : undefined;
+  return size === "small" ? video.picture ?? largest?.uri : largest?.uri ?? video.picture;
+}
+
+async function resolveImageHashes(accountId: string, hashes: string[]): Promise<Map<string, AdImage>> {
+  const response = await metaApiClient.get<MetaApiResponse<AdImage>>(
+    `/${accountId}/adimages`,
+    {
+      fields: IMAGE_DEFAULT_FIELDS.join(","),
+      hashes: JSON.stringify(hashes),
+    },
+  );
+  return new Map((response.data ?? []).map((img) => [img.hash, img]));
+}
+
+function safeHostname(url: string | undefined): string | undefined {
+  if (!url) return undefined;
+  try {
+    return new URL(url).hostname;
+  } catch {
+    return undefined;
+  }
+}
+
+// URLs echoed back in tool metadata must never carry credentials, even if a
+// Meta response ever embeds them. Clean URLs are returned byte-identical —
+// re-serializing would re-encode the query and could invalidate CDN
+// signatures. CDN signing params (oh/oe) always stay.
+function sanitizeMetadataUrl(url: string | undefined): string | undefined {
+  if (!url) return undefined;
+  try {
+    const parsed = new URL(url);
+    const hasUserinfo = parsed.username !== "" || parsed.password !== "";
+    const hasTokenParam = parsed.searchParams.has("access_token");
+    const hasTokenFragment = parsed.hash.toLowerCase().includes("access_token");
+    if (!hasUserinfo && !hasTokenParam && !hasTokenFragment) return url;
+    parsed.username = "";
+    parsed.password = "";
+    parsed.searchParams.delete("access_token");
+    if (hasTokenFragment) parsed.hash = "";
+    return parsed.toString();
+  } catch {
+    return undefined;
+  }
+}
+
+export interface CreativeMediaDeps {
+  download?: typeof downloadSafePublicImage;
+}
+
+export function registerCreativeMediaTools(server: McpServer, deps: CreativeMediaDeps = {}): void {
+  const download = deps.download ?? downloadSafePublicImage;
+
+  server.registerTool(
+    "ads_get_creative_media",
+    {
+      description:
+        "Download the actual creative media for an ad or creative and return the images inline for visual analysis. Images (including carousel cards and video thumbnails) come back as image content blocks a multimodal model can see directly; videos additionally return a short-lived signed source URL in the JSON metadata for external download or analysis (e.g. curl or a video-capable model).",
+      inputSchema: {
+        ad_id: z.string().optional().describe("Ad ID — its creative is resolved automatically"),
+        creative_id: z.string().optional().describe("Creative ID (alternative to ad_id)"),
+        account_id: z
+          .string()
+          .optional()
+          .describe("Ad account ID (act_… or numeric). Only needed as a fallback when the creative references image hashes and the account cannot be derived from the ad/creative"),
+        image_size: z
+          .enum(["full", "small"])
+          .default("full")
+          .describe("full = original CDN image; small = 128px preview (url_128) when available — cheaper on context"),
+        max_images: z
+          .number()
+          .min(1)
+          .max(10)
+          .default(5)
+          .describe("Cap on returned image blocks (bounds response/context size)"),
+        include_videos: z
+          .boolean()
+          .default(true)
+          .describe("Also resolve videos: returns each video's thumbnail as an image block plus its signed source URL in the JSON metadata"),
+      },
+      annotations: { ...READ },
+    },
+    async ({ ad_id, creative_id, account_id, image_size = "full", max_images = 5, include_videos = true }) => {
+      if (!ad_id && !creative_id) {
+        throw new Error("Either ad_id or creative_id is required.");
+      }
+      if (ad_id && creative_id) {
+        throw new Error("Provide either ad_id or creative_id, not both.");
+      }
+
+      let resolvedAccountId = account_id ? normalizeAccountId(account_id) : undefined;
+      let creativeId = creative_id;
+
+      if (ad_id) {
+        const adId = validateMetaId(ad_id, "ad");
+        const ad = await metaApiClient.get<{ id: string; account_id?: string; creative?: { id: string } }>(
+          `/${adId}`,
+          { fields: "id,account_id,creative{id}" },
+        );
+        if (!ad.creative?.id) {
+          throw new Error(`Ad ${adId} has no creative attached.`);
+        }
+        creativeId = ad.creative.id;
+        if (!resolvedAccountId && ad.account_id) {
+          resolvedAccountId = normalizeAccountId(ad.account_id);
+        }
+      }
+
+      const id = validateMetaId(creativeId as string, "creative");
+      // thumbnail_width/height make Graph return an upsized thumbnail_url, so the
+      // boosted-post fallback yields an analyzable image instead of a 64px one.
+      const creative = await metaApiClient.get<AdCreative>(`/${id}`, {
+        fields: [...CREATIVE_DEFAULT_FIELDS, "account_id"].join(","),
+        thumbnail_width: 1080,
+        thumbnail_height: 1080,
+      });
+      if (!resolvedAccountId && creative.account_id) {
+        resolvedAccountId = normalizeAccountId(creative.account_id);
+      }
+
+      const { images, videos } = collectCreativeMedia(creative);
+      const warnings: string[] = [];
+
+      // In "small" mode a hash is worth resolving even when the spec already
+      // carries a full-size URL — the adimages lookup is what provides url_128.
+      const wantSmall = image_size === "small";
+      const hashesToResolve = new Set<string>();
+      for (const ref of images) {
+        if (ref.hash && (!ref.url || wantSmall)) hashesToResolve.add(ref.hash);
+      }
+      for (const ref of videos) {
+        if (ref.specThumbnailHash && (!ref.specThumbnailUrl || wantSmall)) hashesToResolve.add(ref.specThumbnailHash);
+      }
+
+      let hashMap = new Map<string, AdImage>();
+      if (hashesToResolve.size > 0) {
+        if (resolvedAccountId) {
+          try {
+            hashMap = await resolveImageHashes(resolvedAccountId, [...hashesToResolve]);
+          } catch (err) {
+            warnings.push(`Image hash lookup failed: ${err instanceof Error ? err.message : String(err)}`);
+          }
+        } else {
+          const blockedByMissingAccount =
+            images.some((ref) => ref.hash && !ref.url)
+            || videos.some((ref) => ref.specThumbnailHash && !ref.specThumbnailUrl);
+          if (blockedByMissingAccount) warnings.push(MISSING_ACCOUNT_HINT);
+        }
+      }
+
+      const resolvedHashUrl = (hash?: string): string | undefined => {
+        if (!hash) return undefined;
+        const resolved = hashMap.get(hash);
+        return wantSmall ? resolved?.url_128 ?? resolved?.url : resolved?.url;
+      };
+
+      const imageAssets: ImageAssetMeta[] = images.map((ref) => {
+        const resolved = ref.hash ? hashMap.get(ref.hash) : undefined;
+        const fullUrl = resolved?.url ?? ref.url;
+        const sourceUrl = image_size === "small" ? resolved?.url_128 ?? fullUrl : fullUrl;
+        return {
+          role: ref.role,
+          carousel_index: ref.carouselIndex,
+          image_hash: ref.hash,
+          width: resolved?.width,
+          height: resolved?.height,
+          permalink_url: resolved?.permalink_url,
+          source_url: sourceUrl,
+          downloaded: false,
+          error: sourceUrl ? undefined : (resolvedAccountId ? "No downloadable URL found for this image." : MISSING_ACCOUNT_HINT),
+        };
+      });
+
+      const videoAssets: VideoAssetMeta[] = [];
+      const videoThumbAssets = new Map<string, ImageAssetMeta>();
+      if (include_videos) {
+        for (const ref of videos) {
+          try {
+            const video = await metaApiClient.get<AdVideo>(
+              `/${validateMetaId(ref.videoId, "video")}`,
+              { fields: VIDEO_DETAIL_FIELDS.join(",") },
+            );
+            const thumbnailUrl = pickVideoThumbnailUrl(video, image_size)
+              ?? (wantSmall ? resolvedHashUrl(ref.specThumbnailHash) ?? ref.specThumbnailUrl : ref.specThumbnailUrl ?? resolvedHashUrl(ref.specThumbnailHash));
+            if (thumbnailUrl) {
+              const thumbAsset: ImageAssetMeta = {
+                role: "video_thumbnail",
+                source_url: thumbnailUrl,
+                downloaded: false,
+              };
+              imageAssets.push(thumbAsset);
+              videoThumbAssets.set(video.id, thumbAsset);
+            }
+            videoAssets.push({
+              video_id: video.id,
+              title: video.title,
+              length_seconds: video.length,
+              source_url: video.source,
+              download_hint: video.source
+                ? `Download with: curl -L -o video_${video.id}.mp4 "<source_url>" — or pass the URL directly to a video-capable model (e.g. Gemini).`
+                : undefined,
+              error: video.source ? undefined : "Video source URL not available (still processing, or missing permission).",
+            });
+          } catch (err) {
+            const fallbackThumb = wantSmall
+              ? resolvedHashUrl(ref.specThumbnailHash) ?? ref.specThumbnailUrl
+              : ref.specThumbnailUrl ?? resolvedHashUrl(ref.specThumbnailHash);
+            if (fallbackThumb) {
+              const thumbAsset: ImageAssetMeta = {
+                role: "video_thumbnail",
+                source_url: fallbackThumb,
+                downloaded: false,
+              };
+              imageAssets.push(thumbAsset);
+              videoThumbAssets.set(ref.videoId, thumbAsset);
+            }
+            videoAssets.push({
+              video_id: ref.videoId,
+              error: err instanceof Error ? err.message : String(err),
+            });
+          }
+        }
+      }
+
+      let totalBytes = 0;
+      let blockIndex = 0;
+      const imageBlocks: ToolContentBlock[] = [];
+      for (const asset of imageAssets) {
+        if (!asset.source_url) continue;
+        if (imageBlocks.length >= max_images) {
+          asset.skipped = "max_images";
+          continue;
+        }
+        const remainingBudget = TOTAL_BYTES_BUDGET - totalBytes;
+        if (remainingBudget <= 0) {
+          asset.skipped = "size_budget";
+          continue;
+        }
+        try {
+          const downloaded = await download(asset.source_url, {
+            maxBytes: Math.min(MAX_IMAGE_BYTES, remainingBudget),
+          });
+          totalBytes += downloaded.buffer.length;
+          imageBlocks.push({
+            type: "image",
+            data: downloaded.buffer.toString("base64"),
+            mimeType: downloaded.contentType,
+          });
+          asset.downloaded = true;
+          asset.block_index = blockIndex;
+          asset.mime_type = downloaded.contentType;
+          asset.bytes = downloaded.buffer.length;
+          blockIndex += 1;
+        } catch (err) {
+          asset.error = err instanceof Error ? err.message : String(err);
+          logger.warn(
+            { imageHost: safeHostname(asset.source_url), role: asset.role },
+            "Creative media download failed",
+          );
+        }
+      }
+
+      for (const video of videoAssets) {
+        const thumbAsset = videoThumbAssets.get(video.video_id);
+        if (thumbAsset?.downloaded) video.thumbnail_block_index = thumbAsset.block_index;
+      }
+
+      if (videoAssets.some((v) => v.source_url)) {
+        warnings.push(VIDEO_EXPIRY_WARNING);
+      }
+
+      const downloadedCount = imageAssets.filter((a) => a.downloaded).length;
+      const failedCount = imageAssets.filter((a) => !a.downloaded && a.error).length;
+      const skippedCount = imageAssets.filter((a) => a.skipped).length;
+
+      const summaryLines: string[] = [];
+      if (downloadedCount === 0 && videoAssets.length === 0) {
+        summaryLines.push(`No downloadable media found for creative ${creative.id}.`);
+      } else {
+        summaryLines.push(
+          `Creative ${creative.id} (${creative.name ?? "Unnamed"}): ${downloadedCount} image(s) attached below${failedCount ? `, ${failedCount} failed` : ""}${skippedCount ? `, ${skippedCount} skipped (limits)` : ""}.`,
+        );
+        const roles = imageAssets
+          .filter((a) => a.downloaded)
+          .map((a) => a.role + (a.carousel_index !== undefined ? `#${a.carousel_index}` : ""));
+        if (roles.length > 0) summaryLines.push(`Image roles, in block order: ${roles.join(", ")}.`);
+        for (const video of videoAssets) {
+          summaryLines.push(
+            video.source_url
+              ? `Video ${video.video_id}${video.length_seconds ? ` (${video.length_seconds}s)` : ""}: not embeddable as an MCP block — download it via the signed source_url in the JSON metadata (curl -L -o video_${video.video_id}.mp4 "<source_url>") or hand that URL to a video-capable model.`
+              : `Video ${video.video_id}: ${video.error ?? "no source URL available"}.`,
+          );
+        }
+      }
+      if (warnings.length > 0) {
+        summaryLines.push(...warnings.map((w) => `⚠ ${w}`));
+      }
+
+      const metadata = {
+        creative_id: creative.id,
+        ad_id: ad_id ?? undefined,
+        account_id: resolvedAccountId,
+        images: imageAssets.map((asset) => ({
+          ...asset,
+          source_url: sanitizeMetadataUrl(asset.source_url),
+          permalink_url: sanitizeMetadataUrl(asset.permalink_url),
+        })),
+        videos: videoAssets.map((video) => ({
+          ...video,
+          source_url: sanitizeMetadataUrl(video.source_url),
+        })),
+        warnings,
+      };
+
+      return {
+        content: [
+          { type: "text", text: summaryLines.join("\n") },
+          ...imageBlocks,
+          { type: "text", text: JSON.stringify(metadata, null, 2) },
+        ] satisfies ToolContentBlock[],
+      };
+    },
+  );
+}

--- a/src/tools/creatives.ts
+++ b/src/tools/creatives.ts
@@ -42,16 +42,16 @@ export const ctaEnum = z.enum([
   "SHOP_WITH_AI", "TRY_ON_WITH_AI",
 ]);
 
-function asRecord(value: unknown): Record<string, unknown> | undefined {
+export function asRecord(value: unknown): Record<string, unknown> | undefined {
   return typeof value === "object" && value !== null ? value as Record<string, unknown> : undefined;
 }
 
-function getString(record: Record<string, unknown> | undefined, key: string): string | undefined {
+export function getString(record: Record<string, unknown> | undefined, key: string): string | undefined {
   const value = record?.[key];
   return typeof value === "string" && value.length > 0 ? value : undefined;
 }
 
-function getNestedString(record: Record<string, unknown> | undefined, path: string[]): string | undefined {
+export function getNestedString(record: Record<string, unknown> | undefined, path: string[]): string | undefined {
   let current: unknown = record;
   for (const key of path) {
     if (typeof current !== "object" || current === null || !(key in current)) {

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -4,6 +4,7 @@ import { registerCampaignTools } from "./campaigns.js";
 import { registerAdSetTools } from "./adsets.js";
 import { registerAdTools } from "./ads.js";
 import { registerCreativeTools } from "./creatives.js";
+import { registerCreativeMediaTools } from "./creative-media.js";
 import { registerInsightsTools } from "./insights.js";
 import { registerInsightsViewTools } from "./insights-views.js";
 import { registerTargetingTools } from "./targeting.js";
@@ -46,6 +47,7 @@ export function registerAllTools(server: McpServer): void {
   registerAdSetTools(server);        // 6 tools
   registerAdTools(server);           // 6 tools
   registerCreativeTools(server);     // 9 tools
+  registerCreativeMediaTools(server); // 1 tool — creative media as inline image blocks
   registerEntityTools(server);       // 3 tools — generic helpers (get_ad_entities, update_entity, activate_entity)
   registerInsightsTools(server);     // 1 tool  — power-tool ads_get_insights
   registerInsightsViewTools(server); // 5 tools — semantic insight views
@@ -84,5 +86,5 @@ export function registerAllTools(server: McpServer): void {
   // ─── Token Management ────────────────────────────────────
   registerTokenTools(server);        // 4 tools — list / set-active / register / delete
 
-  // Total: 126 tools (79 renamed + 14 new in v3 + 3 audience-sharing + 1 invoices + 27 WhatsApp + 1 url-tags + 1 bulk video ads)
+  // Total: 127 tools (79 renamed + 14 new in v3 + 3 audience-sharing + 1 invoices + 27 WhatsApp + 1 url-tags + 1 bulk video ads + 1 creative media)
 }

--- a/tests/tools/creative-media.test.ts
+++ b/tests/tools/creative-media.test.ts
@@ -1,0 +1,571 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { registerCreativeMediaTools, collectCreativeMedia, pickVideoThumbnailUrl } from "../../src/tools/creative-media.js";
+import { downloadSafePublicImage } from "../../src/utils/safe-download.js";
+import { createMockMcpServer, mockFetchResponse, setupTestToken, cleanupTestToken } from "../setup.js";
+
+type ToolResult = { content: Array<Record<string, unknown>> };
+
+function fakeDownload() {
+  return vi.fn(async (url: string) => ({
+    buffer: Buffer.from("img"),
+    contentType: "image/jpeg",
+    extension: ".jpg" as const,
+    finalUrl: new URL(url),
+  }));
+}
+
+function registerWithDownload(download = fakeDownload()) {
+  const server = createMockMcpServer();
+  registerCreativeMediaTools(server as never, { download: download as never });
+  return { server, download, handler: server._registeredTools[0].handler };
+}
+
+function fetchCalls(): string[] {
+  const fetchMock = globalThis.fetch as ReturnType<typeof vi.fn>;
+  return fetchMock.mock.calls.map((call) => String(call[0]));
+}
+
+function resultJson(result: ToolResult): Record<string, unknown> {
+  const last = result.content[result.content.length - 1];
+  return JSON.parse(last.text as string) as Record<string, unknown>;
+}
+
+describe("registerCreativeMediaTools", () => {
+  beforeEach(() => setupTestToken());
+  afterEach(() => {
+    cleanupTestToken();
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("registers exactly one read-only tool with a meaningful description", () => {
+    const { server } = registerWithDownload();
+    expect(server.registerTool).toHaveBeenCalledTimes(1);
+    const tool = server._registeredTools[0];
+    expect(tool.name).toBe("ads_get_creative_media");
+    expect(tool.annotations?.readOnlyHint).toBe(true);
+    expect(tool.description.length).toBeGreaterThan(10);
+  });
+
+  it("requires exactly one of ad_id or creative_id", async () => {
+    const { handler } = registerWithDownload();
+    vi.stubGlobal("fetch", vi.fn());
+
+    await expect(handler({})).rejects.toThrow(/ad_id or creative_id is required/);
+    await expect(handler({ ad_id: "1", creative_id: "2" })).rejects.toThrow(/not both/);
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
+  it("returns a simple image creative as an inline image block", async () => {
+    const { handler, download } = registerWithDownload();
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValueOnce(mockFetchResponse({
+      id: "40123",
+      name: "Test creative",
+      image_url: "https://cdn.example.com/full.jpg",
+    })));
+
+    const result = await handler({ creative_id: "40123" }) as ToolResult;
+
+    expect(fetchCalls()).toHaveLength(1);
+    expect(fetchCalls()[0]).toContain("/40123");
+    expect(fetchCalls()[0]).toContain("thumbnail_width=1080");
+    expect(download).toHaveBeenCalledWith("https://cdn.example.com/full.jpg", expect.objectContaining({ maxBytes: expect.any(Number) }));
+
+    expect(result.content).toHaveLength(3);
+    expect(result.content[0].type).toBe("text");
+    expect(result.content[1]).toEqual({
+      type: "image",
+      data: Buffer.from("img").toString("base64"),
+      mimeType: "image/jpeg",
+    });
+
+    const json = resultJson(result);
+    const images = json.images as Array<Record<string, unknown>>;
+    expect(images[0]).toMatchObject({ role: "primary", block_index: 0, downloaded: true, bytes: 3 });
+  });
+
+  it("resolves the creative and account from an ad_id", async () => {
+    const { handler, download } = registerWithDownload();
+    vi.stubGlobal("fetch", vi.fn()
+      .mockResolvedValueOnce(mockFetchResponse({ id: "120001", account_id: "111", creative: { id: "40123" } }))
+      .mockResolvedValueOnce(mockFetchResponse({ id: "40123", name: "C", image_hash: "h1" }))
+      .mockResolvedValueOnce(mockFetchResponse({ data: [{ hash: "h1", url: "https://cdn.example.com/h1.jpg", width: 1080, height: 1080 }] })));
+
+    const result = await handler({ ad_id: "120001" }) as ToolResult;
+
+    const calls = fetchCalls();
+    expect(calls[0]).toContain("/120001");
+    expect(calls[0]).toContain(encodeURIComponent("creative{id}"));
+    expect(calls[1]).toContain("/40123");
+    expect(calls[2]).toContain("/act_111/adimages");
+    expect(download).toHaveBeenCalledWith("https://cdn.example.com/h1.jpg", expect.anything());
+
+    const json = resultJson(result);
+    expect(json.account_id).toBe("act_111");
+    const images = json.images as Array<Record<string, unknown>>;
+    expect(images[0]).toMatchObject({ image_hash: "h1", width: 1080, downloaded: true });
+  });
+
+  it("handles carousels with one batched hash lookup and dedupes repeated hashes", async () => {
+    const { handler, download } = registerWithDownload();
+    vi.stubGlobal("fetch", vi.fn()
+      .mockResolvedValueOnce(mockFetchResponse({
+        id: "40123",
+        name: "Carousel",
+        account_id: "111",
+        object_story_spec: {
+          link_data: {
+            child_attachments: [
+              { image_hash: "h1" },
+              { image_hash: "h2" },
+              { image_hash: "h1" },
+            ],
+          },
+        },
+      }))
+      .mockResolvedValueOnce(mockFetchResponse({ data: [
+        { hash: "h1", url: "https://cdn.example.com/h1.jpg" },
+        { hash: "h2", url: "https://cdn.example.com/h2.jpg" },
+      ] })));
+
+    const result = await handler({ creative_id: "40123" }) as ToolResult;
+
+    const adimagesCalls = fetchCalls().filter((u) => u.includes("/adimages"));
+    expect(adimagesCalls).toHaveLength(1);
+    expect(adimagesCalls[0]).toContain(encodeURIComponent(JSON.stringify(["h1", "h2"])));
+    expect(download).toHaveBeenCalledTimes(2);
+
+    const images = resultJson(result).images as Array<Record<string, unknown>>;
+    expect(images).toHaveLength(2);
+    expect(images[0]).toMatchObject({ role: "carousel_child", carousel_index: 0 });
+    expect(images[1]).toMatchObject({ role: "carousel_child", carousel_index: 1 });
+  });
+
+  it("reports hash-only images as unresolved when no account_id can be derived", async () => {
+    const { handler, download } = registerWithDownload();
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValueOnce(mockFetchResponse({
+      id: "40123",
+      name: "C",
+      image_hash: "h1",
+    })));
+
+    const result = await handler({ creative_id: "40123" }) as ToolResult;
+
+    expect(fetchCalls()).toHaveLength(1);
+    expect(download).not.toHaveBeenCalled();
+
+    const json = resultJson(result);
+    const images = json.images as Array<Record<string, unknown>>;
+    expect(images[0].downloaded).toBe(false);
+    expect(String(images[0].error)).toContain("account_id");
+    expect((json.warnings as string[]).some((w) => w.includes("account_id"))).toBe(true);
+  });
+
+  it("returns video creatives as thumbnail block + signed source URL in metadata", async () => {
+    const { handler, download } = registerWithDownload();
+    const videoFetch = vi.fn()
+      .mockResolvedValueOnce(mockFetchResponse({
+        id: "40123",
+        name: "Video creative",
+        object_story_spec: { video_data: { video_id: "501" } },
+      }))
+      .mockResolvedValueOnce(mockFetchResponse({
+        id: "501",
+        title: "Spot",
+        length: 15,
+        source: "https://video.example.com/v.mp4?sig=abc",
+        picture: "https://cdn.example.com/small.jpg",
+        thumbnails: { data: [
+          { uri: "https://cdn.example.com/t-small.jpg", width: 128, height: 128 },
+          { uri: "https://cdn.example.com/t-big.jpg", width: 1080, height: 1080 },
+        ] },
+      }));
+    vi.stubGlobal("fetch", videoFetch);
+
+    const result = await handler({ creative_id: "40123" }) as ToolResult;
+
+    expect(fetchCalls()[1]).toContain("/501");
+    expect(download).toHaveBeenCalledWith("https://cdn.example.com/t-big.jpg", expect.anything());
+
+    const json = resultJson(result);
+    const videos = json.videos as Array<Record<string, unknown>>;
+    expect(videos[0]).toMatchObject({
+      video_id: "501",
+      source_url: "https://video.example.com/v.mp4?sig=abc",
+      thumbnail_block_index: 0,
+      length_seconds: 15,
+    });
+    expect(String(videos[0].download_hint)).toContain("curl");
+    expect((json.warnings as string[]).some((w) => w.includes("expire"))).toBe(true);
+    expect(String(result.content[0].text)).toContain("source_url");
+  });
+
+  it("skips video resolution when include_videos is false", async () => {
+    const { handler, download } = registerWithDownload();
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValueOnce(mockFetchResponse({
+      id: "40123",
+      name: "Video creative",
+      object_story_spec: { video_data: { video_id: "501" } },
+    })));
+
+    const result = await handler({ creative_id: "40123", include_videos: false }) as ToolResult;
+
+    expect(fetchCalls()).toHaveLength(1);
+    expect(download).not.toHaveBeenCalled();
+    expect(resultJson(result).videos).toEqual([]);
+  });
+
+  it("caps the cumulative download budget by shrinking maxBytes per download", async () => {
+    const seven = 7 * 1024 * 1024;
+    const download = vi.fn(async (url: string) => ({
+      buffer: Buffer.alloc(seven),
+      contentType: "image/jpeg",
+      extension: ".jpg" as const,
+      finalUrl: new URL(url),
+    }));
+    const { handler } = registerWithDownload(download);
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValueOnce(mockFetchResponse({
+      id: "40123",
+      name: "Feed",
+      asset_feed_spec: { images: [
+        { url: "https://cdn.example.com/1.jpg" },
+        { url: "https://cdn.example.com/2.jpg" },
+        { url: "https://cdn.example.com/3.jpg" },
+      ] },
+    })));
+
+    await handler({ creative_id: "40123" });
+
+    const maxBytesPerCall = download.mock.calls.map((call) => (call[1] as { maxBytes: number }).maxBytes);
+    expect(maxBytesPerCall).toEqual([
+      8 * 1024 * 1024,
+      8 * 1024 * 1024,
+      20 * 1024 * 1024 - 2 * seven,
+    ]);
+  });
+
+  it("strips access_token and userinfo from metadata URLs but downloads the original", async () => {
+    const { handler, download } = registerWithDownload();
+    const tokenUrl = "https://cdn.example.com/full.jpg?access_token=SECRETTOKEN123&oh=keepme";
+    vi.stubGlobal("fetch", vi.fn()
+      .mockResolvedValueOnce(mockFetchResponse({
+        id: "40123",
+        name: "C",
+        image_url: tokenUrl,
+        object_story_spec: { video_data: { video_id: "501" } },
+      }))
+      .mockResolvedValueOnce(mockFetchResponse({
+        id: "501",
+        source: "https://user:pass@video.example.com/v.mp4?access_token=SECRETTOKEN123&sig=ok",
+        picture: "https://cdn.example.com/pic.jpg",
+      })));
+
+    const result = await handler({ creative_id: "40123" }) as ToolResult;
+
+    expect(download).toHaveBeenCalledWith(tokenUrl, expect.anything());
+    const serialized = JSON.stringify(resultJson(result));
+    expect(serialized).not.toContain("SECRETTOKEN123");
+    expect(serialized).not.toContain("user:pass@");
+    const json = resultJson(result);
+    expect((json.images as Array<Record<string, unknown>>)[0].source_url).toContain("oh=keepme");
+    expect((json.videos as Array<Record<string, unknown>>)[0].source_url).toContain("sig=ok");
+  });
+
+  it("resolves hashes in small mode even when the spec already has a full URL", async () => {
+    const { handler, download } = registerWithDownload();
+    vi.stubGlobal("fetch", vi.fn()
+      .mockResolvedValueOnce(mockFetchResponse({
+        id: "40123",
+        name: "C",
+        account_id: "111",
+        image_hash: "h1",
+        image_url: "https://cdn.example.com/full.jpg",
+      }))
+      .mockResolvedValueOnce(mockFetchResponse({ data: [
+        { hash: "h1", url: "https://cdn.example.com/full.jpg", url_128: "https://cdn.example.com/small.jpg" },
+      ] })));
+
+    await handler({ creative_id: "40123", image_size: "small" });
+
+    expect(fetchCalls().some((u) => u.includes("/adimages"))).toBe(true);
+    expect(download).toHaveBeenCalledWith("https://cdn.example.com/small.jpg", expect.anything());
+  });
+
+  it("still returns the spec thumbnail when the video detail fetch fails", async () => {
+    const { handler, download } = registerWithDownload();
+    vi.stubGlobal("fetch", vi.fn()
+      .mockResolvedValueOnce(mockFetchResponse({
+        id: "40123",
+        name: "Video creative",
+        object_story_spec: { video_data: { video_id: "501", image_url: "https://cdn.example.com/spec-thumb.jpg" } },
+      }))
+      .mockResolvedValueOnce(mockFetchResponse({ error: { message: "video gone", code: 100 } }, { status: 400 })));
+
+    const result = await handler({ creative_id: "40123" }) as ToolResult;
+
+    expect(download).toHaveBeenCalledWith("https://cdn.example.com/spec-thumb.jpg", expect.anything());
+    const json = resultJson(result);
+    const videos = json.videos as Array<Record<string, unknown>>;
+    expect(videos[0].error).toBeDefined();
+    expect(videos[0].thumbnail_block_index).toBe(0);
+    const images = json.images as Array<Record<string, unknown>>;
+    expect(images[0]).toMatchObject({ role: "video_thumbnail", downloaded: true });
+  });
+
+  it("returns clean metadata URLs byte-identical and strips fragment tokens", async () => {
+    const { handler } = registerWithDownload();
+    const preEncodedUrl = "https://cdn.example.com/a%20b.jpg?sig=x%2By&oh=~z";
+    vi.stubGlobal("fetch", vi.fn()
+      .mockResolvedValueOnce(mockFetchResponse({
+        id: "40123",
+        name: "C",
+        image_url: preEncodedUrl,
+        object_story_spec: { video_data: { video_id: "501" } },
+      }))
+      .mockResolvedValueOnce(mockFetchResponse({
+        id: "501",
+        source: "https://video.example.com/v.mp4#access_token=SECRETFRAG",
+        picture: "https://cdn.example.com/pic.jpg",
+      })));
+
+    const result = await handler({ creative_id: "40123" }) as ToolResult;
+
+    const json = resultJson(result);
+    expect((json.images as Array<Record<string, unknown>>)[0].source_url).toBe(preEncodedUrl);
+    expect(JSON.stringify(json)).not.toContain("SECRETFRAG");
+  });
+
+  it("does not warn about account_id in small mode when a full URL is available", async () => {
+    const { handler, download } = registerWithDownload();
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValueOnce(mockFetchResponse({
+      id: "40123",
+      name: "C",
+      image_hash: "h1",
+      image_url: "https://cdn.example.com/full.jpg",
+    })));
+
+    const result = await handler({ creative_id: "40123", image_size: "small" }) as ToolResult;
+
+    expect(download).toHaveBeenCalledWith("https://cdn.example.com/full.jpg", expect.anything());
+    const json = resultJson(result);
+    expect(json.warnings).toEqual([]);
+    expect((json.images as Array<Record<string, unknown>>)[0].downloaded).toBe(true);
+  });
+
+  it("uses url_128 for the spec thumbnail in small mode when the video detail fetch fails", async () => {
+    const { handler, download } = registerWithDownload();
+    vi.stubGlobal("fetch", vi.fn()
+      .mockResolvedValueOnce(mockFetchResponse({
+        id: "40123",
+        name: "Video creative",
+        account_id: "111",
+        object_story_spec: { video_data: { video_id: "501", image_hash: "th1" } },
+      }))
+      .mockResolvedValueOnce(mockFetchResponse({ data: [
+        { hash: "th1", url: "https://cdn.example.com/thumb-full.jpg", url_128: "https://cdn.example.com/thumb-small.jpg" },
+      ] }))
+      .mockResolvedValueOnce(mockFetchResponse({ error: { message: "video gone", code: 100 } }, { status: 400 })));
+
+    await handler({ creative_id: "40123", image_size: "small" });
+
+    expect(download).toHaveBeenCalledWith("https://cdn.example.com/thumb-small.jpg", expect.anything());
+  });
+
+  it("prefers url_128 when image_size is small", async () => {
+    const { handler, download } = registerWithDownload();
+    vi.stubGlobal("fetch", vi.fn()
+      .mockResolvedValueOnce(mockFetchResponse({ id: "40123", name: "C", account_id: "111", image_hash: "h1" }))
+      .mockResolvedValueOnce(mockFetchResponse({ data: [
+        { hash: "h1", url: "https://cdn.example.com/full.jpg", url_128: "https://cdn.example.com/small.jpg" },
+      ] })));
+
+    await handler({ creative_id: "40123", image_size: "small" });
+
+    expect(download).toHaveBeenCalledWith("https://cdn.example.com/small.jpg", expect.anything());
+  });
+
+  it("caps returned blocks at max_images and marks the rest skipped", async () => {
+    const { handler, download } = registerWithDownload();
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValueOnce(mockFetchResponse({
+      id: "40123",
+      name: "Feed",
+      asset_feed_spec: { images: [
+        { url: "https://cdn.example.com/1.jpg" },
+        { url: "https://cdn.example.com/2.jpg" },
+        { url: "https://cdn.example.com/3.jpg" },
+      ] },
+    })));
+
+    const result = await handler({ creative_id: "40123", max_images: 2 }) as ToolResult;
+
+    expect(download).toHaveBeenCalledTimes(2);
+    const images = resultJson(result).images as Array<Record<string, unknown>>;
+    expect(images.filter((i) => i.downloaded)).toHaveLength(2);
+    expect(images[2].skipped).toBe("max_images");
+    expect(result.content.filter((c) => c.type === "image")).toHaveLength(2);
+  });
+
+  it("continues past a failing download and reports the error", async () => {
+    const download = vi.fn()
+      .mockImplementationOnce(async (url: string) => ({ buffer: Buffer.from("img"), contentType: "image/jpeg", extension: ".jpg" as const, finalUrl: new URL(url) }))
+      .mockRejectedValueOnce(new Error("boom"))
+      .mockImplementationOnce(async (url: string) => ({ buffer: Buffer.from("img"), contentType: "image/jpeg", extension: ".jpg" as const, finalUrl: new URL(url) }));
+    const { handler } = registerWithDownload(download);
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValueOnce(mockFetchResponse({
+      id: "40123",
+      name: "Feed",
+      asset_feed_spec: { images: [
+        { url: "https://cdn.example.com/1.jpg" },
+        { url: "https://cdn.example.com/2.jpg" },
+        { url: "https://cdn.example.com/3.jpg" },
+      ] },
+    })));
+
+    const result = await handler({ creative_id: "40123" }) as ToolResult;
+
+    const images = resultJson(result).images as Array<Record<string, unknown>>;
+    expect(images[0]).toMatchObject({ downloaded: true, block_index: 0 });
+    expect(images[1]).toMatchObject({ downloaded: false, error: "boom" });
+    expect(images[2]).toMatchObject({ downloaded: true, block_index: 1 });
+    expect(result.content.filter((c) => c.type === "image")).toHaveLength(2);
+  });
+
+  it("refuses images resolving to private IPs when wired to the real downloader", async () => {
+    const download = vi.fn(async (url: string) =>
+      downloadSafePublicImage(url, {
+        resolve: async () => [{ address: "10.0.0.5" }],
+      }));
+    const { handler } = registerWithDownload(download as never);
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValueOnce(mockFetchResponse({
+      id: "40123",
+      name: "C",
+      image_url: "https://internal.example.com/image.jpg",
+    })));
+
+    const result = await handler({ creative_id: "40123" }) as ToolResult;
+
+    const images = resultJson(result).images as Array<Record<string, unknown>>;
+    expect(images[0].downloaded).toBe(false);
+    expect(String(images[0].error)).toMatch(/private IP/);
+    expect(result.content.filter((c) => c.type === "image")).toHaveLength(0);
+  });
+
+  it("returns a text-only result when the creative has no media", async () => {
+    const { handler, download } = registerWithDownload();
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValueOnce(mockFetchResponse({
+      id: "40123",
+      name: "Empty",
+    })));
+
+    const result = await handler({ creative_id: "40123" }) as ToolResult;
+
+    expect(download).not.toHaveBeenCalled();
+    expect(result.content).toHaveLength(2);
+    expect(String(result.content[0].text)).toContain("No downloadable media found");
+  });
+
+  it("falls back to the upsized thumbnail_url for boosted-post creatives", async () => {
+    const { handler, download } = registerWithDownload();
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValueOnce(mockFetchResponse({
+      id: "40123",
+      name: "Boosted",
+      thumbnail_url: "https://cdn.example.com/thumb.jpg",
+      effective_object_story_id: "111_222",
+    })));
+
+    const result = await handler({ creative_id: "40123" }) as ToolResult;
+
+    expect(fetchCalls()[0]).toContain("thumbnail_width=1080");
+    expect(download).toHaveBeenCalledWith("https://cdn.example.com/thumb.jpg", expect.anything());
+    const images = resultJson(result).images as Array<Record<string, unknown>>;
+    expect(images[0]).toMatchObject({ role: "thumbnail_fallback", downloaded: true });
+  });
+});
+
+describe("collectCreativeMedia", () => {
+  it("walks all spec locations and dedupes by hash and url", () => {
+    const { images, videos } = collectCreativeMedia({
+      id: "1",
+      name: "c",
+      image_hash: "h1",
+      image_url: "https://cdn.example.com/h1.jpg",
+      object_story_spec: {
+        link_data: {
+          image_hash: "h1",
+          child_attachments: [
+            { image_hash: "h2" },
+            { video_id: "v1", image_hash: "h3" },
+          ],
+        },
+      },
+      asset_feed_spec: {
+        images: [{ hash: "h2" }, { url: "https://cdn.example.com/u1.jpg" }],
+        videos: [{ video_id: "v1" }, { video_id: "v2", thumbnail_url: "https://cdn.example.com/vt.jpg" }],
+      },
+    });
+
+    expect(images.map((i) => i.role)).toEqual(["primary", "carousel_child", "asset_feed_image"]);
+    expect(videos.map((v) => v.videoId)).toEqual(["v1", "v2"]);
+    expect(videos[1].specThumbnailUrl).toBe("https://cdn.example.com/vt.jpg");
+  });
+
+  it("merges two existing entries when a later reference connects them", () => {
+    const { images } = collectCreativeMedia({
+      id: "1",
+      name: "c",
+      image_hash: "h1",
+      asset_feed_spec: {
+        images: [
+          { url: "https://cdn.example.com/u1.jpg" },
+          { hash: "h1", url: "https://cdn.example.com/u1.jpg" },
+        ],
+      },
+    });
+
+    expect(images).toHaveLength(1);
+    expect(images[0]).toMatchObject({
+      role: "primary",
+      hash: "h1",
+      url: "https://cdn.example.com/u1.jpg",
+    });
+  });
+
+  it("merges hash-only and url-only references to the same image", () => {
+    const { images } = collectCreativeMedia({
+      id: "1",
+      name: "c",
+      image_url: "https://cdn.example.com/same.jpg",
+      asset_feed_spec: {
+        images: [{ hash: "h9", url: "https://cdn.example.com/same.jpg" }],
+      },
+    });
+
+    expect(images).toHaveLength(1);
+    expect(images[0]).toMatchObject({
+      role: "primary",
+      url: "https://cdn.example.com/same.jpg",
+      hash: "h9",
+    });
+  });
+});
+
+describe("pickVideoThumbnailUrl", () => {
+  const video = {
+    id: "501",
+    picture: "https://cdn.example.com/picture.jpg",
+    thumbnails: { data: [
+      { uri: "https://cdn.example.com/small.jpg", width: 128, height: 128 },
+      { uri: "https://cdn.example.com/big.jpg", width: 1080, height: 1080 },
+    ] },
+  };
+
+  it("prefers the largest thumbnail at full size and picture at small size", () => {
+    expect(pickVideoThumbnailUrl(video, "full")).toBe("https://cdn.example.com/big.jpg");
+    expect(pickVideoThumbnailUrl(video, "small")).toBe("https://cdn.example.com/picture.jpg");
+  });
+
+  it("falls back across sources when fields are missing", () => {
+    expect(pickVideoThumbnailUrl({ id: "1", picture: "https://cdn.example.com/p.jpg" }, "full")).toBe("https://cdn.example.com/p.jpg");
+    expect(pickVideoThumbnailUrl({ id: "1" }, "small")).toBeUndefined();
+  });
+});

--- a/tests/tools/registration.test.ts
+++ b/tests/tools/registration.test.ts
@@ -3,16 +3,17 @@ import { registerAllTools } from "../../src/tools/index.js";
 import { createMockMcpServer } from "../setup.js";
 
 describe("registerAllTools", () => {
-  it("registers exactly 126 tools total", () => {
+  it("registers exactly 127 tools total", () => {
     // 79 v2 tools renamed (with account_insights removed → 79) + 14 new in v3 +
     //   3 audience-sharing tools (share / unshare / get-shared-accounts) +
     //   1 invoices tool (ads_get_invoices) +
     //   27 WhatsApp Business tools (whatsapp_*) +
     //   1 UTM editing tool (ads_update_ad_url_tags) +
-    //   1 bulk video-ad macro (ads_bulk_create_video_ads).
+    //   1 bulk video-ad macro (ads_bulk_create_video_ads) +
+    //   1 creative media tool (ads_get_creative_media).
     const server = createMockMcpServer();
     registerAllTools(server as never);
-    expect(server.registerTool).toHaveBeenCalledTimes(126);
+    expect(server.registerTool).toHaveBeenCalledTimes(127);
   });
 
   it("registers all tools with unique names", () => {
@@ -102,6 +103,7 @@ describe("registerAllTools", () => {
     expect(names).toContain("ads_create_campaign");
     expect(names).toContain("ads_get_insights");
     expect(names).toContain("ads_get_creative_details");
+    expect(names).toContain("ads_get_creative_media");
     expect(names).toContain("ads_update_ad_url_tags");
     expect(names).toContain("ads_clone_ad_set_bundle");
 


### PR DESCRIPTION
## Summary

New read-only tool **`ads_get_creative_media`** (tool count 126 → 127): given an `ad_id` or `creative_id`, it resolves every media asset of the creative, downloads the images server-side and returns them as **inline MCP `image` content blocks** so a multimodal model (Claude, Gemini) can visually analyze the creative — today the server only ever returned URLs as text.

### What it resolves
- `image_url` / `image_hash` (batched `adimages` lookup for hashes)
- `object_story_spec.link_data` incl. carousel `child_attachments`
- `object_story_spec.video_data` and `asset_feed_spec` images/videos
- Upsized `thumbnail_url` fallback for boosted-post creatives (`thumbnail_width/height=1080`)

### Video support
MCP has no video block, so each video returns its best **thumbnail as an inline image** plus the **signed short-lived `source` URL** (+ ready-to-use `download_hint`) in the JSON metadata for external download or video-capable models, with an expiry warning.

### Safety & bounds
- All downloads go through the existing SSRF-hardened `downloadSafePublicImage` (https-only, private-IP guard, DNS pinning, MIME allowlist)
- `max_images` cap (default 5, max 10), 8 MB per image, 20 MB cumulative budget enforced via per-download `maxBytes`
- Metadata URLs sanitized: userinfo + `access_token` (query & fragment) stripped; clean URLs pass through byte-identical to preserve CDN signatures
- Partial failures (expired CDN URL, unresolvable hash, dead video) reported per-asset without failing the call

### Pre-PR audit
Diff audited twice with Codex CLI (read-only sandbox). All 5 first-round findings fixed (cumulative-budget enforcement, URL sanitization, hash/url dedupe merge, `small`-mode hash resolution, video-detail-failure thumbnail fallback) and re-verified in the second pass; the second pass's remaining nits were also addressed with dedicated tests.

## Test plan
- [x] 26 new tests in `tests/tools/creative-media.test.ts` (registration, XOR validation, ad→creative→account resolution, carousel batch+dedupe, merge of connected refs, video flow incl. detail-fetch failure fallback, `image_size: small` incl. `url_128`, `max_images` cap, byte-budget shrinking, download failure continuation, real-downloader SSRF rejection, URL sanitization, empty creative, boosted-post fallback)
- [x] Full suite: 528 tests, 42 files — all passing
- [x] `npm run lint` / `typecheck` / `build` clean
- [x] `gitleaks` (full history + staged) — no leaks

🤖 Generated with [Claude Code](https://claude.com/claude-code)