### PR TITLE
feat: Meta Ad Library scraping via Apify (8 ads_library_* tools)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -48,6 +48,13 @@ META_TOKENS=
 # Service-to-service API key (skips OAuth entirely)
 MCP_API_KEY=
 
+# ── Apify (Meta Ad Library scraping, optional) ───────────────
+# The primary path is per-tenant: each user registers their own token with
+# ads_library_register_apify_token and it is stored encrypted in Firestore.
+# This env var is only a fallback for stdio / single-operator deployments.
+# Get a token at https://console.apify.com/settings/integrations
+APIFY_TOKEN=
+
 # ── Server settings ──────────────────────────────────────────
 META_API_VERSION=v22.0
 PORT=3000

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -33,6 +33,14 @@ regex = '''EAA[A-Za-z0-9]{40,}'''
 tags = ["meta", "token"]
 
 [[rules]]
+id = "apify-api-token"
+description = "Apify API token (apify_api_ prefix)"
+# Real tokens are apify_api_ + ~36 base62 chars; require ≥20 to skip short
+# fixtures like "apify_api_bogus" while still catching real leaks.
+regex = '''apify_api_[A-Za-z0-9]{20,}'''
+tags = ["apify", "token"]
+
+[[rules]]
 id = "meta-tokens-json"
 description = "Meta multi-tenant tokens JSON map containing real EAA tokens"
 regex = '''(?i)META_TOKENS\s*[:=]\s*["']?\{[^}]*EAA[A-Za-z0-9]{40,}'''

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,68 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Added
+
+- **Meta Ad Library scraping via Apify — 8 new `ads_library_*` tools (127 → 135).**
+  Competitor ad research against the *public* Meta Ad Library, which the Graph
+  API does not expose. Backed by the
+  [curious_coder/facebook-ads-library-scraper](https://apify.com/curious_coder/facebook-ads-library-scraper)
+  actor.
+  - `ads_library_scrape` starts an asynchronous run from either a keyword
+    search (country / active status / ad type / search type) or a
+    facebook.com Ad Library or page URL, and returns a `run_id` +
+    `dataset_id`.
+  - `ads_library_get_run_status`, `ads_library_get_results` (paginated, with a
+    compact per-ad projection and a `raw` escape hatch), `ads_library_abort_run`
+    and `ads_library_list_runs` cover the rest of the run lifecycle.
+  - `ads_library_register_apify_token`, `ads_library_get_apify_token_status`
+    and `ads_library_delete_apify_token` manage the credential.
+- **Per-tenant Apify tokens, encrypted at rest** (`src/store/apify-token-repo.ts`).
+  Each user registers their own token; it is validated against the Apify API
+  *before* being persisted, then stored AES-256-GCM-encrypted in
+  `users/{fbUserId}/apify_tokens/default`. The GCM AAD is namespaced
+  `apify_token:{fbUserId}:default`, so a ciphertext cannot be relocated between
+  users or between the `meta_tokens` and `apify_tokens` collections.
+- **`src/apify/client.ts`** — a dedicated Apify API client with the same
+  timeout / retry / typed-error guarantees as `metaApiClient`. The token travels
+  in an `Authorization: Bearer` header (never a query param, so it cannot leak
+  into a logged URL), the base URL is not env-overridable, run/dataset ids are
+  validated before path interpolation, and every error message is scrubbed both
+  of `apify_api_*` substrings and of the exact token value in play.
+
+### Security
+
+- **Tenant isolation fails closed.** In multi-tenant mode (Meta OAuth app
+  configured, HTTP transport) a caller with no OAuth identity — an API-key
+  request, or any flow that loses `fbUserId` — is refused rather than bucketed
+  into a shared credential. The `APIFY_TOKEN` environment variable is honoured
+  **only** in single-tenant mode (stdio, or no Meta app configured); it is
+  never used as a cross-tenant fallback, so one advertiser's scrapes can never
+  be billed to the operator's Apify account.
+- A stored token that fails authenticated decryption (GCM tag mismatch from a
+  relocated document, key rotation, or tampering) raises an error instead of
+  being reported as "no token" — degrading an integrity failure to absence
+  would have fallen through to a fallback credential.
+- Cost containment: each scrape sends Apify a hard `maxTotalChargeUsd` cap
+  derived from the requested `count`. The actor bills PAY_PER_EVENT
+  ($0.00075/ad), so Apify aborts the run server-side rather than billing past
+  the cap; `count` is additionally capped at 2,000 per call. Note this bounds
+  each *run*, not a tenant's aggregate spend — a client can still start many
+  runs, each against its own Apify account and credit.
+- `POST` is never retried automatically, which removes the client-side
+  duplicate-run path. It does **not** make double billing impossible: Apify can
+  accept a run and lose the response, so a timed-out start is *indeterminate*.
+  The timeout message says so and points at `ads_library_list_runs` to check
+  before retrying.
+- `ads_library_scrape` accepts URLs only over https on an exact `facebook.com`
+  host allowlist, and additionally rejects embedded credentials, non-default
+  ports, and Facebook's outbound redirect endpoints (`/l.php` and friends) that
+  would send the scraper off-site.
+- Added an `apify-api-token` rule to [.gitleaks.toml](.gitleaks.toml).
+- Pino now has a `redact` configuration (previously none at all) covering
+  token- and authorization-shaped keys, as defense in depth behind the existing
+  call-site hashing/masking convention.
+
 ## [3.5.0] — 2026-08-09
 
 ### Security

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,7 @@ Before **any** `git commit -m`, `git push`, `gcloud run deploy`, `docker push`, 
 7. **No project-specific patterns** appear in the staged diff. Custom regex covers (full list in [.gitleaks.toml](.gitleaks.toml)):
    - `META_APP_SECRET=`, `OAUTH_SECRET=`, `OAUTH_APPROVAL_PIN=`, `SESSION_COOKIE_SECRET=`, `TOKEN_ENCRYPTION_KEY=`, `MCP_API_KEY=`
    - Meta access tokens: `EAA[A-Za-z0-9]{20,}`
+   - Apify API tokens: `apify_api_[A-Za-z0-9]{20,}`
    - `META_TOKENS` as a JSON map of `EAA…` tokens (multi-tenant)
    - Google: `AIza[A-Za-z0-9_-]{35}`, `ya29\.[A-Za-z0-9_-]+`, GCP service account JSON
    - Generic: `-----BEGIN … PRIVATE KEY-----`, GitHub PATs (`gh[pousr]_`), AWS keys (`AKIA`)
@@ -88,6 +89,7 @@ Source: [.env.example](.env.example). Each one is treated as a hard secret.
 | `SESSION_COOKIE_SECRET` | Cookie signing for OAuth flow | Forge in-flight authenticating sessions. |
 | `TOKEN_ENCRYPTION_KEY` | AES-256-GCM key for tokens-at-rest | Decrypt every Meta token in Firestore. **Catastrophic.** |
 | `MCP_API_KEY` | Service-to-service key | Bypass OAuth entirely. |
+| `APIFY_TOKEN` | Apify API token (fallback only; per-tenant tokens live encrypted in Firestore) | Full control of the Apify account: run any actor, drain credits, read every dataset. |
 | GCP creds (WIF / service account) | Cloud auth | Deploy malicious revisions, read Firestore, escalate via IAM. |
 
 If any of these leaks, see the rotation playbooks in [.github/pre-deploy-guard/references/sensitive-patterns.md](.github/pre-deploy-guard/references/sensitive-patterns.md).

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 - [Who is this for?](#who-is-this-for)
 - [Aligned with Meta's official MCP](#aligned-with-metas-official-mcp)
 - [Features](#features)
-- [Tools (127 total)](#tools-127-total)
+- [Tools (135 total)](#tools-135-total)
 - [Quick start](#quick-start)
 - [Authentication — three modes](#authentication--three-modes)
 - [Setting up Sign in with Meta](#setting-up-sign-in-with-meta)
@@ -78,7 +78,7 @@ When to use which:
 
 ## Features
 
-- **127 tools** covering campaign management, creatives, targeting, audiences, reporting, comments, billing, invoices, tokens, Instagram workflows, WhatsApp Business management, rate-limit observability, semantic insight views, diagnostics, help-center search, and agency-tier cross-account macros.
+- **135 tools** covering campaign management, creatives, targeting, audiences, reporting, comments, billing, invoices, tokens, Instagram workflows, WhatsApp Business management, rate-limit observability, semantic insight views, diagnostics, help-center search, competitor research via the public Meta Ad Library, and agency-tier cross-account macros.
 - **Aligned vocabulary** with Meta's official MCP server so agents transfer cleanly between both.
 - **Sign in with Meta (Facebook Login)** — replaces shared PINs. Each user lands their own long-lived (60-day) Meta token.
 - **System User token registry** — for tokens that don't expire, register them per user from the consent UI.
@@ -94,7 +94,7 @@ When to use which:
 - **Async reports with safe polling** — `ads_run_report_and_wait` one-shot with 5 s-min / 60 s-max backoff, proper `Job Failed` / `Job Skipped` handling.
 - **Retry logic** — exponential backoff on truly transient errors only (never on throttled requests).
 
-## Tools (127 total)
+## Tools (135 total)
 
 Ads tools use the `ads_*` naming convention, aligned with Meta's official MCP server; WhatsApp Business tools use `whatsapp_*`. Read tools declare `readOnlyHint: true`; mutating tools declare `destructiveHint` / `idempotentHint` and prefix descriptions with a `⚠️` warning.
 
@@ -125,12 +125,35 @@ Ads tools use the `ads_*` naming convention, aligned with Meta's official MCP se
 | Agency macros | 2 | `ads_diagnose_underperformance`, `ads_portfolio_summary` (cross-account) |
 | Bulk ad creation | 1 | `ads_bulk_create_video_ads` — video URLs → upload, processing wait, auto-thumbnail, creative and ad in one call |
 | Instagram | 2 | IG account and media lookup |
+| Ad Library (Apify) | 8 | Competitor ad research: `ads_library_scrape` the public Meta Ad Library by keyword or Facebook page, poll run status, page through results, abort runs, plus per-user Apify token register/status/delete |
 | Tokens | 4 | List / set-active / register / delete |
 | Rate Status | 1 | Live view of quota usage, open circuits and write-pacer state |
 | WhatsApp — WABAs & phones | 8 | `whatsapp_get_business_accounts`, phone number list/register/deregister/verify, business profile get/update |
 | WhatsApp — Templates & analytics | 6 | Message template CRUD (`whatsapp_create_template`, edit, delete), WABA analytics (messaging/conversation/pricing), per-template analytics |
 | WhatsApp — Flows | 6 | Flow list/create/update (incl. Flow JSON upload), publish, deprecate, delete |
 | WhatsApp — QR & webhooks | 7 | QR deep-link CRUD (`message_qrdls`), webhook subscription get/subscribe/unsubscribe |
+
+The `ads_library_*` tools read the **public** Meta Ad Library through the
+[curious_coder/facebook-ads-library-scraper](https://apify.com/curious_coder/facebook-ads-library-scraper)
+Apify actor, so they need no Meta permissions — but they do need an Apify token
+and they cost money (about **$0.75 per 1,000 ads**). Each user registers their
+own token with `ads_library_register_apify_token`; it is validated against the
+Apify API and then stored encrypted with AES-256-GCM in Firestore, scoped to
+that user, exactly like Meta tokens. Every scrape sends Apify a hard
+`maxTotalChargeUsd` cap derived from the requested `count`, so a single run
+cannot bill past it (the cap is per run, not a per-tenant budget).
+
+Credential resolution **fails closed**: in multi-tenant mode a caller with no
+OAuth identity is refused rather than falling back to a shared credential. The
+`APIFY_TOKEN` environment variable is honoured only in single-tenant mode
+(stdio transport, or no Meta OAuth app configured), so one advertiser's scrapes
+can never be billed to the operator's Apify account.
+
+Two operational caveats worth knowing: runs execute against the actor's
+`latest` build, so an upstream change to its input schema or pricing can alter
+behaviour without a change in this repo; and a scrape start that times out is
+*indeterminate* rather than failed — Apify may have accepted it — so check
+`ads_library_list_runs` before starting another.
 
 WhatsApp tools require the `whatsapp_business_management` permission. Tokens issued before this scope was added must be re-authorized (sign in again through the OAuth flow) before the `whatsapp_*` tools will work, and the Meta App must have the **WhatsApp product** added in the developer dashboard.
 
@@ -575,6 +598,7 @@ services:
       - META_ACCESS_TOKEN=${META_ACCESS_TOKEN:-}
       - META_TOKENS=${META_TOKENS:-}
       - MCP_API_KEY=${MCP_API_KEY:-}
+      - APIFY_TOKEN=${APIFY_TOKEN:-}
       - META_API_VERSION=${META_API_VERSION:-v22.0}
       - PORT=3000
       - LOG_LEVEL=${LOG_LEVEL:-info}

--- a/docs/adding-a-tool.md
+++ b/docs/adding-a-tool.md
@@ -10,7 +10,7 @@ If you're contributing for the first time, also read [CONTRIBUTING.md](../CONTRI
 2. Add a `register*Tools(server)` function (or extend the existing one) that calls `server.registerTool(name, config, handler)`.
 3. Use the `ads_*` naming convention (no `meta_` prefix) and aligned vocabulary (`ad_set` not `adset`).
 4. Spread the appropriate annotation constant from [src/tools/_register.ts](../src/tools/_register.ts) into `annotations`. Prefix write-tool descriptions with `WRITE_WARNING`.
-5. In the handler, call **`metaApiClient.get / post / postForm / postMultipart / delete / getPaginated`** — never `fetch` directly.
+5. In the handler, call **`metaApiClient.get / post / postForm / postMultipart / delete / getPaginated`** — never `fetch` directly. (One exception exists: the `ads_library_*` tools talk to Apify, not the Graph API, and route through `apifyApiClient` in [src/apify/client.ts](../src/apify/client.ts), which provides the same timeout / retry / typed-`McpError` guarantees. Any *new* non-Meta upstream needs its own such client — never a bare `fetch` in a handler.)
 6. Validate IDs with `normalizeAccountId` / `validateMetaId` from [src/utils/format.ts](../src/utils/format.ts).
 7. Reuse type definitions from [src/meta/types/](../src/meta/types/), register the new module in [src/tools/index.ts](../src/tools/index.ts), and bump the tool count assertion in [tests/tools/registration.test.ts](../tests/tools/registration.test.ts).
 8. Mirror the source path under `tests/tools/` with a vitest, run `npm run lint && npm run typecheck && npm test && npm run build`, and open a PR using [.github/PULL_REQUEST_TEMPLATE.md](../.github/PULL_REQUEST_TEMPLATE.md).
@@ -380,7 +380,7 @@ The full checklist lives in [.github/PULL_REQUEST_TEMPLATE.md](../.github/PULL_R
 - [ ] Tool name uses `ads_*` prefix, with `ad_set` (not `adset`) where applicable.
 - [ ] `annotations` declared with the right constant from [src/tools/_register.ts](../src/tools/_register.ts); write-tool descriptions prefixed with `WRITE_WARNING`.
 - [ ] Zod schema with `.describe()` on every field; narrow enums where possible.
-- [ ] All Graph API calls go through `metaApiClient` — no direct `fetch`.
+- [ ] All Graph API calls go through `metaApiClient` — no direct `fetch`. (Apify calls go through `apifyApiClient`; any other upstream needs its own client.)
 - [ ] IDs validated with `normalizeAccountId` / `validateMetaId`.
 - [ ] If the endpoint hits `/insights`, `enforceInsightsGuardrails(...)` is called.
 - [ ] No raw token in logs (`hashToken` / `maskToken`).

--- a/src/apify/client.ts
+++ b/src/apify/client.ts
@@ -1,0 +1,349 @@
+import { McpError, ErrorCode } from "@modelcontextprotocol/sdk/types.js";
+import { getCurrentFbUserId, hashToken } from "../auth/token-store.js";
+import { getApifyTokenRepo } from "../store/apify-token-repo.js";
+import { logger } from "../utils/logger.js";
+import { isStdioTransport } from "../utils/transport-mode.js";
+import type { ApifyErrorBody } from "./types.js";
+
+/** Fixed on purpose: an env-overridable base URL would let a config change redirect tenant tokens to an attacker host. */
+const APIFY_BASE_URL = "https://api.apify.com";
+const DEFAULT_TIMEOUT = 30_000;
+const MAX_RETRIES = 3;
+const RETRY_BASE_DELAY = 1000;
+
+export const ADS_LIBRARY_ACTOR_ID = "curious_coder~facebook-ads-library-scraper";
+
+/**
+ * Storage key for stdio / single-operator mode, where there is no OAuth
+ * request context. Facebook user ids are numeric, so this cannot collide with
+ * a real tenant. It is only ever reachable via isSingleTenantMode().
+ */
+export const LOCAL_TENANT_ID = "_local";
+
+const APIFY_TOKEN_PATTERN = /apify_api_[A-Za-z0-9]+/g;
+
+/**
+ * Belt-and-braces: Apify does not echo tokens in error bodies today, but a
+ * malformed request could surface one, and these strings end up in McpError
+ * messages that travel back to the MCP client.
+ *
+ * `exactToken` covers credentials that do not match the `apify_api_` shape —
+ * legacy, future, or simply malformed values the pattern alone would miss.
+ */
+export function scrubApifyToken(text: string, exactToken?: string): string {
+  if (!exactToken || exactToken.length < 8) {
+    return text.replace(APIFY_TOKEN_PATTERN, "apify_api_[REDACTED]");
+  }
+
+  // Both alternatives must be considered in a single left-to-right pass.
+  // Neither sequential order is safe: running the pattern first leaves the
+  // tail of a hybrid value (`apify_api_abc-secret` → `…[REDACTED]-secret`),
+  // while running the exact value first fragments a longer token that the
+  // exact value happens to prefix (`apify_api_abc` inside `apify_api_abcdef`
+  // → `[REDACTED]def`). Folding trailing base62 into the exact alternative
+  // makes it swallow the whole credential either way.
+  const combined = new RegExp(
+    `${escapeRegExp(exactToken)}[A-Za-z0-9]*|apify_api_[A-Za-z0-9]+`,
+    "g",
+  );
+  return text.replace(combined, (match) =>
+    match.startsWith("apify_api_") ? "apify_api_[REDACTED]" : "[REDACTED]",
+  );
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/** Apify run/dataset/actor ids are 17-char base62. Validating keeps them out of the URL path as anything else. */
+export function validateApifyId(id: string, label: string): string {
+  const trimmed = id.trim();
+  if (!/^[A-Za-z0-9]{5,32}$/.test(trimmed)) {
+    throw new McpError(
+      ErrorCode.InvalidParams,
+      `Invalid Apify ${label} id "${trimmed}". Expected 5-32 alphanumeric characters.`,
+    );
+  }
+  return trimmed;
+}
+
+/**
+ * Shows only the non-secret `apify_api_` prefix. Deliberately reveals no
+ * characters of the secret body — not even a suffix — since nothing downstream
+ * needs to disambiguate between two tokens for the same user (there is only
+ * ever one).
+ */
+export function maskApifyToken(token: string): string {
+  return token.startsWith("apify_api_") ? "apify_api_***" : "***";
+}
+
+/**
+ * Multi-tenant is on exactly when the Meta OAuth app is configured, mirroring
+ * `metaAppConfigured` in src/transport/security-config.ts. Read directly from
+ * env rather than calling resolveSecurityConfig(), which validates and can
+ * throw — this runs on every request and must not turn a config problem into
+ * an unrelated tool failure.
+ */
+function isSingleTenantMode(): boolean {
+  if (isStdioTransport(process.argv)) return true;
+  return !(process.env.META_APP_ID?.trim() && process.env.META_APP_SECRET?.trim());
+}
+
+/**
+ * Which encrypted-token bucket this request may read.
+ *
+ * Fails closed: in multi-tenant HTTP mode an unidentified caller (API-key
+ * mode, or any flow that loses the OAuth identity) must NOT silently land in
+ * the shared `_local` bucket or on the server-wide APIFY_TOKEN — that would
+ * let one tenant read another's credential and spend their Apify credit.
+ */
+export function resolveApifyTenantId(): string {
+  const fbUserId = getCurrentFbUserId();
+  if (fbUserId) return fbUserId;
+
+  if (isSingleTenantMode()) return LOCAL_TENANT_ID;
+
+  throw new McpError(
+    ErrorCode.InvalidRequest,
+    "The ads_library_* tools need an authenticated user in multi-tenant mode. Sign in through the Meta OAuth flow — API-key requests have no tenant identity, so no Apify token can be resolved for them.",
+  );
+}
+
+/**
+ * Whether the server-wide APIFY_TOKEN would actually be used for this request.
+ * Reporting "an env token exists" without this check misleads a multi-tenant
+ * caller into thinking they are covered when resolveApifyToken() will refuse.
+ */
+export function isApifyEnvFallbackUsable(): boolean {
+  return Boolean(process.env.APIFY_TOKEN?.trim()) && isSingleTenantMode();
+}
+
+/**
+ * Per-tenant encrypted token first. The server-wide APIFY_TOKEN is only
+ * honoured in single-tenant mode; sharing it across OAuth tenants would bill
+ * one advertiser's scrapes to the operator's Apify account.
+ */
+export async function resolveApifyToken(): Promise<string> {
+  const tenantId = resolveApifyTenantId();
+  const stored = await getApifyTokenRepo().getDecryptedToken(tenantId);
+  if (stored) return stored;
+
+  if (tenantId === LOCAL_TENANT_ID) {
+    const envToken = process.env.APIFY_TOKEN?.trim();
+    if (envToken) return envToken;
+  }
+
+  throw new McpError(
+    ErrorCode.InvalidRequest,
+    "No Apify token registered for this user. Register one with ads_library_register_apify_token.",
+  );
+}
+
+function isApifyErrorBody(body: unknown): body is ApifyErrorBody {
+  return (
+    typeof body === "object" &&
+    body !== null &&
+    "error" in body &&
+    typeof (body as ApifyErrorBody).error === "object"
+  );
+}
+
+function describeApifyError(body: unknown, status: number, exactToken?: string): string {
+  if (isApifyErrorBody(body)) {
+    const { type, message } = body.error;
+    return scrubApifyToken(`${type ?? "error"}: ${message ?? "(no message)"}`, exactToken);
+  }
+  return `HTTP ${status}`;
+}
+
+function toMcpError(
+  status: number,
+  body: unknown,
+  retryAfter: string | null,
+  exactToken?: string,
+): McpError {
+  const detail = describeApifyError(body, status, exactToken);
+
+  switch (status) {
+    case 400:
+      return new McpError(ErrorCode.InvalidParams, `Apify rejected the request — ${detail}`);
+    case 401:
+    case 403:
+      return new McpError(
+        ErrorCode.InvalidRequest,
+        `Apify authentication failed — ${detail}. Re-register your token with ads_library_register_apify_token.`,
+      );
+    case 402:
+      return new McpError(
+        ErrorCode.InvalidRequest,
+        `Apify refused the run for billing reasons — ${detail}. Check your credits at console.apify.com/billing.`,
+      );
+    case 404:
+      return new McpError(ErrorCode.InvalidParams, `Apify resource not found — ${detail}`);
+    case 429:
+      return new McpError(
+        ErrorCode.InvalidRequest,
+        `Apify rate limit exceeded — ${detail}.${retryAfter ? ` Retry after ${retryAfter}s.` : ""}`,
+      );
+    default:
+      return new McpError(
+        status >= 500 ? ErrorCode.InternalError : ErrorCode.InvalidRequest,
+        `Apify request failed (HTTP ${status}) — ${detail}`,
+      );
+  }
+}
+
+export interface ApifyRequestParams {
+  [key: string]: string | number | boolean | undefined;
+}
+
+export class ApifyApiClient {
+  private readonly timeout: number;
+  private readonly maxRetries: number;
+
+  constructor(config?: { timeout?: number; maxRetries?: number }) {
+    this.timeout = config?.timeout ?? DEFAULT_TIMEOUT;
+    this.maxRetries = config?.maxRetries ?? MAX_RETRIES;
+  }
+
+  async get<T>(path: string, params?: ApifyRequestParams, tokenOverride?: string): Promise<T> {
+    return this.execute<T>("GET", path, params, undefined, tokenOverride, true);
+  }
+
+  /**
+   * Never retried: starting an actor run costs real money, so a retried
+   * timeout could mint (and bill for) a duplicate scrape.
+   */
+  async post<T>(
+    path: string,
+    body?: unknown,
+    params?: ApifyRequestParams,
+    tokenOverride?: string,
+  ): Promise<T> {
+    return this.execute<T>("POST", path, params, body, tokenOverride, false);
+  }
+
+  async delete<T>(path: string, params?: ApifyRequestParams, tokenOverride?: string): Promise<T> {
+    return this.execute<T>("DELETE", path, params, undefined, tokenOverride, false);
+  }
+
+  private buildUrl(path: string, params?: ApifyRequestParams): string {
+    const url = new URL(`${APIFY_BASE_URL}${path}`);
+    for (const [key, value] of Object.entries(params ?? {})) {
+      if (value !== undefined) url.searchParams.set(key, String(value));
+    }
+    return url.toString();
+  }
+
+  private async execute<T>(
+    method: string,
+    path: string,
+    params: ApifyRequestParams | undefined,
+    body: unknown,
+    tokenOverride: string | undefined,
+    canRetry: boolean,
+  ): Promise<T> {
+    const token = tokenOverride ?? (await resolveApifyToken());
+    const tokenHash = hashToken(token);
+    const url = this.buildUrl(path, params);
+
+    let lastError: Error | undefined;
+
+    for (let attempt = 0; attempt <= this.maxRetries; attempt++) {
+      const controller = new AbortController();
+      const timeoutId = setTimeout(() => controller.abort(), this.timeout);
+
+      try {
+        const response = await fetch(url, {
+          method,
+          // Bearer header, never a query param — keeps the token out of every
+          // URL that could be logged or embedded in an error message.
+          headers: {
+            Authorization: `Bearer ${token}`,
+            ...(body !== undefined ? { "Content-Type": "application/json" } : {}),
+          },
+          ...(body !== undefined ? { body: JSON.stringify(body) } : {}),
+          signal: controller.signal,
+        });
+
+        // NB: the abort timer is deliberately still armed here. A server can
+        // send headers and then stall mid-body forever; clearing the timeout
+        // at header time would hang the call and hold the connection open.
+        if (!response.ok) {
+          const errorBody = await response.json().catch(() => null);
+
+          if (response.status >= 500 && canRetry && attempt < this.maxRetries) {
+            lastError = toMcpError(response.status, errorBody, null, token);
+            await this.backoff(attempt);
+            continue;
+          }
+
+          logger.warn(
+            {
+              event: "apify_error",
+              path,
+              status: response.status,
+              apifyErrorType: isApifyErrorBody(errorBody) ? errorBody.error.type : undefined,
+              tokenHash,
+            },
+            "Apify request failed",
+          );
+          throw toMcpError(
+            response.status,
+            errorBody,
+            response.headers.get("retry-after"),
+            token,
+          );
+        }
+
+        // Apify returns 204 with no body for some endpoints (e.g. deletes).
+        if (response.status === 204) return undefined as T;
+        return (await response.json()) as T;
+      } catch (error) {
+        if (error instanceof McpError) throw error;
+
+        // Any failure after the request left the client is indeterminate for a
+        // non-retryable (billable) call, not just a timeout: Apify may have
+        // accepted the run and then dropped the connection or returned a
+        // truncated body. Callers must not read this as "safe to retry".
+        const indeterminate = canRetry
+          ? ""
+          : " The request may still have been accepted — check ads_library_list_runs before starting another scrape.";
+
+        if (error instanceof Error && error.name === "AbortError") {
+          lastError = new McpError(
+            ErrorCode.InternalError,
+            `Apify request timed out after ${this.timeout}ms.${indeterminate}`,
+          );
+        } else {
+          lastError = new McpError(
+            ErrorCode.InternalError,
+            scrubApifyToken(
+              `Apify request failed: ${error instanceof Error ? error.message : String(error)}`,
+              token,
+            ) + indeterminate,
+          );
+        }
+
+        if (canRetry && attempt < this.maxRetries) {
+          await this.backoff(attempt);
+          continue;
+        }
+        throw lastError;
+      } finally {
+        clearTimeout(timeoutId);
+      }
+    }
+
+    logger.error({ event: "apify_retries_exhausted", path, tokenHash }, "All Apify retries exhausted");
+    throw lastError ?? new McpError(ErrorCode.InternalError, "Apify request failed after retries");
+  }
+
+  private async backoff(attempt: number): Promise<void> {
+    const delay = RETRY_BASE_DELAY * Math.pow(2, attempt);
+    const jitter = delay * (Math.random() * 0.4 - 0.2);
+    await new Promise((resolve) => setTimeout(resolve, delay + jitter));
+  }
+}
+
+export const apifyApiClient = new ApifyApiClient();

--- a/src/apify/types.ts
+++ b/src/apify/types.ts
@@ -1,0 +1,75 @@
+/** Apify API v2 shapes. Every endpoint except /datasets/{id}/items wraps its payload in `{ data: ... }`. */
+
+export type ApifyRunStatus =
+  | "READY"
+  | "RUNNING"
+  | "SUCCEEDED"
+  | "FAILED"
+  | "ABORTING"
+  | "ABORTED"
+  | "TIMING-OUT"
+  | "TIMED-OUT";
+
+export const TERMINAL_RUN_STATUSES: readonly ApifyRunStatus[] = [
+  "SUCCEEDED",
+  "FAILED",
+  "ABORTED",
+  "TIMED-OUT",
+];
+
+export interface ApifyRun {
+  id: string;
+  actId: string;
+  status: ApifyRunStatus;
+  startedAt: string;
+  finishedAt: string | null;
+  defaultDatasetId: string;
+  usageTotalUsd?: number;
+  stats?: { runTimeSecs?: number };
+}
+
+export interface ApifyUser {
+  id: string;
+  username: string;
+}
+
+export interface ApifyEnvelope<T> {
+  data: T;
+}
+
+export interface ApifyErrorBody {
+  error: { type?: string; message?: string };
+}
+
+/**
+ * Input for curious_coder/facebook-ads-library-scraper, build 2.7.x.
+ *
+ * The `scrapePageAds.*` keys are literal dotted property names in the actor's
+ * INPUT_SCHEMA, and they only apply to Facebook *page* URLs — for Ad Library
+ * search URLs the equivalent filters travel inside the URL query string.
+ */
+export interface AdLibraryActorInput {
+  urls: Array<{ url: string }>;
+  count: number;
+  scrapeAdDetails: boolean;
+  "scrapePageAds.activeStatus": AdLibraryActiveStatus;
+  "scrapePageAds.countryCode": string;
+  "scrapePageAds.period": AdLibraryPeriod;
+  "scrapePageAds.sortBy": AdLibrarySortBy;
+}
+
+export type AdLibraryActiveStatus = "all" | "active" | "inactive";
+export type AdLibraryPeriod = "" | "last24h" | "last7d" | "last14d" | "last30d";
+export type AdLibrarySortBy = "impressions_desc" | "most_recent";
+export type AdLibraryAdType =
+  | "all"
+  | "political_and_issue_ads"
+  | "housing_ads"
+  | "employment_ads"
+  | "financial_products_and_services_ads";
+export type AdLibrarySearchType = "keyword_unordered" | "keyword_exact_phrase";
+
+/** USD charged per ad in the default dataset (PAY_PER_EVENT `apify-default-dataset-item`). */
+export const USD_PER_AD = 0.00075;
+/** One-time `apify-actor-start` event, per GB of actor memory. */
+export const USD_PER_RUN_START = 0.00005;

--- a/src/store/apify-token-repo.ts
+++ b/src/store/apify-token-repo.ts
@@ -1,0 +1,190 @@
+import type { Firestore } from "@google-cloud/firestore";
+import { decryptToken, encryptToken, type EncryptedPayload } from "../auth/crypto.js";
+import { getFirestore, isFirestoreEnabled } from "./firestore.js";
+import { logger } from "../utils/logger.js";
+
+/**
+ * One Apify API token per tenant, encrypted at rest with the same
+ * AES-256-GCM machinery as the Meta tokens (src/auth/crypto.ts).
+ *
+ * Layout: users/{fbUserId}/apify_tokens/default
+ *
+ * A subcollection with a fixed `default` doc id mirrors the meta_tokens
+ * layout and leaves room for named tokens later without a migration.
+ */
+
+const USERS_COLLECTION = "users";
+const APIFY_TOKENS_SUBCOLLECTION = "apify_tokens";
+const DOC_ID = "default";
+
+/**
+ * Bound into the GCM tag so a (ciphertext, iv, tag) tuple cannot be relocated
+ * between users — or between the meta_tokens and apify_tokens collections,
+ * which is why the namespace prefix differs from meta-token-repo's `mcp_token:`.
+ */
+function aadFor(fbUserId: string): string {
+  return `apify_token:${fbUserId}:${DOC_ID}`;
+}
+
+export interface ApifyTokenDoc {
+  encryptedToken: EncryptedPayload;
+  apifyUserId: string | null;
+  apifyUsername: string | null;
+  createdAt: number;
+  updatedAt: number;
+}
+
+export interface ApifyTokenStatus {
+  registered: boolean;
+  apifyUserId: string | null;
+  apifyUsername: string | null;
+  updatedAt: number | null;
+}
+
+export interface ApifyTokenRepo {
+  saveToken(
+    fbUserId: string,
+    token: string,
+    user: { id: string; username: string } | null,
+  ): Promise<void>;
+  /** Returns null (rather than throwing) when absent so callers can fall through to the env fallback. */
+  getDecryptedToken(fbUserId: string): Promise<string | null>;
+  getStatus(fbUserId: string): Promise<ApifyTokenStatus>;
+  deleteToken(fbUserId: string): Promise<boolean>;
+}
+
+const EMPTY_STATUS: ApifyTokenStatus = {
+  registered: false,
+  apifyUserId: null,
+  apifyUsername: null,
+  updatedAt: null,
+};
+
+function buildDoc(
+  fbUserId: string,
+  token: string,
+  user: { id: string; username: string } | null,
+  createdAt: number,
+): ApifyTokenDoc {
+  const now = Math.floor(Date.now() / 1000);
+  return {
+    encryptedToken: encryptToken(token, aadFor(fbUserId)),
+    apifyUserId: user?.id ?? null,
+    apifyUsername: user?.username ?? null,
+    createdAt,
+    updatedAt: now,
+  };
+}
+
+function statusFrom(doc: ApifyTokenDoc): ApifyTokenStatus {
+  return {
+    registered: true,
+    apifyUserId: doc.apifyUserId ?? null,
+    apifyUsername: doc.apifyUsername ?? null,
+    updatedAt: doc.updatedAt ?? null,
+  };
+}
+
+export class InMemoryApifyTokenRepo implements ApifyTokenRepo {
+  private readonly docs = new Map<string, ApifyTokenDoc>();
+
+  async saveToken(
+    fbUserId: string,
+    token: string,
+    user: { id: string; username: string } | null,
+  ): Promise<void> {
+    const existing = this.docs.get(fbUserId);
+    const createdAt = existing?.createdAt ?? Math.floor(Date.now() / 1000);
+    this.docs.set(fbUserId, buildDoc(fbUserId, token, user, createdAt));
+  }
+
+  async getDecryptedToken(fbUserId: string): Promise<string | null> {
+    const doc = this.docs.get(fbUserId);
+    if (!doc) return null;
+    return decryptToken(doc.encryptedToken, aadFor(fbUserId));
+  }
+
+  async getStatus(fbUserId: string): Promise<ApifyTokenStatus> {
+    const doc = this.docs.get(fbUserId);
+    return doc ? statusFrom(doc) : { ...EMPTY_STATUS };
+  }
+
+  async deleteToken(fbUserId: string): Promise<boolean> {
+    return this.docs.delete(fbUserId);
+  }
+}
+
+export class FirestoreApifyTokenRepo implements ApifyTokenRepo {
+  constructor(private readonly db: Firestore) {}
+
+  private docRef(fbUserId: string) {
+    return this.db
+      .collection(USERS_COLLECTION)
+      .doc(fbUserId)
+      .collection(APIFY_TOKENS_SUBCOLLECTION)
+      .doc(DOC_ID);
+  }
+
+  async saveToken(
+    fbUserId: string,
+    token: string,
+    user: { id: string; username: string } | null,
+  ): Promise<void> {
+    const ref = this.docRef(fbUserId);
+    const snap = await ref.get();
+    const existing = snap.exists ? (snap.data() as ApifyTokenDoc) : undefined;
+    const createdAt = existing?.createdAt ?? Math.floor(Date.now() / 1000);
+    await ref.set(buildDoc(fbUserId, token, user, createdAt));
+  }
+
+  async getDecryptedToken(fbUserId: string): Promise<string | null> {
+    const snap = await this.docRef(fbUserId).get();
+    if (!snap.exists) return null;
+    const doc = snap.data() as ApifyTokenDoc;
+    if (!doc?.encryptedToken) return null;
+    try {
+      return decryptToken(doc.encryptedToken, aadFor(fbUserId));
+    } catch (error) {
+      // A GCM tag mismatch means the stored ciphertext was written under a
+      // different user, a different key, or was tampered with. Propagate:
+      // degrading an integrity failure to "no token" would silently fall
+      // through to a shared fallback credential.
+      logger.error(
+        { event: "apify_token_decrypt_failed" },
+        "Stored Apify token failed authenticated decryption",
+      );
+      throw new Error(
+        "Stored Apify token could not be decrypted (authentication tag mismatch). Re-register it with ads_library_register_apify_token.",
+        { cause: error },
+      );
+    }
+  }
+
+  async getStatus(fbUserId: string): Promise<ApifyTokenStatus> {
+    const snap = await this.docRef(fbUserId).get();
+    if (!snap.exists) return { ...EMPTY_STATUS };
+    return statusFrom(snap.data() as ApifyTokenDoc);
+  }
+
+  async deleteToken(fbUserId: string): Promise<boolean> {
+    const ref = this.docRef(fbUserId);
+    const snap = await ref.get();
+    if (!snap.exists) return false;
+    await ref.delete();
+    return true;
+  }
+}
+
+let cachedRepo: ApifyTokenRepo | undefined;
+
+export function getApifyTokenRepo(): ApifyTokenRepo {
+  if (cachedRepo) return cachedRepo;
+  cachedRepo = isFirestoreEnabled()
+    ? new FirestoreApifyTokenRepo(getFirestore())
+    : new InMemoryApifyTokenRepo();
+  return cachedRepo;
+}
+
+export function configureApifyTokenRepoForTests(repo: ApifyTokenRepo | undefined): void {
+  cachedRepo = repo;
+}

--- a/src/tools/_register.ts
+++ b/src/tools/_register.ts
@@ -50,3 +50,6 @@ export const WRITE_WARNING = "⚠️ Modifies live ads/account data. ";
 
 /** Same, for WhatsApp Business tools. */
 export const WHATSAPP_WRITE_WARNING = "⚠️ Modifies live WhatsApp Business data. ";
+
+/** Same, for Apify-backed tools: these spend the tenant's Apify credit or touch their stored credentials. */
+export const APIFY_WRITE_WARNING = "⚠️ Uses your Apify account (paid credits / stored credentials). ";

--- a/src/tools/ads-library.ts
+++ b/src/tools/ads-library.ts
@@ -1,0 +1,623 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { McpError, ErrorCode } from "@modelcontextprotocol/sdk/types.js";
+import {
+  ADS_LIBRARY_ACTOR_ID,
+  apifyApiClient,
+  isApifyEnvFallbackUsable,
+  maskApifyToken,
+  resolveApifyTenantId,
+  validateApifyId,
+} from "../apify/client.js";
+import {
+  USD_PER_AD,
+  USD_PER_RUN_START,
+  type AdLibraryActiveStatus,
+  type AdLibraryActorInput,
+  type AdLibraryAdType,
+  type AdLibraryPeriod,
+  type AdLibrarySearchType,
+  type AdLibrarySortBy,
+  type ApifyEnvelope,
+  type ApifyRun,
+  type ApifyUser,
+} from "../apify/types.js";
+import { getApifyTokenRepo } from "../store/apify-token-repo.js";
+import { hashToken } from "../auth/token-store.js";
+import { truncateResponse } from "../utils/format.js";
+import { logger } from "../utils/logger.js";
+import { APIFY_WRITE_WARNING, DELETE, READ, TOKEN, TOGGLE, CREATE } from "./_register.js";
+
+/**
+ * Hosts the actor knows how to scrape. Deliberately NOT routed through
+ * assertSafePublicUrl: we never fetch this URL ourselves — Apify does — so the
+ * risk is not SSRF against our network but "spend the tenant's Apify credit
+ * scraping an unrelated site". An exact host allowlist is the right control.
+ */
+const ALLOWED_URL_HOSTS = new Set([
+  "facebook.com",
+  "www.facebook.com",
+  "web.facebook.com",
+  "m.facebook.com",
+]);
+
+const MAX_COUNT = 2000;
+
+function tenantId(): string {
+  return resolveApifyTenantId();
+}
+
+function estimateMaxChargeUsd(count: number): number {
+  // Cent-rounded ceiling over the per-ad events plus the one-time start event.
+  return Math.ceil((count * USD_PER_AD + USD_PER_RUN_START) * 100) / 100;
+}
+
+/** Facebook's own outbound redirectors — following one would leave the allowlisted host. */
+const REDIRECT_PATHS = new Set(["/l.php", "/flx/warn", "/away.php", "/away"]);
+
+/**
+ * Facebook normalizes percent-encoded and duplicated path segments, so a raw
+ * `pathname` comparison is bypassable with `/%6c.php`, `//l.php` or `/l.php/`.
+ * Decode (repeatedly, to defeat double-encoding), then collapse.
+ */
+function canonicalPath(pathname: string): string {
+  let decoded = pathname;
+  for (let i = 0; i < 3; i++) {
+    let next: string;
+    try {
+      next = decodeURIComponent(decoded);
+    } catch {
+      break;
+    }
+    if (next === decoded) break;
+    decoded = next;
+  }
+  const collapsed = decoded.toLowerCase().replace(/\/{2,}/g, "/").replace(/\/+$/, "");
+  return collapsed === "" ? "/" : collapsed;
+}
+
+function validateFacebookUrl(raw: string): string {
+  let parsed: URL;
+  try {
+    parsed = new URL(raw);
+  } catch {
+    throw new McpError(ErrorCode.InvalidParams, `"${raw}" is not a valid URL.`);
+  }
+  if (parsed.protocol !== "https:") {
+    throw new McpError(ErrorCode.InvalidParams, "Only https:// URLs are accepted.");
+  }
+  if (!ALLOWED_URL_HOSTS.has(parsed.hostname.toLowerCase())) {
+    throw new McpError(
+      ErrorCode.InvalidParams,
+      `Host "${parsed.hostname}" is not allowed. Use a facebook.com Ad Library search URL or a Facebook page URL.`,
+    );
+  }
+  if (parsed.username || parsed.password) {
+    throw new McpError(ErrorCode.InvalidParams, "URLs with embedded credentials are not accepted.");
+  }
+  if (parsed.port && parsed.port !== "443") {
+    throw new McpError(
+      ErrorCode.InvalidParams,
+      `Port ${parsed.port} is not allowed; only the default https port is accepted.`,
+    );
+  }
+  if (REDIRECT_PATHS.has(canonicalPath(parsed.pathname))) {
+    throw new McpError(
+      ErrorCode.InvalidParams,
+      `"${parsed.pathname}" is a Facebook redirect endpoint, which would send the scraper off-site. Pass the destination URL directly.`,
+    );
+  }
+  return parsed.toString();
+}
+
+function buildAdLibrarySearchUrl(opts: {
+  query: string;
+  country: string;
+  activeStatus: AdLibraryActiveStatus;
+  adType: AdLibraryAdType;
+  searchType: AdLibrarySearchType;
+}): string {
+  const params = new URLSearchParams({
+    active_status: opts.activeStatus,
+    ad_type: opts.adType,
+    country: opts.country,
+    q: opts.query,
+    search_type: opts.searchType,
+    media_type: "all",
+  });
+  return `https://www.facebook.com/ads/library/?${params.toString()}`;
+}
+
+function buildActorInput(opts: {
+  url: string;
+  count: number;
+  scrapeAdDetails: boolean;
+  activeStatus: AdLibraryActiveStatus;
+  country: string;
+  period: AdLibraryPeriod;
+  sortBy: AdLibrarySortBy;
+}): AdLibraryActorInput {
+  return {
+    urls: [{ url: opts.url }],
+    count: opts.count,
+    scrapeAdDetails: opts.scrapeAdDetails,
+    "scrapePageAds.activeStatus": opts.activeStatus,
+    "scrapePageAds.countryCode": opts.country,
+    "scrapePageAds.period": opts.period,
+    "scrapePageAds.sortBy": opts.sortBy,
+  };
+}
+
+interface RawAd {
+  [key: string]: unknown;
+}
+
+function slimAd(ad: RawAd): Record<string, unknown> {
+  const snapshot = (ad.snapshot ?? {}) as Record<string, unknown>;
+  return {
+    ad_archive_id: ad.ad_archive_id ?? ad.adArchiveID ?? null,
+    page_id: ad.page_id ?? ad.pageID ?? null,
+    page_name: ad.page_name ?? ad.pageName ?? snapshot.page_name ?? null,
+    is_active: ad.is_active ?? ad.isActive ?? null,
+    start_date: ad.start_date ?? ad.startDate ?? null,
+    end_date: ad.end_date ?? ad.endDate ?? null,
+    publisher_platform: ad.publisher_platform ?? ad.publisherPlatform ?? null,
+    currency: ad.currency ?? null,
+    spend: ad.spend ?? null,
+    body: snapshot.body ?? null,
+    title: snapshot.title ?? null,
+    cta_text: snapshot.cta_text ?? null,
+    link_url: snapshot.link_url ?? null,
+    display_format: snapshot.display_format ?? null,
+    collation_count: ad.collation_count ?? null,
+    reach_estimate: ad.reach_estimate ?? null,
+  };
+}
+
+function describeRun(run: ApifyRun): string {
+  const cost = run.usageTotalUsd !== undefined ? ` — cost so far $${run.usageTotalUsd.toFixed(4)}` : "";
+  const runtime = run.stats?.runTimeSecs !== undefined ? ` — ${Math.round(run.stats.runTimeSecs)}s` : "";
+  return `${run.id} — ${run.status}${runtime}${cost}`;
+}
+
+export function registerAdsLibraryTools(server: McpServer): void {
+  server.registerTool(
+    "ads_library_register_apify_token",
+    {
+      description: `${APIFY_WRITE_WARNING}Register your Apify API token so the ads_library_* tools can scrape the public Meta Ad Library. The token is validated against the Apify API and then stored encrypted (AES-256-GCM) and scoped to your account. Get a token at console.apify.com/settings/integrations.`,
+      inputSchema: {
+        apify_token: z
+          .string()
+          .min(10)
+          .max(200)
+          .describe("Apify API token (starts with apify_api_)"),
+      },
+      annotations: { ...TOKEN },
+    },
+    async ({ apify_token }) => {
+      const token = apify_token.trim();
+      logger.info({ tokenHash: hashToken(token) }, "Validating Apify token before registration");
+
+      let user: ApifyUser;
+      try {
+        const response = await apifyApiClient.get<ApifyEnvelope<ApifyUser>>(
+          "/v2/users/me",
+          undefined,
+          token,
+        );
+        user = response.data;
+      } catch (error) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Apify token validation failed: ${
+                error instanceof Error ? error.message : String(error)
+              }\n\nThe token was NOT stored.`,
+            },
+          ],
+          isError: true,
+        };
+      }
+
+      await getApifyTokenRepo().saveToken(tenantId(), token, {
+        id: user.id,
+        username: user.username,
+      });
+
+      return {
+        content: [
+          {
+            type: "text",
+            text:
+              `Apify token registered and encrypted at rest.\n` +
+              `Apify account: ${user.username} (${user.id})\n` +
+              `Token: ${maskApifyToken(token)}`,
+          },
+        ],
+      };
+    },
+  );
+
+  server.registerTool(
+    "ads_library_get_apify_token_status",
+    {
+      description:
+        "Check whether an Apify token is available for the current user, where it comes from (encrypted per-user storage or the APIFY_TOKEN environment fallback), and optionally verify it is still valid against the Apify API.",
+      inputSchema: {
+        verify: z
+          .boolean()
+          .default(false)
+          .describe("Also call the Apify API to confirm the token still works"),
+      },
+      annotations: { ...READ },
+    },
+    async ({ verify }) => {
+      const status = await getApifyTokenRepo().getStatus(tenantId());
+      const envAvailable = isApifyEnvFallbackUsable();
+      const source = status.registered ? "encrypted_user_storage" : envAvailable ? "env" : "none";
+
+      let verification = "not requested";
+      if (verify && source !== "none") {
+        try {
+          const me = await apifyApiClient.get<ApifyEnvelope<ApifyUser>>("/v2/users/me");
+          verification = `valid — ${me.data.username}`;
+        } catch (error) {
+          verification = `invalid — ${error instanceof Error ? error.message : String(error)}`;
+        }
+      }
+
+      const summary =
+        source === "none"
+          ? "No Apify token available. Register one with ads_library_register_apify_token."
+          : `Apify token source: ${source}` +
+            (status.apifyUsername ? `\nApify account: ${status.apifyUsername}` : "") +
+            (status.updatedAt ? `\nLast updated: ${new Date(status.updatedAt * 1000).toISOString()}` : "") +
+            `\nVerification: ${verification}`;
+
+      return {
+        content: [
+          { type: "text", text: summary },
+          {
+            type: "text",
+            text: JSON.stringify(
+              { source, envFallbackAvailable: envAvailable, ...status, verification },
+              null,
+              2,
+            ),
+          },
+        ],
+      };
+    },
+  );
+
+  server.registerTool(
+    "ads_library_delete_apify_token",
+    {
+      description: `${APIFY_WRITE_WARNING}Delete the Apify token stored for the current user. Does not affect the APIFY_TOKEN environment fallback, if one is configured.`,
+      inputSchema: {},
+      annotations: { ...DELETE },
+    },
+    async () => {
+      const deleted = await getApifyTokenRepo().deleteToken(tenantId());
+      const envAvailable = isApifyEnvFallbackUsable();
+
+      if (!deleted) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `No stored Apify token found for this user.${
+                envAvailable ? " The APIFY_TOKEN environment fallback is still active." : ""
+              }`,
+            },
+          ],
+          isError: true,
+        };
+      }
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Stored Apify token deleted.${
+              envAvailable
+                ? " Note: the APIFY_TOKEN environment fallback is still active and will be used."
+                : ""
+            }`,
+          },
+        ],
+      };
+    },
+  );
+
+  server.registerTool(
+    "ads_library_scrape",
+    {
+      description: `${APIFY_WRITE_WARNING}Start an asynchronous scrape of the public Meta Ad Library (competitor ad research) via the curious_coder/facebook-ads-library-scraper Apify actor. Costs about $0.75 per 1,000 ads; a hard spend cap derived from "count" is sent to Apify so a run can never bill beyond it. Returns a run_id and dataset_id — poll ads_library_get_run_status, then read ads_library_get_results.`,
+      inputSchema: {
+        query: z
+          .string()
+          .trim()
+          .min(1)
+          .max(200)
+          .optional()
+          .describe("Keyword to search in the Ad Library. Mutually exclusive with 'url'."),
+        url: z
+          .string()
+          .optional()
+          .describe(
+            "An https://www.facebook.com Ad Library search URL or a Facebook page URL to scrape ads from. Mutually exclusive with 'query'.",
+          ),
+        country: z
+          .string()
+          .regex(/^([A-Z]{2}|ALL)$/)
+          .default("ALL")
+          .describe("Uppercase ISO 3166-1 alpha-2 country code (e.g. CO, US), or ALL"),
+        active_status: z
+          .enum(["all", "active", "inactive"])
+          .default("active")
+          .describe("Filter by whether the ad is currently running"),
+        ad_type: z
+          .enum([
+            "all",
+            "political_and_issue_ads",
+            "housing_ads",
+            "employment_ads",
+            "financial_products_and_services_ads",
+          ])
+          .default("all")
+          .describe("Ad Library category filter (applies to keyword searches)"),
+        search_type: z
+          .enum(["keyword_unordered", "keyword_exact_phrase"])
+          .default("keyword_unordered")
+          .describe("Whether the keyword must match as an exact phrase"),
+        period: z
+          .enum(["", "last24h", "last7d", "last14d", "last30d"])
+          .default("")
+          .describe("Date range filter. Only applies when scraping a Facebook page URL."),
+        sort_by: z
+          .enum(["impressions_desc", "most_recent"])
+          .default("impressions_desc")
+          .describe("Result ordering. Only applies when scraping a Facebook page URL."),
+        count: z
+          .number()
+          .int()
+          .min(1)
+          .max(MAX_COUNT)
+          .default(100)
+          .describe(
+            `Maximum ads to scrape (1-${MAX_COUNT}). Drives the spend cap: roughly $0.75 per 1,000 ads.`,
+          ),
+        scrape_ad_details: z
+          .boolean()
+          .default(false)
+          .describe("Also fetch per-ad detail such as EU reach/transparency data. Slower."),
+      },
+      annotations: { ...CREATE },
+    },
+    async ({
+      query,
+      url,
+      country,
+      active_status,
+      ad_type,
+      search_type,
+      period,
+      sort_by,
+      count,
+      scrape_ad_details,
+    }) => {
+      // Re-trim rather than trusting the Zod transform: a whitespace-only
+      // keyword would otherwise become an unbounded (and billable) search.
+      const keyword = query?.trim();
+      if ((keyword && url) || (!keyword && !url)) {
+        throw new McpError(
+          ErrorCode.InvalidParams,
+          "Provide exactly one of 'query' (keyword search) or 'url' (Ad Library search URL or Facebook page URL).",
+        );
+      }
+
+      const targetUrl = url
+        ? validateFacebookUrl(url)
+        : buildAdLibrarySearchUrl({
+            query: keyword as string,
+            country,
+            activeStatus: active_status,
+            adType: ad_type,
+            searchType: search_type,
+          });
+
+      const maxTotalChargeUsd = estimateMaxChargeUsd(count);
+
+      const response = await apifyApiClient.post<ApifyEnvelope<ApifyRun>>(
+        `/v2/acts/${ADS_LIBRARY_ACTOR_ID}/runs`,
+        buildActorInput({
+          url: targetUrl,
+          count,
+          scrapeAdDetails: scrape_ad_details,
+          activeStatus: active_status,
+          country,
+          period,
+          sortBy: sort_by,
+        }),
+        // Server-side hard cap: this actor bills PAY_PER_EVENT, so Apify aborts
+        // the run rather than billing past this amount.
+        { maxTotalChargeUsd },
+      );
+
+      const run = response.data;
+
+      return {
+        content: [
+          {
+            type: "text",
+            text:
+              `Ad Library scrape started.\n` +
+              `run_id: ${run.id}\n` +
+              `dataset_id: ${run.defaultDatasetId}\n` +
+              `status: ${run.status}\n` +
+              `target: ${targetUrl}\n` +
+              `spend cap: $${maxTotalChargeUsd.toFixed(2)} (up to ${count} ads)\n\n` +
+              `Poll ads_library_get_run_status with this run_id, then read the ads with ads_library_get_results.`,
+          },
+          {
+            type: "text",
+            text: JSON.stringify(
+              {
+                runId: run.id,
+                datasetId: run.defaultDatasetId,
+                status: run.status,
+                targetUrl,
+                maxTotalChargeUsd,
+              },
+              null,
+              2,
+            ),
+          },
+        ],
+      };
+    },
+  );
+
+  server.registerTool(
+    "ads_library_get_run_status",
+    {
+      description:
+        "Check the status of an Ad Library scrape started with ads_library_scrape. Returns the run state, elapsed runtime, accrued cost, and the dataset id to read results from.",
+      inputSchema: {
+        run_id: z.string().describe("Run id returned by ads_library_scrape"),
+      },
+      annotations: { ...READ },
+    },
+    async ({ run_id }) => {
+      const id = validateApifyId(run_id, "run");
+      const { data: run } = await apifyApiClient.get<ApifyEnvelope<ApifyRun>>(
+        `/v2/actor-runs/${id}`,
+      );
+
+      const nextStep =
+        run.status === "SUCCEEDED"
+          ? `\n\nDone. Read the ads with ads_library_get_results (dataset_id: ${run.defaultDatasetId}).`
+          : run.status === "RUNNING" || run.status === "READY"
+            ? "\n\nStill running — poll again in a few seconds."
+            : "";
+
+      return {
+        content: [
+          { type: "text", text: `${describeRun(run)}${nextStep}` },
+          { type: "text", text: JSON.stringify(run, null, 2) },
+        ],
+      };
+    },
+  );
+
+  server.registerTool(
+    "ads_library_get_results",
+    {
+      description:
+        "Read scraped ads from a completed Ad Library run's dataset. Returns a compact projection of each ad (page, copy, CTA, dates, platforms, spend) by default; pass raw=true for every field the actor produced.",
+      inputSchema: {
+        dataset_id: z.string().describe("Dataset id from ads_library_scrape or ads_library_get_run_status"),
+        offset: z.number().int().min(0).default(0).describe("Number of ads to skip"),
+        limit: z
+          .number()
+          .int()
+          .min(1)
+          .max(200)
+          .default(50)
+          .describe("Ads to return per call (1-200)"),
+        raw: z
+          .boolean()
+          .default(false)
+          .describe("Return the actor's full untrimmed records instead of the compact projection"),
+      },
+      annotations: { ...READ },
+    },
+    async ({ dataset_id, offset, limit, raw }) => {
+      const id = validateApifyId(dataset_id, "dataset");
+      const items = await apifyApiClient.get<RawAd[]>(`/v2/datasets/${id}/items`, {
+        offset,
+        limit,
+        clean: true,
+        format: "json",
+      });
+
+      const ads = Array.isArray(items) ? items : [];
+      const projected = raw ? ads : ads.map(slimAd);
+
+      const summary =
+        ads.length === 0
+          ? `No ads at offset ${offset}. The run may still be in progress, or you have reached the end of the dataset.`
+          : `Fetched ${ads.length} ad(s) starting at offset ${offset}.` +
+            (ads.length === limit
+              ? ` More may be available — call again with offset=${offset + ads.length}.`
+              : "");
+
+      return {
+        content: [
+          { type: "text", text: summary },
+          { type: "text", text: truncateResponse(JSON.stringify(projected, null, 2)) },
+        ],
+      };
+    },
+  );
+
+  server.registerTool(
+    "ads_library_abort_run",
+    {
+      description: `${APIFY_WRITE_WARNING}Abort a running Ad Library scrape to stop it accruing cost. Ads already written to the dataset remain readable with ads_library_get_results.`,
+      inputSchema: {
+        run_id: z.string().describe("Run id to abort"),
+      },
+      annotations: { ...TOGGLE },
+    },
+    async ({ run_id }) => {
+      const id = validateApifyId(run_id, "run");
+      const { data: run } = await apifyApiClient.post<ApifyEnvelope<ApifyRun>>(
+        `/v2/actor-runs/${id}/abort`,
+      );
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Run ${run.id} is now ${run.status}. Partial results remain in dataset ${run.defaultDatasetId}.`,
+          },
+          { type: "text", text: JSON.stringify(run, null, 2) },
+        ],
+      };
+    },
+  );
+
+  server.registerTool(
+    "ads_library_list_runs",
+    {
+      description:
+        "List recent Ad Library scrape runs for the current Apify account, newest first. Useful for recovering a run_id or dataset_id, and for reviewing what each run cost.",
+      inputSchema: {
+        limit: z.number().int().min(1).max(50).default(10).describe("Runs to return (1-50)"),
+      },
+      annotations: { ...READ },
+    },
+    async ({ limit }) => {
+      const { data } = await apifyApiClient.get<ApifyEnvelope<{ items: ApifyRun[] }>>(
+        `/v2/acts/${ADS_LIBRARY_ACTOR_ID}/runs`,
+        { desc: true, limit },
+      );
+
+      const runs = data.items ?? [];
+      const summary =
+        runs.length === 0
+          ? "No Ad Library scrape runs found for this Apify account."
+          : `Found ${runs.length} run(s):\n\n${runs.map((r) => `• ${describeRun(r)}`).join("\n")}`;
+
+      return {
+        content: [
+          { type: "text", text: summary },
+          { type: "text", text: JSON.stringify(runs, null, 2) },
+        ],
+      };
+    },
+  );
+}

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -20,6 +20,7 @@ import { registerReportTools } from "./reports.js";
 import { registerBillingTools } from "./billing.js";
 import { registerTokenTools } from "./tokens.js";
 import { registerInstagramTools } from "./instagram.js";
+import { registerAdsLibraryTools } from "./ads-library.js";
 import { registerRateStatusTools } from "./rate-status.js";
 import { registerEntityTools } from "./entities.js";
 import { registerDiagnosticTools } from "./diagnostics.js";
@@ -83,8 +84,11 @@ export function registerAllTools(server: McpServer): void {
   registerWhatsAppFlowTools(server);     // 6 tools — WhatsApp Flows lifecycle
   registerWhatsAppConfigTools(server);   // 7 tools — QR deep links + webhook subscriptions
 
+  // ─── Ad Library scraping (Apify) ─────────────────────────
+  registerAdsLibraryTools(server);   // 8 tools — competitor ad research via Apify + token mgmt
+
   // ─── Token Management ────────────────────────────────────
   registerTokenTools(server);        // 4 tools — list / set-active / register / delete
 
-  // Total: 127 tools (79 renamed + 14 new in v3 + 3 audience-sharing + 1 invoices + 27 WhatsApp + 1 url-tags + 1 bulk video ads + 1 creative media)
+  // Total: 135 tools (79 renamed + 14 new in v3 + 3 audience-sharing + 1 invoices + 27 WhatsApp + 1 url-tags + 1 bulk video ads + 1 creative media + 8 Ad Library/Apify)
 }

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -3,13 +3,36 @@ import { isStdioTransport } from "./transport-mode.js";
 
 const isStdio = isStdioTransport(process.argv);
 
+/**
+ * Defense in depth only. Secret hygiene is enforced at the call sites (log
+ * hashToken()/maskToken() output, never the raw value); this catches a future
+ * `logger.info({ apify_token })` slipping through code review.
+ */
+const redact = {
+  paths: [
+    "apify_token",
+    "*.apify_token",
+    "apifyToken",
+    "*.apifyToken",
+    "access_token",
+    "*.access_token",
+    "accessToken",
+    "*.accessToken",
+    "authorization",
+    "*.authorization",
+    "headers.Authorization",
+  ],
+  censor: "[REDACTED]",
+};
+
 export const logger = isStdio
   ? pino(
-      { level: process.env.LOG_LEVEL ?? "info" },
+      { level: process.env.LOG_LEVEL ?? "info", redact },
       pino.destination({ fd: 2, sync: false }),
     )
   : pino({
       level: process.env.LOG_LEVEL ?? "info",
+      redact,
       transport:
         process.env.NODE_ENV !== "production"
           ? { target: "pino-pretty", options: { colorize: true } }

--- a/tests/apify/client.test.ts
+++ b/tests/apify/client.test.ts
@@ -1,0 +1,368 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { McpError } from "@modelcontextprotocol/sdk/types.js";
+import {
+  ApifyApiClient,
+  maskApifyToken,
+  resolveApifyTenantId,
+  resolveApifyToken,
+  scrubApifyToken,
+  validateApifyId,
+} from "../../src/apify/client.js";
+import {
+  InMemoryApifyTokenRepo,
+  configureApifyTokenRepoForTests,
+} from "../../src/store/apify-token-repo.js";
+import { resetKeyCacheForTests } from "../../src/auth/crypto.js";
+import { mockFetchResponse } from "../setup.js";
+
+// Kept under the 20-char suffix that .gitleaks.toml's apify-api-token rule
+// matches, so this fixture never trips the secret scanner.
+const TOKEN = "apify_api_testfixture";
+
+describe("apify client", () => {
+  beforeEach(() => {
+    process.env.TOKEN_ENCRYPTION_KEY = "b".repeat(64);
+    resetKeyCacheForTests();
+    configureApifyTokenRepoForTests(new InMemoryApifyTokenRepo());
+    process.env.APIFY_TOKEN = TOKEN;
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    delete process.env.APIFY_TOKEN;
+    delete process.env.TOKEN_ENCRYPTION_KEY;
+    resetKeyCacheForTests();
+    configureApifyTokenRepoForTests(undefined);
+  });
+
+  describe("token handling", () => {
+    it("sends the token as a Bearer header and never in the URL", async () => {
+      const fetchMock = vi.fn().mockResolvedValue(mockFetchResponse({ data: { ok: true } }));
+      vi.stubGlobal("fetch", fetchMock);
+
+      await new ApifyApiClient().get("/v2/users/me");
+
+      const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+      expect(url).toBe("https://api.apify.com/v2/users/me");
+      expect(url).not.toContain(TOKEN);
+      expect(url).not.toContain("token");
+      expect((init.headers as Record<string, string>).Authorization).toBe(`Bearer ${TOKEN}`);
+    });
+
+    it("keeps the token out of the URL even when query params are present", async () => {
+      const fetchMock = vi.fn().mockResolvedValue(mockFetchResponse([]));
+      vi.stubGlobal("fetch", fetchMock);
+
+      await new ApifyApiClient().get("/v2/datasets/abc12/items", { offset: 10, limit: 5 });
+
+      const [url] = fetchMock.mock.calls[0] as [string];
+      expect(url).toBe("https://api.apify.com/v2/datasets/abc12/items?offset=10&limit=5");
+      expect(url).not.toContain("apify_api");
+    });
+
+    it("prefers a tokenOverride over the resolved token", async () => {
+      const fetchMock = vi.fn().mockResolvedValue(mockFetchResponse({ data: {} }));
+      vi.stubGlobal("fetch", fetchMock);
+
+      await new ApifyApiClient().get("/v2/users/me", undefined, "apify_api_candidate");
+
+      const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+      expect((init.headers as Record<string, string>).Authorization).toBe(
+        "Bearer apify_api_candidate",
+      );
+    });
+
+    it("resolves the per-tenant stored token ahead of the env fallback", async () => {
+      const repo = new InMemoryApifyTokenRepo();
+      await repo.saveToken("_local", "apify_api_stored", null);
+      configureApifyTokenRepoForTests(repo);
+
+      expect(await resolveApifyToken()).toBe("apify_api_stored");
+    });
+
+    it("falls back to APIFY_TOKEN when nothing is stored", async () => {
+      expect(await resolveApifyToken()).toBe(TOKEN);
+    });
+
+    it("throws actionable guidance when no token is available at all", async () => {
+      delete process.env.APIFY_TOKEN;
+
+      await expect(resolveApifyToken()).rejects.toThrow(/ads_library_register_apify_token/);
+    });
+  });
+
+  describe("tenant isolation", () => {
+    const savedAppId = process.env.META_APP_ID;
+    const savedAppSecret = process.env.META_APP_SECRET;
+
+    function enableMultiTenant() {
+      process.env.META_APP_ID = "1234567890";
+      process.env.META_APP_SECRET = "f".repeat(32);
+    }
+
+    afterEach(() => {
+      if (savedAppId === undefined) delete process.env.META_APP_ID;
+      else process.env.META_APP_ID = savedAppId;
+      if (savedAppSecret === undefined) delete process.env.META_APP_SECRET;
+      else process.env.META_APP_SECRET = savedAppSecret;
+    });
+
+    it("uses the _local bucket only when no OAuth app is configured", () => {
+      expect(resolveApifyTenantId()).toBe("_local");
+    });
+
+    it("refuses to resolve a tenant for an unidentified caller in multi-tenant mode", () => {
+      enableMultiTenant();
+
+      // An API-key request has no fbUserId. It must not land in the shared
+      // _local bucket alongside every other unidentified caller.
+      expect(() => resolveApifyTenantId()).toThrow(/authenticated user in multi-tenant mode/);
+    });
+
+    it("never falls back to the server-wide APIFY_TOKEN in multi-tenant mode", async () => {
+      enableMultiTenant();
+      process.env.APIFY_TOKEN = TOKEN;
+
+      await expect(resolveApifyToken()).rejects.toThrow(/authenticated user in multi-tenant mode/);
+    });
+
+    it("scopes a stored token to its own tenant", async () => {
+      const repo = new InMemoryApifyTokenRepo();
+      await repo.saveToken("user-a", "apify_api_aaa", null);
+      configureApifyTokenRepoForTests(repo);
+
+      expect(await repo.getDecryptedToken("user-a")).toBe("apify_api_aaa");
+      expect(await repo.getDecryptedToken("user-b")).toBeNull();
+    });
+  });
+
+  describe("retries", () => {
+    it("retries a GET on 500 and succeeds", async () => {
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(mockFetchResponse({ error: { message: "boom" } }, { status: 500 }))
+        .mockResolvedValueOnce(mockFetchResponse({ data: { ok: true } }));
+      vi.stubGlobal("fetch", fetchMock);
+
+      const result = await new ApifyApiClient({ maxRetries: 2 }).get<{ data: { ok: boolean } }>(
+        "/v2/users/me",
+      );
+
+      expect(result.data.ok).toBe(true);
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+
+    it("never retries a POST, so a run is never started twice", async () => {
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValue(mockFetchResponse({ error: { message: "boom" } }, { status: 500 }));
+      vi.stubGlobal("fetch", fetchMock);
+
+      await expect(
+        new ApifyApiClient({ maxRetries: 3 }).post("/v2/acts/x/runs", { urls: [] }),
+      ).rejects.toThrow(McpError);
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    it("flags a POST body-read failure as indeterminate, not as a safe failure", async () => {
+      // Apify accepted the run (201) but the body never completed. The client
+      // must not let the caller read this as "nothing happened".
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue({
+          ok: true,
+          status: 201,
+          headers: new Headers(),
+          json: async () => {
+            throw new SyntaxError("Unexpected end of JSON input");
+          },
+        } as unknown as Response),
+      );
+
+      await expect(new ApifyApiClient({ maxRetries: 0 }).post("/v2/acts/x/runs")).rejects.toThrow(
+        /may still have been accepted/,
+      );
+    });
+
+    it("does not add the indeterminate warning to a retryable GET", async () => {
+      vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("network down")));
+
+      const error = await new ApifyApiClient({ maxRetries: 0 })
+        .get("/v2/users/me")
+        .catch((e: Error) => e);
+
+      expect(error.message).not.toContain("may still have been accepted");
+    });
+
+    it("does not retry a 429", async () => {
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValue(
+          mockFetchResponse({ error: { type: "rate-limit-exceeded" } }, { status: 429 }),
+        );
+      vi.stubGlobal("fetch", fetchMock);
+
+      await expect(new ApifyApiClient({ maxRetries: 3 }).get("/v2/users/me")).rejects.toThrow(
+        /rate limit/i,
+      );
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("error mapping", () => {
+    it("maps 401 to guidance about re-registering", async () => {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue(
+          mockFetchResponse({ error: { type: "token-not-found", message: "bad token" } }, { status: 401 }),
+        ),
+      );
+
+      await expect(new ApifyApiClient().get("/v2/users/me")).rejects.toThrow(
+        /ads_library_register_apify_token/,
+      );
+    });
+
+    it("maps 402 to a billing hint", async () => {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue(
+          mockFetchResponse({ error: { type: "insufficient-credit" } }, { status: 402 }),
+        ),
+      );
+
+      await expect(new ApifyApiClient().post("/v2/acts/x/runs")).rejects.toThrow(/billing|credits/i);
+    });
+
+    it("maps 404 to InvalidParams", async () => {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue(
+          mockFetchResponse({ error: { type: "record-not-found" } }, { status: 404 }),
+        ),
+      );
+
+      await expect(new ApifyApiClient().get("/v2/actor-runs/abc12")).rejects.toThrow(/not found/i);
+    });
+
+    it("scrubs a token echoed back inside an Apify error body", async () => {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue(
+          mockFetchResponse(
+            { error: { type: "bad-request", message: `token ${TOKEN} is malformed` } },
+            { status: 400 },
+          ),
+        ),
+      );
+
+      const error = await new ApifyApiClient().get("/v2/users/me").catch((e: Error) => e);
+
+      expect(error.message).not.toContain(TOKEN);
+      expect(error.message).toContain("[REDACTED]");
+      expect(error.message).toContain("is malformed");
+    });
+
+    it("scrubs an apify_api_ token echoed back when it is not the token in play", async () => {
+      const other = "apify_api_someoneelsestoken";
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue(
+          mockFetchResponse(
+            { error: { type: "bad-request", message: `conflict with ${other}` } },
+            { status: 400 },
+          ),
+        ),
+      );
+
+      const error = await new ApifyApiClient().get("/v2/users/me").catch((e: Error) => e);
+
+      expect(error.message).not.toContain(other);
+      expect(error.message).toContain("apify_api_[REDACTED]");
+    });
+
+    it("scrubs a token surfaced through a transport error", async () => {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockRejectedValue(new Error(`connect failed for ${TOKEN}`)),
+      );
+
+      const error = await new ApifyApiClient({ maxRetries: 0 })
+        .post("/v2/acts/x/runs")
+        .catch((e: Error) => e);
+
+      expect(error.message).not.toContain(TOKEN);
+      expect(error.message).toContain("[REDACTED]");
+    });
+  });
+
+  describe("validateApifyId", () => {
+    it("accepts a normal Apify id", () => {
+      expect(validateApifyId("XtaWFhbtfxyzqrFmd", "run")).toBe("XtaWFhbtfxyzqrFmd");
+    });
+
+    it.each([
+      ["../../v2/users/me", "path traversal"],
+      ["", "empty"],
+      ["abc12?foo=bar", "query string"],
+      ["abc 12", "whitespace"],
+      ["abc/def", "slash"],
+      ["a".repeat(64), "too long"],
+    ])("rejects %s (%s)", (id) => {
+      expect(() => validateApifyId(id, "run")).toThrow(McpError);
+    });
+  });
+
+  describe("helpers", () => {
+    it("scrubApifyToken removes every occurrence", () => {
+      const scrubbed = scrubApifyToken(`a ${TOKEN} b ${TOKEN} c`);
+      expect(scrubbed).not.toContain(TOKEN);
+      expect(scrubbed.match(/apify_api_\[REDACTED\]/g)).toHaveLength(2);
+    });
+
+    it("scrubApifyToken also removes an exact token that does not match the pattern", () => {
+      const odd = "legacy-style-token-value";
+      const scrubbed = scrubApifyToken(`failed for ${odd}`, odd);
+      expect(scrubbed).not.toContain(odd);
+      expect(scrubbed).toContain("[REDACTED]");
+    });
+
+    it("scrubApifyToken does not fragment a longer token that the exact value prefixes", () => {
+      // Regression: replacing the exact value first split "apify_api_abcdefXYZ"
+      // into "[REDACTED]defXYZ", after which the generic pattern no longer
+      // recognised the remainder and the suffix leaked.
+      const scrubbed = scrubApifyToken("saw apify_api_abcdefXYZ here", "apify_api_abc");
+      expect(scrubbed).not.toContain("defXYZ");
+      expect(scrubbed).toBe("saw apify_api_[REDACTED] here");
+    });
+
+    it("scrubApifyToken handles regex metacharacters in the exact token", () => {
+      const weird = "tok+en(with)[meta].chars";
+      const scrubbed = scrubApifyToken(`failed for ${weird}`, weird);
+      expect(scrubbed).not.toContain(weird);
+      expect(scrubbed).toContain("[REDACTED]");
+    });
+
+    it("scrubApifyToken leaves no tail when the exact token only partly matches the pattern", () => {
+      // The pattern stops at the hyphen. Scrubbing the exact value must happen
+      // first, or "-secret" survives.
+      const hybrid = "apify_api_abc123def456-secret";
+      const scrubbed = scrubApifyToken(`token ${hybrid} rejected`, hybrid);
+      expect(scrubbed).not.toContain(hybrid);
+      expect(scrubbed).not.toContain("-secret");
+    });
+
+    it("maskApifyToken reveals only the non-secret prefix", () => {
+      const masked = maskApifyToken(TOKEN);
+      expect(masked).toBe("apify_api_***");
+      // Not one character of the secret body survives.
+      expect(TOKEN.slice("apify_api_".length)).not.toBe("");
+      expect(masked).not.toContain(TOKEN.slice("apify_api_".length));
+    });
+
+    it("maskApifyToken fully hides values with no known prefix", () => {
+      expect(maskApifyToken("some-other-credential")).toBe("***");
+    });
+  });
+});

--- a/tests/store/apify-token-repo.test.ts
+++ b/tests/store/apify-token-repo.test.ts
@@ -1,0 +1,229 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import {
+  FirestoreApifyTokenRepo,
+  InMemoryApifyTokenRepo,
+  configureApifyTokenRepoForTests,
+  getApifyTokenRepo,
+  type ApifyTokenDoc,
+} from "../../src/store/apify-token-repo.js";
+import { encryptToken, decryptToken, resetKeyCacheForTests } from "../../src/auth/crypto.js";
+
+// Kept under the 20-char suffix that .gitleaks.toml's apify-api-token rule
+// matches, and carrying the repo's `fixture` marker, so it never trips the
+// secret scanner.
+const TOKEN = "apify_api_testfixture";
+
+describe("apify-token-repo", () => {
+  beforeEach(() => {
+    process.env.TOKEN_ENCRYPTION_KEY = "a".repeat(64);
+    resetKeyCacheForTests();
+    configureApifyTokenRepoForTests(undefined);
+  });
+
+  afterEach(() => {
+    delete process.env.TOKEN_ENCRYPTION_KEY;
+    resetKeyCacheForTests();
+    configureApifyTokenRepoForTests(undefined);
+  });
+
+  describe("InMemoryApifyTokenRepo", () => {
+    it("round-trips a token through encryption", async () => {
+      const repo = new InMemoryApifyTokenRepo();
+      await repo.saveToken("user-1", TOKEN, { id: "u1", username: "byads" });
+
+      expect(await repo.getDecryptedToken("user-1")).toBe(TOKEN);
+    });
+
+    it("reports status without exposing the token", async () => {
+      const repo = new InMemoryApifyTokenRepo();
+      await repo.saveToken("user-1", TOKEN, { id: "u1", username: "byads" });
+
+      const status = await repo.getStatus("user-1");
+      expect(status.registered).toBe(true);
+      expect(status.apifyUsername).toBe("byads");
+      expect(status.apifyUserId).toBe("u1");
+      expect(status.updatedAt).toBeTypeOf("number");
+      expect(JSON.stringify(status)).not.toContain(TOKEN);
+    });
+
+    it("returns an empty status for an unknown tenant", async () => {
+      const repo = new InMemoryApifyTokenRepo();
+      expect(await repo.getStatus("nobody")).toEqual({
+        registered: false,
+        apifyUserId: null,
+        apifyUsername: null,
+        updatedAt: null,
+      });
+    });
+
+    it("returns null rather than throwing when no token is stored", async () => {
+      const repo = new InMemoryApifyTokenRepo();
+      expect(await repo.getDecryptedToken("nobody")).toBeNull();
+    });
+
+    it("isolates tenants from each other", async () => {
+      const repo = new InMemoryApifyTokenRepo();
+      await repo.saveToken("user-1", "apify_api_one", null);
+      await repo.saveToken("user-2", "apify_api_two", null);
+
+      expect(await repo.getDecryptedToken("user-1")).toBe("apify_api_one");
+      expect(await repo.getDecryptedToken("user-2")).toBe("apify_api_two");
+    });
+
+    it("preserves createdAt but bumps updatedAt when re-registering", async () => {
+      const repo = new InMemoryApifyTokenRepo();
+      await repo.saveToken("user-1", TOKEN, null);
+      const first = await repo.getStatus("user-1");
+
+      await repo.saveToken("user-1", "apify_api_rotated", null);
+      const second = await repo.getStatus("user-1");
+
+      expect(await repo.getDecryptedToken("user-1")).toBe("apify_api_rotated");
+      expect(second.updatedAt).toBeGreaterThanOrEqual(first.updatedAt as number);
+    });
+
+    it("deletes a token and reports whether anything was removed", async () => {
+      const repo = new InMemoryApifyTokenRepo();
+      await repo.saveToken("user-1", TOKEN, null);
+
+      expect(await repo.deleteToken("user-1")).toBe(true);
+      expect(await repo.deleteToken("user-1")).toBe(false);
+      expect(await repo.getDecryptedToken("user-1")).toBeNull();
+    });
+  });
+
+  describe("FirestoreApifyTokenRepo", () => {
+    /**
+     * Minimal Firestore stand-in that records exactly what would be persisted,
+     * so we can assert on the real stored document rather than on an opaque
+     * in-memory object.
+     */
+    function fakeFirestore() {
+      const written = new Map<string, ApifyTokenDoc>();
+      const db = {
+        collection: (c: string) => ({
+          doc: (userId: string) => ({
+            collection: (sub: string) => ({
+              doc: (id: string) => {
+                const key = `${c}/${userId}/${sub}/${id}`;
+                return {
+                  get: async () => ({
+                    exists: written.has(key),
+                    data: () => written.get(key),
+                  }),
+                  set: async (doc: ApifyTokenDoc) => {
+                    written.set(key, doc);
+                  },
+                  delete: async () => {
+                    written.delete(key);
+                  },
+                };
+              },
+            }),
+          }),
+        }),
+      };
+      return { db, written };
+    }
+
+    it("persists ciphertext only — the plaintext token never reaches Firestore", async () => {
+      const { db, written } = fakeFirestore();
+      const repo = new FirestoreApifyTokenRepo(db as never);
+
+      await repo.saveToken("user-1", TOKEN, { id: "u1", username: "byads" });
+
+      const stored = written.get("users/user-1/apify_tokens/default");
+      expect(stored).toBeDefined();
+      expect(JSON.stringify(stored)).not.toContain(TOKEN);
+      expect(stored?.encryptedToken).toMatchObject({
+        ciphertext: expect.any(String),
+        iv: expect.any(String),
+        tag: expect.any(String),
+      });
+      expect(stored).not.toHaveProperty("token");
+      expect(await repo.getDecryptedToken("user-1")).toBe(TOKEN);
+    });
+
+    it("refuses a document relocated from another tenant instead of decrypting it", async () => {
+      const { db, written } = fakeFirestore();
+      const repo = new FirestoreApifyTokenRepo(db as never);
+
+      await repo.saveToken("user-1", TOKEN, null);
+      const stolen = written.get("users/user-1/apify_tokens/default")!;
+      written.set("users/user-2/apify_tokens/default", stolen);
+
+      await expect(repo.getDecryptedToken("user-2")).rejects.toThrow(/could not be decrypted/i);
+    });
+
+    it("surfaces a tampered ciphertext rather than degrading to no token", async () => {
+      const { db, written } = fakeFirestore();
+      const repo = new FirestoreApifyTokenRepo(db as never);
+
+      await repo.saveToken("user-1", TOKEN, null);
+      const doc = written.get("users/user-1/apify_tokens/default")!;
+      written.set("users/user-1/apify_tokens/default", {
+        ...doc,
+        encryptedToken: { ...doc.encryptedToken, ciphertext: Buffer.from("tampered").toString("base64") },
+      });
+
+      await expect(repo.getDecryptedToken("user-1")).rejects.toThrow(/could not be decrypted/i);
+    });
+
+    it("returns null for a tenant that never registered", async () => {
+      const { db } = fakeFirestore();
+      const repo = new FirestoreApifyTokenRepo(db as never);
+      expect(await repo.getDecryptedToken("nobody")).toBeNull();
+    });
+
+    it("deletes and reports whether anything existed", async () => {
+      const { db } = fakeFirestore();
+      const repo = new FirestoreApifyTokenRepo(db as never);
+
+      await repo.saveToken("user-1", TOKEN, null);
+      expect(await repo.deleteToken("user-1")).toBe(true);
+      expect(await repo.deleteToken("user-1")).toBe(false);
+    });
+  });
+
+  describe("AAD binding", () => {
+    it("refuses to decrypt a ciphertext relocated to another tenant", () => {
+      const payload = encryptToken(TOKEN, "apify_token:user-1:default");
+
+      expect(() => decryptToken(payload, "apify_token:user-2:default")).toThrow();
+      expect(decryptToken(payload, "apify_token:user-1:default")).toBe(TOKEN);
+    });
+
+    it("refuses to decrypt a Meta-namespaced ciphertext as an Apify token", () => {
+      const payload = encryptToken(TOKEN, "mcp_token:user-1:default");
+
+      expect(() => decryptToken(payload, "apify_token:user-1:default")).toThrow();
+    });
+  });
+
+  describe("getApifyTokenRepo", () => {
+    it("falls back to the in-memory repo when Firestore is not configured", () => {
+      const saved = {
+        FIRESTORE_PROJECT_ID: process.env.FIRESTORE_PROJECT_ID,
+        GOOGLE_CLOUD_PROJECT: process.env.GOOGLE_CLOUD_PROJECT,
+        FIRESTORE_EMULATOR_HOST: process.env.FIRESTORE_EMULATOR_HOST,
+      };
+      delete process.env.FIRESTORE_PROJECT_ID;
+      delete process.env.GOOGLE_CLOUD_PROJECT;
+      delete process.env.FIRESTORE_EMULATOR_HOST;
+
+      try {
+        expect(getApifyTokenRepo()).toBeInstanceOf(InMemoryApifyTokenRepo);
+      } finally {
+        for (const [key, value] of Object.entries(saved)) {
+          if (value !== undefined) process.env[key] = value;
+        }
+      }
+    });
+
+    it("returns the repo injected for tests", () => {
+      const injected = new InMemoryApifyTokenRepo();
+      configureApifyTokenRepoForTests(injected);
+      expect(getApifyTokenRepo()).toBe(injected);
+    });
+  });
+});

--- a/tests/tools/ads-library.test.ts
+++ b/tests/tools/ads-library.test.ts
@@ -1,0 +1,534 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { McpError } from "@modelcontextprotocol/sdk/types.js";
+import { registerAdsLibraryTools } from "../../src/tools/ads-library.js";
+import {
+  InMemoryApifyTokenRepo,
+  configureApifyTokenRepoForTests,
+} from "../../src/store/apify-token-repo.js";
+import { resetKeyCacheForTests } from "../../src/auth/crypto.js";
+import { createMockMcpServer, mockFetchResponse } from "../setup.js";
+
+// Kept under the 20-char suffix that .gitleaks.toml's apify-api-token rule
+// matches, so this fixture never trips the secret scanner.
+const TOKEN = "apify_api_testfixture";
+
+type ToolResult = { content: Array<{ type: string; text: string }>; isError?: boolean };
+
+function setup() {
+  const server = createMockMcpServer();
+  registerAdsLibraryTools(server as never);
+  const byName = (name: string) => {
+    const tool = server._registeredTools.find((t) => t.name === name);
+    if (!tool) throw new Error(`tool ${name} not registered`);
+    return tool.handler as (args: Record<string, unknown>) => Promise<ToolResult>;
+  };
+  return { server, byName };
+}
+
+const SCRAPE_DEFAULTS = {
+  query: undefined,
+  url: undefined,
+  country: "ALL",
+  active_status: "active",
+  ad_type: "all",
+  search_type: "keyword_unordered",
+  period: "",
+  sort_by: "impressions_desc",
+  count: 100,
+  scrape_ad_details: false,
+};
+
+describe("ads_library_* tools", () => {
+  let repo: InMemoryApifyTokenRepo;
+
+  beforeEach(() => {
+    process.env.TOKEN_ENCRYPTION_KEY = "c".repeat(64);
+    resetKeyCacheForTests();
+    repo = new InMemoryApifyTokenRepo();
+    configureApifyTokenRepoForTests(repo);
+    process.env.APIFY_TOKEN = TOKEN;
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    delete process.env.APIFY_TOKEN;
+    delete process.env.TOKEN_ENCRYPTION_KEY;
+    resetKeyCacheForTests();
+    configureApifyTokenRepoForTests(undefined);
+  });
+
+  describe("registration", () => {
+    it("registers exactly 8 tools", () => {
+      const { server } = setup();
+      expect(server.registerTool).toHaveBeenCalledTimes(8);
+    });
+
+    it("registers the expected names", () => {
+      const { server } = setup();
+      expect(server._registeredTools.map((t) => t.name)).toEqual([
+        "ads_library_register_apify_token",
+        "ads_library_get_apify_token_status",
+        "ads_library_delete_apify_token",
+        "ads_library_scrape",
+        "ads_library_get_run_status",
+        "ads_library_get_results",
+        "ads_library_abort_run",
+        "ads_library_list_runs",
+      ]);
+    });
+
+    it("warns on every non-read tool", () => {
+      const { server } = setup();
+      for (const tool of server._registeredTools) {
+        if (tool.annotations?.readOnlyHint !== true) {
+          expect(tool.description).toContain("⚠️");
+        }
+      }
+    });
+  });
+
+  describe("ads_library_register_apify_token", () => {
+    it("validates against Apify then stores the token encrypted", async () => {
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValue(mockFetchResponse({ data: { id: "u1", username: "byads" } }));
+      vi.stubGlobal("fetch", fetchMock);
+
+      const result = await setup().byName("ads_library_register_apify_token")({
+        apify_token: TOKEN,
+      });
+
+      const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+      expect(url).toBe("https://api.apify.com/v2/users/me");
+      expect((init.headers as Record<string, string>).Authorization).toBe(`Bearer ${TOKEN}`);
+
+      expect(result.isError).toBeUndefined();
+      expect(await repo.getDecryptedToken("_local")).toBe(TOKEN);
+    });
+
+    it("never echoes the raw token back to the client", async () => {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue(mockFetchResponse({ data: { id: "u1", username: "byads" } })),
+      );
+
+      const result = await setup().byName("ads_library_register_apify_token")({
+        apify_token: TOKEN,
+      });
+
+      const rendered = JSON.stringify(result);
+      expect(rendered).not.toContain(TOKEN);
+      // Not even a suffix of the secret body leaks back to the MCP client.
+      expect(rendered).not.toContain(TOKEN.slice(-4));
+      expect(rendered).toContain("byads");
+      expect(rendered).toContain("apify_api_***");
+    });
+
+    it("does not store the token when validation fails", async () => {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue(
+          mockFetchResponse({ error: { type: "token-not-found" } }, { status: 401 }),
+        ),
+      );
+
+      const result = await setup().byName("ads_library_register_apify_token")({
+        apify_token: "apify_api_bogus",
+      });
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain("NOT stored");
+      expect(await repo.getDecryptedToken("_local")).toBeNull();
+    });
+  });
+
+  describe("ads_library_get_apify_token_status", () => {
+    it("reports the encrypted per-user source once registered", async () => {
+      await repo.saveToken("_local", TOKEN, { id: "u1", username: "byads" });
+
+      const result = await setup().byName("ads_library_get_apify_token_status")({
+        verify: false,
+      });
+
+      expect(result.content[0].text).toContain("encrypted_user_storage");
+      expect(JSON.stringify(result)).not.toContain(TOKEN);
+    });
+
+    it("reports the env fallback when nothing is stored in single-tenant mode", async () => {
+      const result = await setup().byName("ads_library_get_apify_token_status")({
+        verify: false,
+      });
+      expect(result.content[0].text).toContain("env");
+    });
+
+    it("does not advertise the env fallback in multi-tenant mode, where it is unreachable", async () => {
+      const savedId = process.env.META_APP_ID;
+      const savedSecret = process.env.META_APP_SECRET;
+      process.env.META_APP_ID = "1234567890";
+      process.env.META_APP_SECRET = "f".repeat(32);
+
+      try {
+        // No OAuth identity + multi-tenant → the resolver refuses outright, so
+        // the status tool must not claim an env token has us covered.
+        await expect(
+          setup().byName("ads_library_get_apify_token_status")({ verify: false }),
+        ).rejects.toThrow(/authenticated user in multi-tenant mode/);
+      } finally {
+        if (savedId === undefined) delete process.env.META_APP_ID;
+        else process.env.META_APP_ID = savedId;
+        if (savedSecret === undefined) delete process.env.META_APP_SECRET;
+        else process.env.META_APP_SECRET = savedSecret;
+      }
+    });
+
+    it("reports none when there is no token anywhere", async () => {
+      delete process.env.APIFY_TOKEN;
+      const result = await setup().byName("ads_library_get_apify_token_status")({
+        verify: false,
+      });
+      expect(result.content[0].text).toContain("No Apify token available");
+    });
+  });
+
+  describe("ads_library_delete_apify_token", () => {
+    it("deletes a stored token", async () => {
+      await repo.saveToken("_local", TOKEN, null);
+
+      const result = await setup().byName("ads_library_delete_apify_token")({});
+
+      expect(result.isError).toBeUndefined();
+      expect(await repo.getDecryptedToken("_local")).toBeNull();
+      expect(result.content[0].text).toContain("environment fallback is still active");
+    });
+
+    it("errors when there is nothing to delete", async () => {
+      const result = await setup().byName("ads_library_delete_apify_token")({});
+      expect(result.isError).toBe(true);
+    });
+  });
+
+  describe("ads_library_scrape", () => {
+    function stubRunStart() {
+      const fetchMock = vi.fn().mockResolvedValue(
+        mockFetchResponse({
+          data: {
+            id: "run123abc",
+            actId: "act1",
+            status: "READY",
+            startedAt: "2026-08-09T00:00:00.000Z",
+            finishedAt: null,
+            defaultDatasetId: "ds123abc",
+          },
+        }),
+      );
+      vi.stubGlobal("fetch", fetchMock);
+      return fetchMock;
+    }
+
+    it("builds an Ad Library search URL from keyword params", async () => {
+      const fetchMock = stubRunStart();
+
+      await setup().byName("ads_library_scrape")({
+        ...SCRAPE_DEFAULTS,
+        query: "nike",
+        country: "CO",
+        count: 20,
+      });
+
+      const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+      expect(url).toContain(
+        "/v2/acts/curious_coder~facebook-ads-library-scraper/runs",
+      );
+
+      const body = JSON.parse(init.body as string) as { urls: Array<{ url: string }>; count: number };
+      const target = new URL(body.urls[0].url);
+      expect(target.origin + target.pathname).toBe("https://www.facebook.com/ads/library/");
+      expect(target.searchParams.get("q")).toBe("nike");
+      expect(target.searchParams.get("country")).toBe("CO");
+      expect(target.searchParams.get("active_status")).toBe("active");
+      expect(target.searchParams.get("search_type")).toBe("keyword_unordered");
+      expect(body.count).toBe(20);
+    });
+
+    it("sends the actor's dotted page-filter keys", async () => {
+      const fetchMock = stubRunStart();
+
+      await setup().byName("ads_library_scrape")({
+        ...SCRAPE_DEFAULTS,
+        url: "https://www.facebook.com/ZapierApp",
+        country: "US",
+        period: "last7d",
+        sort_by: "most_recent",
+        active_status: "all",
+      });
+
+      const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+      const body = JSON.parse(init.body as string) as Record<string, unknown>;
+      expect(body["scrapePageAds.activeStatus"]).toBe("all");
+      expect(body["scrapePageAds.countryCode"]).toBe("US");
+      expect(body["scrapePageAds.period"]).toBe("last7d");
+      expect(body["scrapePageAds.sortBy"]).toBe("most_recent");
+      expect(body.urls).toEqual([{ url: "https://www.facebook.com/ZapierApp" }]);
+    });
+
+    it("sends a server-side spend cap derived from count", async () => {
+      const fetchMock = stubRunStart();
+
+      await setup().byName("ads_library_scrape")({
+        ...SCRAPE_DEFAULTS,
+        query: "nike",
+        count: 1000,
+      });
+
+      const [url] = fetchMock.mock.calls[0] as [string];
+      // 1000 ads * $0.00075 + $0.00005 start → ceil to $0.76
+      expect(new URL(url).searchParams.get("maxTotalChargeUsd")).toBe("0.76");
+    });
+
+    it("reports the run and dataset ids", async () => {
+      stubRunStart();
+
+      const result = await setup().byName("ads_library_scrape")({
+        ...SCRAPE_DEFAULTS,
+        query: "nike",
+      });
+
+      expect(result.content[0].text).toContain("run123abc");
+      expect(result.content[0].text).toContain("ds123abc");
+      expect(JSON.parse(result.content[1].text)).toMatchObject({
+        runId: "run123abc",
+        datasetId: "ds123abc",
+      });
+    });
+
+    it.each([
+      ["http://www.facebook.com/ads/library/", "plain http"],
+      ["https://evil.com/ads/library/", "non-facebook host"],
+      ["https://facebook.com.evil.com/x", "suffix lookalike host"],
+      ["https://notfacebook.com/x", "prefix lookalike host"],
+      ["https://www.facebook.com@evil.com/x", "userinfo host confusion"],
+      ["https://user:pass@www.facebook.com/x", "embedded credentials"],
+      ["https://www.facebook.com:8443/x", "non-default port"],
+      ["https://www.facebook.com/l.php?u=https://evil.com", "outbound redirector"],
+      ["https://www.facebook.com/%6c.php?u=https://evil.com", "percent-encoded redirector"],
+      ["https://www.facebook.com//l.php?u=https://evil.com", "doubled-slash redirector"],
+      ["https://www.facebook.com/l.php/?u=https://evil.com", "trailing-slash redirector"],
+      ["https://www.facebook.com/AWAY.PHP?u=https://evil.com", "uppercase redirector"],
+      ["not a url", "unparseable"],
+    ])("rejects %s (%s)", async (url) => {
+      const fetchMock = vi.fn();
+      vi.stubGlobal("fetch", fetchMock);
+
+      await expect(
+        setup().byName("ads_library_scrape")({ ...SCRAPE_DEFAULTS, url }),
+      ).rejects.toThrow(McpError);
+
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it("rejects passing both query and url", async () => {
+      const fetchMock = vi.fn();
+      vi.stubGlobal("fetch", fetchMock);
+
+      await expect(
+        setup().byName("ads_library_scrape")({
+          ...SCRAPE_DEFAULTS,
+          query: "nike",
+          url: "https://www.facebook.com/Nike",
+        }),
+      ).rejects.toThrow(/exactly one/i);
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it("rejects passing neither query nor url", async () => {
+      vi.stubGlobal("fetch", vi.fn());
+
+      await expect(
+        setup().byName("ads_library_scrape")({ ...SCRAPE_DEFAULTS }),
+      ).rejects.toThrow(/exactly one/i);
+    });
+
+    it("rejects a whitespace-only query instead of starting a billable open search", async () => {
+      const fetchMock = vi.fn();
+      vi.stubGlobal("fetch", fetchMock);
+
+      await expect(
+        setup().byName("ads_library_scrape")({ ...SCRAPE_DEFAULTS, query: "   " }),
+      ).rejects.toThrow(/exactly one/i);
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("ads_library_get_run_status", () => {
+    it("summarises a succeeded run and points at the dataset", async () => {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue(
+          mockFetchResponse({
+            data: {
+              id: "run123abc",
+              actId: "act1",
+              status: "SUCCEEDED",
+              startedAt: "2026-08-09T00:00:00.000Z",
+              finishedAt: "2026-08-09T00:01:00.000Z",
+              defaultDatasetId: "ds123abc",
+              usageTotalUsd: 0.0153,
+              stats: { runTimeSecs: 42.4 },
+            },
+          }),
+        ),
+      );
+
+      const result = await setup().byName("ads_library_get_run_status")({ run_id: "run123abc" });
+
+      expect(result.content[0].text).toContain("SUCCEEDED");
+      expect(result.content[0].text).toContain("$0.0153");
+      expect(result.content[0].text).toContain("ads_library_get_results");
+    });
+
+    it("rejects a malformed run id before calling Apify", async () => {
+      const fetchMock = vi.fn();
+      vi.stubGlobal("fetch", fetchMock);
+
+      await expect(
+        setup().byName("ads_library_get_run_status")({ run_id: "../../v2/users/me" }),
+      ).rejects.toThrow(McpError);
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("ads_library_get_results", () => {
+    const rawAd = {
+      ad_archive_id: "123",
+      page_id: "456",
+      page_name: "Nike",
+      is_active: true,
+      snapshot: { body: "Just do it", title: "Nike", cta_text: "Shop now" },
+      internal_noise: "x".repeat(100),
+    };
+
+    it("requests the dataset with pagination params", async () => {
+      const fetchMock = vi.fn().mockResolvedValue(mockFetchResponse([rawAd]));
+      vi.stubGlobal("fetch", fetchMock);
+
+      await setup().byName("ads_library_get_results")({
+        dataset_id: "ds123abc",
+        offset: 20,
+        limit: 10,
+        raw: false,
+      });
+
+      const url = new URL((fetchMock.mock.calls[0] as [string])[0]);
+      expect(url.pathname).toBe("/v2/datasets/ds123abc/items");
+      expect(url.searchParams.get("offset")).toBe("20");
+      expect(url.searchParams.get("limit")).toBe("10");
+      expect(url.searchParams.get("clean")).toBe("true");
+    });
+
+    it("returns a compact projection by default", async () => {
+      vi.stubGlobal("fetch", vi.fn().mockResolvedValue(mockFetchResponse([rawAd])));
+
+      const result = await setup().byName("ads_library_get_results")({
+        dataset_id: "ds123abc",
+        offset: 0,
+        limit: 50,
+        raw: false,
+      });
+
+      const ads = JSON.parse(result.content[1].text) as Array<Record<string, unknown>>;
+      expect(ads[0].page_name).toBe("Nike");
+      expect(ads[0].body).toBe("Just do it");
+      expect(ads[0]).not.toHaveProperty("internal_noise");
+    });
+
+    it("returns untouched records when raw=true", async () => {
+      vi.stubGlobal("fetch", vi.fn().mockResolvedValue(mockFetchResponse([rawAd])));
+
+      const result = await setup().byName("ads_library_get_results")({
+        dataset_id: "ds123abc",
+        offset: 0,
+        limit: 50,
+        raw: true,
+      });
+
+      const ads = JSON.parse(result.content[1].text) as Array<Record<string, unknown>>;
+      expect(ads[0]).toHaveProperty("internal_noise");
+    });
+
+    it("hints at the next page when the page is full", async () => {
+      vi.stubGlobal("fetch", vi.fn().mockResolvedValue(mockFetchResponse([rawAd, rawAd])));
+
+      const result = await setup().byName("ads_library_get_results")({
+        dataset_id: "ds123abc",
+        offset: 0,
+        limit: 2,
+        raw: false,
+      });
+
+      expect(result.content[0].text).toContain("offset=2");
+    });
+
+    it("handles an empty dataset without throwing", async () => {
+      vi.stubGlobal("fetch", vi.fn().mockResolvedValue(mockFetchResponse([])));
+
+      const result = await setup().byName("ads_library_get_results")({
+        dataset_id: "ds123abc",
+        offset: 0,
+        limit: 50,
+        raw: false,
+      });
+
+      expect(result.content[0].text).toContain("No ads at offset 0");
+      expect(JSON.parse(result.content[1].text)).toEqual([]);
+    });
+  });
+
+  describe("ads_library_abort_run", () => {
+    it("posts to the abort endpoint and reports the new status", async () => {
+      const fetchMock = vi.fn().mockResolvedValue(
+        mockFetchResponse({
+          data: { id: "run123abc", status: "ABORTED", defaultDatasetId: "ds123abc" },
+        }),
+      );
+      vi.stubGlobal("fetch", fetchMock);
+
+      const result = await setup().byName("ads_library_abort_run")({ run_id: "run123abc" });
+
+      const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+      expect(url).toBe("https://api.apify.com/v2/actor-runs/run123abc/abort");
+      expect(init.method).toBe("POST");
+      expect(result.content[0].text).toContain("ABORTED");
+    });
+  });
+
+  describe("ads_library_list_runs", () => {
+    it("lists runs newest first", async () => {
+      const fetchMock = vi.fn().mockResolvedValue(
+        mockFetchResponse({
+          data: {
+            items: [
+              { id: "run1", status: "SUCCEEDED", defaultDatasetId: "ds1", usageTotalUsd: 0.02 },
+              { id: "run2", status: "ABORTED", defaultDatasetId: "ds2" },
+            ],
+          },
+        }),
+      );
+      vi.stubGlobal("fetch", fetchMock);
+
+      const result = await setup().byName("ads_library_list_runs")({ limit: 10 });
+
+      const url = new URL((fetchMock.mock.calls[0] as [string])[0]);
+      expect(url.searchParams.get("desc")).toBe("true");
+      expect(url.searchParams.get("limit")).toBe("10");
+      expect(result.content[0].text).toContain("Found 2 run(s)");
+      expect(result.content[0].text).toContain("run1");
+    });
+
+    it("handles an account with no runs", async () => {
+      vi.stubGlobal("fetch", vi.fn().mockResolvedValue(mockFetchResponse({ data: { items: [] } })));
+
+      const result = await setup().byName("ads_library_list_runs")({ limit: 10 });
+      expect(result.content[0].text).toContain("No Ad Library scrape runs");
+    });
+  });
+});

--- a/tests/tools/registration.test.ts
+++ b/tests/tools/registration.test.ts
@@ -3,17 +3,18 @@ import { registerAllTools } from "../../src/tools/index.js";
 import { createMockMcpServer } from "../setup.js";
 
 describe("registerAllTools", () => {
-  it("registers exactly 127 tools total", () => {
+  it("registers exactly 135 tools total", () => {
     // 79 v2 tools renamed (with account_insights removed → 79) + 14 new in v3 +
     //   3 audience-sharing tools (share / unshare / get-shared-accounts) +
     //   1 invoices tool (ads_get_invoices) +
     //   27 WhatsApp Business tools (whatsapp_*) +
     //   1 UTM editing tool (ads_update_ad_url_tags) +
     //   1 bulk video-ad macro (ads_bulk_create_video_ads) +
-    //   1 creative media tool (ads_get_creative_media).
+    //   1 creative media tool (ads_get_creative_media) +
+    //   8 Ad Library scraping tools (ads_library_*, Apify-backed).
     const server = createMockMcpServer();
     registerAllTools(server as never);
-    expect(server.registerTool).toHaveBeenCalledTimes(127);
+    expect(server.registerTool).toHaveBeenCalledTimes(135);
   });
 
   it("registers all tools with unique names", () => {
@@ -43,6 +44,26 @@ describe("registerAllTools", () => {
       t.name.startsWith("whatsapp_"),
     );
     expect(whatsappTools.length).toBe(27);
+  });
+
+  it("registers exactly 8 ads_library_ tools", () => {
+    const server = createMockMcpServer();
+    registerAllTools(server as never);
+
+    const names = server._registeredTools
+      .map((t) => t.name)
+      .filter((n) => n.startsWith("ads_library_"));
+
+    expect(names.sort()).toEqual([
+      "ads_library_abort_run",
+      "ads_library_delete_apify_token",
+      "ads_library_get_apify_token_status",
+      "ads_library_get_results",
+      "ads_library_get_run_status",
+      "ads_library_list_runs",
+      "ads_library_register_apify_token",
+      "ads_library_scrape",
+    ]);
   });
 
   it("all tools have non-empty descriptions", () => {


### PR DESCRIPTION
## Summary

Adds 8 `ads_library_*` tools (127 → 135) for competitor ad research against the **public** Meta Ad Library, which the Graph API does not expose. Backed by the [curious_coder/facebook-ads-library-scraper](https://apify.com/curious_coder/facebook-ads-library-scraper) Apify actor, with per-tenant Apify tokens encrypted at rest.

## Why

Agencies need to see what competitors are running, not just their own accounts. The Ad Library is public but has no official API. Apify's actor already solves the scraping; this exposes it as MCP tools with the credential handling and cost controls this repo expects.

## What's in it

**Tools** — async lifecycle so long scrapes never block:

| Tool | Purpose |
|---|---|
| `ads_library_scrape` | Start a run from a keyword search or a facebook.com URL |
| `ads_library_get_run_status` | Poll state, runtime, accrued cost |
| `ads_library_get_results` | Paginated ads, compact projection by default (`raw` escape hatch) |
| `ads_library_abort_run` | Stop a run accruing cost |
| `ads_library_list_runs` | Recover run/dataset ids, review spend |
| `ads_library_{register,get,delete}_apify_token` | Per-user credential management |

**New modules**: `src/apify/client.ts`, `src/apify/types.ts`, `src/store/apify-token-repo.ts`, `src/tools/ads-library.ts`.

The actor's input schema was read from its live build (`INPUT_SCHEMA` on build 2.7.19) rather than guessed — `count`, `scrapeAdDetails` and the dotted `scrapePageAds.*` keys are the real field names.

## Security posture

- **Per-tenant tokens, encrypted at rest.** Validated against the Apify API *before* being persisted, then AES-256-GCM in `users/{fbUserId}/apify_tokens/default`. The GCM AAD is namespaced `apify_token:{fbUserId}:default`, so a ciphertext cannot be relocated between users or between the `meta_tokens` and `apify_tokens` collections.
- **Fails closed.** In multi-tenant mode a caller with no OAuth identity (API-key requests, or any flow losing `fbUserId`) is refused rather than bucketed into a shared credential. `APIFY_TOKEN` is honoured **only** in single-tenant mode (stdio, or no Meta app configured) — never as a cross-tenant fallback.
- **Token never leaves.** `Authorization: Bearer` header (never a query param), `hashToken()` in logs, only the non-secret `apify_api_` prefix in responses, and every error message scrubbed of both the `apify_api_*` pattern and the exact token in play — in a single pass, so overlapping values cannot fragment.
- **Integrity failures surface.** A GCM tag mismatch throws instead of being reported as "no token", which would have fallen through to a fallback credential.
- **Cost caps.** The actor bills PAY_PER_EVENT ($0.00075/ad), so each run carries a hard server-side `maxTotalChargeUsd` derived from `count`, plus a 2,000-ad ceiling per call.
- **URL allowlist.** https-only, exact `facebook.com` host set, and rejects embedded credentials, non-default ports, and Facebook's outbound redirectors (`/l.php` and friends, canonicalized against `/%6c.php`, `//l.php`, `/l.php/`).
- Added an `apify-api-token` gitleaks rule, and a pino `redact` config (there was none before).

## Known limits, stated rather than papered over

- The spend cap bounds each **run**, not a tenant's aggregate spend. Each tenant spends their own Apify credit.
- Not retrying `POST` removes the client-side duplicate path but does **not** make double billing impossible — Apify can accept a run and lose the response. A timed-out or truncated start is reported as *indeterminate*, pointing at `ads_library_list_runs`.
- Runs execute against the actor's `latest` build, so upstream schema or pricing changes can alter behaviour without a change here.
- Run/dataset ids are not bound to a tenant in our own storage. With one Apify account per tenant, `list_runs` cannot enumerate another tenant's runs and every call is authorized by that tenant's token; the residual path needs both a leaked 17-char id and the owner opting into Apify's "anyone with the ID can read" mode. A run-ownership ledger wasn't judged worth the complexity for public ad-library data.

## How to verify

```bash
npm ci && npm run lint && npm run typecheck && npm test && npm run build
```

End-to-end against a real Apify account (stdio):

```bash
APIFY_TOKEN=... npm run dev:stdio
# ads_library_scrape { query: "nike", country: "CO", count: 20 }
# ads_library_get_run_status { run_id } → poll to SUCCEEDED
# ads_library_get_results { dataset_id }
# expected cost ≈ $0.015
```

## Tests

97 new tests across `tests/apify/client.test.ts`, `tests/store/apify-token-repo.test.ts` and `tests/tools/ads-library.test.ts`. Full suite **624 passing** (was 528).

Coverage includes: the token never appearing in a URL or a tool response; multi-tenant refusal of unidentified callers; AAD cross-tenant relocation and ciphertext tampering (against a Firestore fake, which also gives the Firestore repo its first coverage); scrubber overlap and metacharacter cases; host-allowlist bypasses; and the `maxTotalChargeUsd` cap.

- [x] New tests added under `tests/` mirroring the source path
- [x] Existing tests still pass (`npm test`)
- [x] Manual verification against a real dev environment — see below

### End-to-end run against a real Apify account

Exercised the actual tool handlers (not curl) against the live API. Two real bugs
that mocks could not have caught, both now fixed:

1. **Cost was reported as $0.0000 for a billable run.** `usageTotalUsd` is
   populated with a lag, so a run that has just flipped to `SUCCEEDED` still
   reads 0 — a caller polling to completion would conclude the scrape was free.
   `chargedEventCounts` is accurate immediately, so the amount is now derived
   from it and labelled as not yet settled.
2. **`snapshot.body` is a `{ text }` object** while `title` is a plain string.
   The slim projection now flattens it.

Observed result: 20 ads scraped for **$0.0150** against the **$0.02** cap the
tool sent, run `SUCCEEDED` in ~9s, the Ad Library URL built exactly as intended
(`active_status=active&ad_type=all&country=CO&q=nike&search_type=keyword_unordered&media_type=all`),
and the token absent from every tool response.

Sample of the returned projection:

```json
{
  "ad_archive_id": "1033781512449452",
  "page_name": "IControl: Easy Widgets Themes",
  "is_active": true,
  "publisher_platform": ["FACEBOOK", "INSTAGRAM", "AUDIENCE_NETWORK", "MESSENGER", "THREADS"],
  "body": "❤️Aesthetic presets for your phone✨",
  "title": "🥰a FREE and personalized APP for you",
  "cta_text": "Install now",
  "link_url": "http://play.google.com/store/apps/details?id=com.icontrol.easy.widgets.themes",
  "display_format": "IMAGE"
}
```

Note `spend` and `reach_estimate` come back null and `currency` empty for
ordinary commercial ads — Meta only populates those for political/issue ads. The
projection passes them through rather than hiding them.

## Checklist

- [x] `npm run lint`, `npm run typecheck`, `npm test`, `npm run build` all pass locally
- [x] No secrets in the diff — `run-checks.sh` green (8/8), gitleaks clean with the new Apify rule
- [x] Updated relevant docs (`README.md`, `CHANGELOG.md`, `CLAUDE.md`, `docs/adding-a-tool.md`)
- [x] Conventional commit prefix in title

## Review notes

This touches `src/store/` and adds a credential path, so per `docs/adding-a-tool.md` it wants maintainer scrutiny.

It went through four adversarial audit passes before merge-readiness. The first returned NO-GO on a genuine multi-tenant isolation break: the `_local` sentinel was reachable from any HTTP request lacking `fbUserId`, pooling every unidentified caller onto one credential. Later passes caught a token-scrubber ordering bug introduced while fixing the first one — no ordering of two sequential passes is safe, so the scrubber now does a single pass. Everything is squashed into one commit here; the audit trail lives in this description rather than in intermediate commits.

One process note worth flagging for the maintainers: the local `gitleaks` (8.30.1) did **not** reproduce a finding that the CI action caught, on the same config and the same content. The finding was a harmless over-long test fixture, since renamed to follow the repo's `fixture` naming convention — but it means `run-checks.sh` passing locally is not currently sufficient evidence that the CI secret scan will pass. Might be worth pinning the gitleaks version across both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

