### PR TITLE
fix(ci): pin gitleaks in the deploy preflight too

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -53,12 +53,27 @@ jobs:
       - name: Build
         run: npm run build
 
+      # Same shared pin as ci.yml and the local guard. Without it the action
+      # supplies its own default, so this gate — the one that actually blocks
+      # production — would keep drifting from the version contributors run.
+      - name: Resolve pinned gitleaks version
+        run: |
+          version="$(tr -d '[:space:]' < .gitleaks-version)"
+          # Checked-out repo content: validate before it reaches GITHUB_ENV,
+          # where anything but a bare x.y.z could smuggle in extra variables.
+          if ! printf '%s' "$version" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "::error::.gitleaks-version must contain a bare semver (got: $version)"
+            exit 1
+          fi
+          echo "GITLEAKS_VERSION=$version" >> "$GITHUB_ENV"
+
       - name: Run gitleaks
         uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7  # v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}
           GITLEAKS_CONFIG: .gitleaks.toml
+          GITLEAKS_VERSION: ${{ env.GITLEAKS_VERSION }}
 
   deploy:
     needs: preflight


### PR DESCRIPTION
## Summary

#120 pinned the gitleaks version in `ci.yml` but missed `deploy.yml`, which runs its own separate gitleaks step.

## How it was caught

Checking the deploy run on `main` right after #120 merged:

```
Preflight (lint, typecheck, test, build, secret scan)  →  gitleaks version: 8.24.3
CI (secret scan)                                        →  gitleaks version: 8.30.1
```

So the drift #120 set out to eliminate was still alive **in the one gate that actually blocks production** — and on the weaker side of the difference: 8.24.3 defaults `max-decode-depth` to `0`, so it scans fewer encoded secrets than the version contributors now run locally.

## The fix

The same `.gitleaks-version` pin, resolved the same way, with the same semver validation before the value reaches `GITHUB_ENV` (the file is checked-out repo content).

## How to verify

After merge, the deploy run's preflight should log `gitleaks version: 8.30.1` instead of `8.24.3`:

```bash
RUN=$(gh run list --workflow deploy.yml --limit 1 --json databaseId -q '.[0].databaseId')
JOB=$(gh run view $RUN --json jobs -q '.jobs[]|select(.name|contains("Preflight"))|.databaseId')
gh run view --job $JOB --log | grep -i "gitleaks version"
```

## Checklist

- [x] `run-checks.sh` green (8/8)
- [x] No secrets in the diff
- [x] Conventional commit prefix in title

Docs-and-CI only — no `src/` change, so deployed behaviour is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
